### PR TITLE
Prevent mounting invalid user-provided volumes

### DIFF
--- a/pkg/util/kubernetes/fields/k8svolume/volumes.go
+++ b/pkg/util/kubernetes/fields/k8svolume/volumes.go
@@ -1,12 +1,11 @@
 package k8svolume
 
 import (
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Contains(vol []corev1.Volume, volumeName string) bool {
-	for _, v := range vol {
+func Contains(volumes []corev1.Volume, volumeName string) bool {
+	for _, v := range volumes {
 		if v.Name == volumeName {
 			return true
 		}
@@ -15,14 +14,12 @@ func Contains(vol []corev1.Volume, volumeName string) bool {
 	return false
 }
 
-func FindByName(volumes []corev1.Volume, volumeName string) (*corev1.Volume, error) {
+func FindByName(volumes []corev1.Volume, volumeName string) *corev1.Volume {
 	for _, volume := range volumes {
 		if volume.Name == volumeName {
-			return &volume, nil
+			return &volume
 		}
 	}
 
-	return nil, errors.Errorf(`Cannot find volume "%s" in the provided slice (len %d)`,
-		volumeName, len(volumes),
-	)
+	return nil
 }

--- a/pkg/webhook/mutation/pod/handler/injection/handle.go
+++ b/pkg/webhook/mutation/pod/handler/injection/handle.go
@@ -148,7 +148,10 @@ func (h *Handler) handlePodMutation(mutationRequest *dtwebhook.MutationRequest) 
 	}
 
 	if mutated {
-		addInitContainerToPod(mutationRequest.Context, mutationRequest.Pod, mutationRequest.InstallContainer)
+		if err := addInitContainerToPod(mutationRequest.Context, mutationRequest.Pod, mutationRequest.InstallContainer); err != nil {
+			return false, err
+		}
+
 		events.SendPodInjectEvent(h.recorder, &mutationRequest.DynaKube, mutationRequest.Pod)
 	}
 

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -58,12 +58,21 @@ func areErrorsSuppressed(pod *corev1.Pod, dk dynakube.DynaKube) bool {
 	return maputils.GetField(pod.Annotations, dtwebhook.AnnotationFailurePolicy, dk.FF().GetInjectionFailurePolicy()) != "fail" // safer than == silent
 }
 
-func addInitContainerToPod(ctx context.Context, pod *corev1.Pod, initContainer *corev1.Container) {
+func addInitContainerToPod(ctx context.Context, pod *corev1.Pod, initContainer *corev1.Container) error {
 	volumes.AddInitConfigVolumeMount(initContainer)
 	volumes.AddInitInputVolumeMount(initContainer)
-	volumes.AddInputVolume(pod)
-	volumes.AddConfigVolume(ctx, pod)
+
+	if err := volumes.AddInputVolume(pod); err != nil {
+		return err
+	}
+
+	if err := volumes.AddConfigVolume(ctx, pod); err != nil {
+		return err
+	}
+
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
+
+	return nil
 }
 
 func defaultInitContainerResources() corev1.ResourceRequirements {
@@ -94,6 +103,7 @@ func securityContextForInitContainer(pod *corev1.Pod, dk dynakube.DynaKube, isOp
 
 	return combineSecurityContexts(initSecurityCtx, *pod)
 }
+
 func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.Pod) *corev1.SecurityContext {
 	containerSecurityCtx := &corev1.SecurityContext{}
 	if len(pod.Spec.Containers) > 0 {

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -36,10 +36,13 @@ func mutateInitContainer(mutationRequest *dtwebhook.MutationRequest, installPath
 
 	if isCSIVolume(mutationRequest.BaseRequest) {
 		log.Info("configuring init-container with CSI bin volume", "name", mutationRequest.PodName())
-		addCSIBinVolume(
+
+		if err := addCSIBinVolume(
 			mutationRequest.Pod,
 			mutationRequest.DynaKube.Name,
-			mutationRequest.DynaKube.FF().GetCSIMaxRetryTimeout().String())
+			mutationRequest.DynaKube.FF().GetCSIMaxRetryTimeout().String()); err != nil {
+			return err
+		}
 		// in case of CSI, the CSI volume itself is already always readonly, so the mount should always be readonly, the init-container should just read from it
 		addInitBinMount(mutationRequest.InstallContainer, true)
 

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init.go
@@ -49,7 +49,10 @@ func mutateInitContainer(mutationRequest *dtwebhook.MutationRequest, installPath
 		}
 	} else {
 		log.Info("configuring init-container with emptyDir bin volume", "name", mutationRequest.PodName())
-		addEmptyDirBinVolume(mutationRequest.Pod, log)
+
+		if err := addEmptyDirBinVolume(mutationRequest.Pod, log); err != nil {
+			return err
+		}
 		// in case of no CSI, the the emptyDir can't be readonly for the init-container, as it first has to download/move the agent into it
 		addInitBinMount(mutationRequest.InstallContainer, false)
 

--- a/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/init_test.go
@@ -146,8 +146,8 @@ func TestMutateInitContainer(t *testing.T) {
 		err := mutateInitContainer(request, installPath)
 		require.NoError(t, err)
 
-		csiVolume, err := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
-		require.NoError(t, err)
+		csiVolume := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
+		require.NotNil(t, csiVolume)
 		require.NotNil(t, csiVolume.CSI)
 		require.NotNil(t, csiVolume.CSI.ReadOnly)
 		require.True(t, *csiVolume.CSI.ReadOnly)
@@ -182,8 +182,8 @@ func TestMutateInitContainer(t *testing.T) {
 		err := mutateInitContainer(request, installPath)
 		require.NoError(t, err)
 
-		csiVolume, err := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
-		require.NoError(t, err)
+		csiVolume := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
+		require.NotNil(t, csiVolume)
 		require.NotNil(t, csiVolume.CSI)
 		require.NotNil(t, csiVolume.CSI.ReadOnly)
 		require.True(t, *csiVolume.CSI.ReadOnly)
@@ -223,8 +223,8 @@ func TestMutateInitContainer(t *testing.T) {
 		err := mutateInitContainer(request, installPath)
 		require.NoError(t, err)
 
-		emptyDirVolume, err := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
-		require.NoError(t, err)
+		emptyDirVolume := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
+		require.NotNil(t, emptyDirVolume)
 		require.NotNil(t, emptyDirVolume.EmptyDir)
 
 		emptyDirMount, err := k8smount.Find(request.InstallContainer.VolumeMounts, BinVolumeName)
@@ -262,8 +262,8 @@ func TestMutateInitContainer(t *testing.T) {
 		err := mutateInitContainer(request, installPath)
 		require.NoError(t, err)
 
-		emptyDirVolume, err := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
-		require.NoError(t, err)
+		emptyDirVolume := k8svolume.FindByName(request.Pod.Spec.Volumes, BinVolumeName)
+		require.NotNil(t, emptyDirVolume)
 		require.NotNil(t, emptyDirVolume.EmptyDir)
 
 		emptyDirMount, err := k8smount.Find(request.InstallContainer.VolumeMounts, BinVolumeName)

--- a/pkg/webhook/mutation/pod/mutator/oneagent/volumes.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/volumes.go
@@ -84,9 +84,16 @@ func addEmptyDirBinVolume(pod *corev1.Pod, log logd.Logger) error {
 	return nil
 }
 
-func addCSIBinVolume(pod *corev1.Pod, dkName string, maxTimeout string) {
-	if k8svolume.Contains(pod.Spec.Volumes, BinVolumeName) {
-		return
+func addCSIBinVolume(pod *corev1.Pod, dkName string, maxTimeout string) error {
+	if vol := k8svolume.FindByName(pod.Spec.Volumes, BinVolumeName); vol != nil {
+		if vol.CSI == nil || vol.CSI.Driver != dtcsi.DriverName {
+			return dtwebhook.MutatorError{
+				Err:      volumes.ExistingVolumeError(BinVolumeName),
+				Annotate: setNotInjectedAnnotationFunc(volumes.ConflictingVolumeTypeReason),
+			}
+		}
+
+		return nil
 	}
 
 	volumeSource := corev1.VolumeSource{
@@ -107,4 +114,6 @@ func addCSIBinVolume(pod *corev1.Pod, dkName string, maxTimeout string) {
 			VolumeSource: volumeSource,
 		},
 	)
+
+	return nil
 }

--- a/pkg/webhook/mutation/pod/mutator/oneagent/volumes.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/volumes.go
@@ -8,6 +8,7 @@ import (
 	appvolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/server/volumes/app"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8svolume"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/volumes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -44,9 +45,16 @@ func addInitBinMount(initContainer *corev1.Container, readonly bool) {
 	)
 }
 
-func addEmptyDirBinVolume(pod *corev1.Pod, log logd.Logger) {
-	if k8svolume.Contains(pod.Spec.Volumes, BinVolumeName) {
-		return
+func addEmptyDirBinVolume(pod *corev1.Pod, log logd.Logger) error {
+	if vol := k8svolume.FindByName(pod.Spec.Volumes, BinVolumeName); vol != nil {
+		if vol.EmptyDir == nil {
+			return dtwebhook.MutatorError{
+				Err:      volumes.ExistingVolumeError(BinVolumeName),
+				Annotate: setNotInjectedAnnotationFunc(volumes.ConflictingVolumeTypeReason),
+			}
+		}
+
+		return nil
 	}
 
 	emptyDirVS := corev1.EmptyDirVolumeSource{}
@@ -72,6 +80,8 @@ func addEmptyDirBinVolume(pod *corev1.Pod, log logd.Logger) {
 			VolumeSource: volumeSource,
 		},
 	)
+
+	return nil
 }
 
 func addCSIBinVolume(pod *corev1.Pod, dkName string, maxTimeout string) {

--- a/pkg/webhook/mutation/pod/mutator/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/volumes_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
+	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	csivolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/server/volumes"
+	appvolumes "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/server/volumes/app"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/volumes"
 	"github.com/stretchr/testify/assert"
@@ -128,5 +131,62 @@ func Test_addEmptyDirBinVolume(t *testing.T) {
 		}
 
 		require.Error(t, addEmptyDirBinVolume(pod, logd.Get()))
+	})
+}
+
+func Test_addCSIBinVolume(t *testing.T) {
+	t.Run("should add CSI bin volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "test-container", Image: "test-image"},
+				},
+			},
+		}
+
+		require.NoError(t, addCSIBinVolume(pod, "test-dk", "10m"))
+
+		assert.Len(t, pod.Spec.Volumes, 1)
+
+		assert.Equal(t, corev1.Volume{
+			Name: BinVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver:   dtcsi.DriverName,
+					ReadOnly: new(true),
+					VolumeAttributes: map[string]string{
+						csivolumes.CSIVolumeAttributeModeField:     appvolumes.Mode,
+						csivolumes.CSIVolumeAttributeDynakubeField: "test-dk",
+						csivolumes.CSIVolumeAttributeRetryTimeout:  "10m",
+					},
+				},
+			},
+		}, pod.Spec.Volumes[0])
+	})
+
+	t.Run("existing volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: BinVolumeName, VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: dtcsi.DriverName}}},
+				},
+			},
+		}
+		expectedPod := pod.DeepCopy()
+
+		require.NoError(t, addCSIBinVolume(pod, "test-dk", "10m"))
+		assert.Equal(t, expectedPod, pod)
+	})
+
+	t.Run("conflicting volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: BinVolumeName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
+				},
+			},
+		}
+
+		require.Error(t, addCSIBinVolume(pod, "test-dk", "10m"))
 	})
 }

--- a/pkg/webhook/mutation/pod/mutator/oneagent/volumes_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/volumes_test.go
@@ -103,4 +103,30 @@ func Test_addEmptyDirBinVolume(t *testing.T) {
 			},
 		}, pod.Spec.Volumes[0])
 	})
+
+	t.Run("existing volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: BinVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumHugePages}}},
+				},
+			},
+		}
+		expectedPod := pod.DeepCopy()
+
+		require.NoError(t, addEmptyDirBinVolume(pod, logd.Get()))
+		assert.Equal(t, expectedPod, pod)
+	})
+
+	t.Run("conflicting volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: BinVolumeName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
+				},
+			},
+		}
+
+		require.Error(t, addEmptyDirBinVolume(pod, logd.Get()))
+	})
 }

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	activeGateTrustedCertVolumeName = "otlp-dynatrace-certs"
+	// ActiveGateTrustedCertVolumeName is the name of the volume holding the ActiveGate trusted certificates mounted into instrumented containers.
+	ActiveGateTrustedCertVolumeName = "otlp-dynatrace-certs"
 	exporterCertsMountPath          = "/etc/dynatrace/ssl"
 )
 
@@ -163,12 +164,12 @@ func (m Mutator) mutate(request *dtwebhook.BaseRequest, log logd.Logger) (bool, 
 }
 
 func ensureCertificateVolumeMounted(c *corev1.Container) {
-	if k8smount.Contains(c.VolumeMounts, activeGateTrustedCertVolumeName) {
+	if k8smount.Contains(c.VolumeMounts, ActiveGateTrustedCertVolumeName) {
 		return
 	}
 
 	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
-		Name:      activeGateTrustedCertVolumeName,
+		Name:      ActiveGateTrustedCertVolumeName,
 		MountPath: exporterCertsMountPath,
 		ReadOnly:  true,
 	})
@@ -237,10 +238,10 @@ func addActiveGateCertVolume(dk dynakube.DynaKube, pod *corev1.Pod) error {
 	}
 
 	// avoid duplicate volume additions on reinvocation or multiple container matches
-	if vol := k8svolume.FindByName(pod.Spec.Volumes, activeGateTrustedCertVolumeName); vol != nil {
+	if vol := k8svolume.FindByName(pod.Spec.Volumes, ActiveGateTrustedCertVolumeName); vol != nil {
 		if vol.Secret == nil || vol.Secret.SecretName != consts.OTLPExporterCertsSecretName {
 			return dtwebhook.MutatorError{
-				Err:      volumes.ExistingVolumeError(activeGateTrustedCertVolumeName),
+				Err:      volumes.ExistingVolumeError(ActiveGateTrustedCertVolumeName),
 				Annotate: setNotInjectedAnnotationFunc(volumes.ConflictingVolumeTypeReason),
 			}
 		}
@@ -250,7 +251,7 @@ func addActiveGateCertVolume(dk dynakube.DynaKube, pod *corev1.Pod) error {
 
 	defaultMode := int32(420)
 	agCertVolume := corev1.Volume{
-		Name: activeGateTrustedCertVolumeName,
+		Name: ActiveGateTrustedCertVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				DefaultMode: &defaultMode,

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8svolume"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/volumes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -155,10 +156,10 @@ func (m Mutator) mutate(request *dtwebhook.BaseRequest, log logd.Logger) (bool, 
 	}
 
 	if shouldAddCertificate && mutated {
-		addActiveGateCertVolume(request.DynaKube, request.Pod)
+		err = addActiveGateCertVolume(request.DynaKube, request.Pod)
 	}
 
-	return mutated, nil
+	return mutated, err
 }
 
 func ensureCertificateVolumeMounted(c *corev1.Container) {
@@ -230,14 +231,21 @@ func setNotInjectedAnnotationFunc(reason string) func(*corev1.Pod) {
 	}
 }
 
-func addActiveGateCertVolume(dk dynakube.DynaKube, pod *corev1.Pod) {
+func addActiveGateCertVolume(dk dynakube.DynaKube, pod *corev1.Pod) error {
 	if !dk.ActiveGate().HasCaCert() && dk.Spec.TrustedCAs == "" {
-		return
+		return nil
 	}
 
 	// avoid duplicate volume additions on reinvocation or multiple container matches
-	if k8svolume.Contains(pod.Spec.Volumes, activeGateTrustedCertVolumeName) {
-		return
+	if vol := k8svolume.FindByName(pod.Spec.Volumes, activeGateTrustedCertVolumeName); vol != nil {
+		if vol.Secret == nil || vol.Secret.SecretName != consts.OTLPExporterCertsSecretName {
+			return dtwebhook.MutatorError{
+				Err:      volumes.ExistingVolumeError(activeGateTrustedCertVolumeName),
+				Annotate: setNotInjectedAnnotationFunc(volumes.ConflictingVolumeTypeReason),
+			}
+		}
+
+		return nil
 	}
 
 	defaultMode := int32(420)
@@ -256,4 +264,6 @@ func addActiveGateCertVolume(dk dynakube.DynaKube, pod *corev1.Pod) {
 	}
 
 	pod.Spec.Volumes = append(pod.Spec.Volumes, agCertVolume)
+
+	return nil
 }

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
@@ -720,7 +720,7 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 
 		// Volume referencing certificate secret must be present
 		{
-			volume := k8svolume.FindByName(request.Pod.Spec.Volumes, activeGateTrustedCertVolumeName)
+			volume := k8svolume.FindByName(request.Pod.Spec.Volumes, ActiveGateTrustedCertVolumeName)
 			require.NotNil(t, volume)
 			require.NotNil(t, volume.Secret)
 			assert.Equal(t, consts.OTLPExporterCertsSecretName, volume.Secret.SecretName)
@@ -730,7 +730,7 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 		for _, c := range request.Pod.Spec.Containers {
 			mountFound := false
 			for _, mnt := range c.VolumeMounts {
-				if mnt.Name == activeGateTrustedCertVolumeName && mnt.MountPath == exporterCertsMountPath {
+				if mnt.Name == ActiveGateTrustedCertVolumeName && mnt.MountPath == exporterCertsMountPath {
 					mountFound = true
 					assert.True(t, mnt.ReadOnly)
 
@@ -758,7 +758,7 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 		// Init containers should not have the mount
 		for _, c := range request.Pod.Spec.InitContainers {
 			for _, mnt := range c.VolumeMounts {
-				assert.NotEqual(t, activeGateTrustedCertVolumeName, mnt.Name)
+				assert.NotEqual(t, ActiveGateTrustedCertVolumeName, mnt.Name)
 			}
 		}
 	})
@@ -766,7 +766,7 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 	t.Run("existing activegate cert volume", func(t *testing.T) {
 		pod := getTestPod()
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-			Name: activeGateTrustedCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: consts.OTLPExporterCertsSecretName}},
+			Name: ActiveGateTrustedCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: consts.OTLPExporterCertsSecretName}},
 		})
 		expectVolumes := pod.DeepCopy().Spec.Volumes
 
@@ -787,7 +787,7 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 	t.Run("conflicting activegate cert volume", func(t *testing.T) {
 		pod := getTestPod()
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-			Name: activeGateTrustedCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo-cert"}},
+			Name: ActiveGateTrustedCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo-cert"}},
 		})
 
 		m := Mutator{}
@@ -854,14 +854,14 @@ func Test_ensureCertificateVolumeMounted(t *testing.T) {
 		ensureCertificateVolumeMounted(&c)
 		require.Len(t, c.VolumeMounts, 1)
 		vm := c.VolumeMounts[0]
-		assert.Equal(t, activeGateTrustedCertVolumeName, vm.Name)
+		assert.Equal(t, ActiveGateTrustedCertVolumeName, vm.Name)
 		assert.Equal(t, exporterCertsMountPath, vm.MountPath)
 		assert.True(t, vm.ReadOnly)
 	})
 
 	t.Run("does not duplicate mount", func(t *testing.T) {
 		c := newContainer()
-		c.VolumeMounts = []corev1.VolumeMount{{Name: activeGateTrustedCertVolumeName, MountPath: exporterCertsMountPath, ReadOnly: true}}
+		c.VolumeMounts = []corev1.VolumeMount{{Name: ActiveGateTrustedCertVolumeName, MountPath: exporterCertsMountPath, ReadOnly: true}}
 		ensureCertificateVolumeMounted(&c)
 		assert.Len(t, c.VolumeMounts, 1)
 	})
@@ -885,7 +885,7 @@ func Test_addActiveGateCertVolume(t *testing.T) {
 		addActiveGateCertVolume(dk, pod)
 		require.Len(t, pod.Spec.Volumes, 1)
 		v := pod.Spec.Volumes[0]
-		assert.Equal(t, activeGateTrustedCertVolumeName, v.Name)
+		assert.Equal(t, ActiveGateTrustedCertVolumeName, v.Name)
 		require.NotNil(t, v.Secret)
 		assert.Equal(t, consts.OTLPExporterCertsSecretName, v.Secret.SecretName)
 

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
@@ -11,6 +11,7 @@ import (
 	otelcactivegate "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8svolume"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -711,26 +712,19 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 		// Enable ActiveGate capability + TLS secret so HasCaCert() is true
 		dk.Spec.ActiveGate = activegate.Spec{Capabilities: []activegate.CapabilityDisplayName{activegate.MetricsIngestCapability.DisplayName}, TLSSecretName: "custom-tls-secret"}
 		dk.Status.OneAgent.ConnectionInfo.TenantUUID = "dummy-uuid"
-
-		override := true
-		dk.Spec.OTLPExporterConfiguration.OverrideEnvVars = &override
+		dk.Spec.OTLPExporterConfiguration.OverrideEnvVars = new(true)
 
 		request := createTestMutationRequest(t, dk)
 		err := m.Mutate(request)
 		require.NoError(t, err)
 
 		// Volume referencing certificate secret must be present
-		volFound := false
-		for _, v := range request.Pod.Spec.Volumes {
-			if v.Name == activeGateTrustedCertVolumeName {
-				volFound = true
-				require.NotNil(t, v.Secret)
-				assert.Equal(t, consts.OTLPExporterCertsSecretName, v.Secret.SecretName)
-
-				break
-			}
+		{
+			volume := k8svolume.FindByName(request.Pod.Spec.Volumes, activeGateTrustedCertVolumeName)
+			require.NotNil(t, volume)
+			require.NotNil(t, volume.Secret)
+			assert.Equal(t, consts.OTLPExporterCertsSecretName, volume.Secret.SecretName)
 		}
-		assert.True(t, volFound, "expected cert volume")
 
 		certPath := getCertificatePath()
 		for _, c := range request.Pod.Spec.Containers {
@@ -767,6 +761,46 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 				assert.NotEqual(t, activeGateTrustedCertVolumeName, mnt.Name)
 			}
 		}
+	})
+
+	t.Run("existing activegate cert volume", func(t *testing.T) {
+		pod := getTestPod()
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: activeGateTrustedCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: consts.OTLPExporterCertsSecretName}},
+		})
+		expectVolumes := pod.DeepCopy().Spec.Volumes
+
+		m := Mutator{}
+
+		dk := getTestDynakube()
+		dk.Spec.APIURL = "http://my-cluster/api"
+		dk.Spec.ActiveGate = activegate.Spec{Capabilities: []activegate.CapabilityDisplayName{activegate.MetricsIngestCapability.DisplayName}, TLSSecretName: "custom-tls-secret"}
+		dk.Status.OneAgent.ConnectionInfo.TenantUUID = "dummy-uuid"
+		dk.Spec.OTLPExporterConfiguration.OverrideEnvVars = new(true)
+
+		request := createTestMutationRequest(t, dk)
+		request.Pod = pod
+		require.NoError(t, m.Mutate(request))
+		assert.Equal(t, expectVolumes, pod.Spec.Volumes)
+	})
+
+	t.Run("conflicting activegate cert volume", func(t *testing.T) {
+		pod := getTestPod()
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: activeGateTrustedCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "foo-cert"}},
+		})
+
+		m := Mutator{}
+
+		dk := getTestDynakube()
+		dk.Spec.APIURL = "http://my-cluster/api"
+		dk.Spec.ActiveGate = activegate.Spec{Capabilities: []activegate.CapabilityDisplayName{activegate.MetricsIngestCapability.DisplayName}, TLSSecretName: "custom-tls-secret"}
+		dk.Status.OneAgent.ConnectionInfo.TenantUUID = "dummy-uuid"
+		dk.Spec.OTLPExporterConfiguration.OverrideEnvVars = new(true)
+
+		request := createTestMutationRequest(t, dk)
+		request.Pod = pod
+		require.Error(t, m.Mutate(request))
 	})
 }
 

--- a/pkg/webhook/mutation/pod/volumes/volumes.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes.go
@@ -25,11 +25,34 @@ const (
 
 	// AnnotationConfigVolumeNameResource is used to specify the volume size for EmptyDir for dynatrace-config.
 	AnnotationConfigVolumeNameResource = AnnotationResourcePrefix + ConfigVolumeName
+
+	// annotationDynatraceInjected is set to "true" by the webhook to Pods to indicate that it has been injected.
+	annotationInjected = AnnotationResourcePrefix + "injected"
+	// annotationDynatraceReason is add to provide extra info why an injection didn't happen.
+	annotationReason = AnnotationResourcePrefix + "reason"
+	// reasonConflictingVolumeType indicates that the user provided a volume definition that conflicts with the one that would be added by the mutator.
+	reasonConflictingVolumeType = "ConflictingVolumeType"
 )
 
-func AddConfigVolume(ctx context.Context, pod *corev1.Pod) {
-	if k8svolume.Contains(pod.Spec.Volumes, ConfigVolumeName) {
-		return
+// existingVolumeError indicates that an existing volume cannot be used for injection because it does not match the expected spec.
+type existingVolumeError struct {
+	volumeName string
+}
+
+func (e existingVolumeError) Error() string {
+	return "user-provided " + e.volumeName + " volume cannot be mounted due to invalid configuration"
+}
+
+func AddConfigVolume(ctx context.Context, pod *corev1.Pod) error {
+	if vol, _ := k8svolume.FindByName(pod.Spec.Volumes, ConfigVolumeName); vol != nil {
+		if vol.EmptyDir == nil {
+			return dtwebhook.MutatorError{
+				Err:      existingVolumeError{ConfigVolumeName},
+				Annotate: setNotInjectedReason(reasonConflictingVolumeType),
+			}
+		}
+
+		return nil
 	}
 
 	emptyDirVS := corev1.EmptyDirVolumeSource{}
@@ -54,6 +77,8 @@ func AddConfigVolume(ctx context.Context, pod *corev1.Pod) {
 			},
 		},
 	)
+
+	return nil
 }
 
 func AddConfigVolumeMount(container *corev1.Container, request *dtwebhook.BaseRequest) {
@@ -90,9 +115,18 @@ func AddInitConfigVolumeMount(container *corev1.Container) {
 	)
 }
 
-func AddInputVolume(pod *corev1.Pod) {
-	if k8svolume.Contains(pod.Spec.Volumes, InputVolumeName) {
-		return
+func AddInputVolume(pod *corev1.Pod) error {
+	if vol, _ := k8svolume.FindByName(pod.Spec.Volumes, InputVolumeName); vol != nil {
+		if vol.Projected == nil || len(vol.Projected.Sources) != 2 ||
+			vol.Projected.Sources[0].Secret == nil || vol.Projected.Sources[0].Secret.Name != consts.BootstrapperInitSecretName ||
+			vol.Projected.Sources[1].Secret == nil || vol.Projected.Sources[1].Secret.Name != consts.BootstrapperInitCertsSecretName {
+			return dtwebhook.MutatorError{
+				Err:      existingVolumeError{InputVolumeName},
+				Annotate: setNotInjectedReason(reasonConflictingVolumeType),
+			}
+		}
+
+		return nil
 	}
 
 	pod.Spec.Volumes = append(pod.Spec.Volumes,
@@ -122,6 +156,8 @@ func AddInputVolume(pod *corev1.Pod) {
 			},
 		},
 	)
+
+	return nil
 }
 
 func AddInitInputVolumeMount(container *corev1.Container) {
@@ -136,4 +172,15 @@ func AddInitInputVolumeMount(container *corev1.Container) {
 			ReadOnly:  true,
 		},
 	)
+}
+
+func setNotInjectedReason(reason string) func(*corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+
+		pod.Annotations[annotationInjected] = "false"
+		pod.Annotations[annotationReason] = reason
+	}
 }

--- a/pkg/webhook/mutation/pod/volumes/volumes.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes.go
@@ -30,25 +30,23 @@ const (
 	annotationInjected = AnnotationResourcePrefix + "injected"
 	// annotationDynatraceReason is add to provide extra info why an injection didn't happen.
 	annotationReason = AnnotationResourcePrefix + "reason"
-	// reasonConflictingVolumeType indicates that the user provided a volume definition that conflicts with the one that would be added by the mutator.
-	reasonConflictingVolumeType = "ConflictingVolumeType"
+	// ConflictingVolumeTypeReason indicates that the user provided a volume definition that conflicts with the one that would be added by the mutator.
+	ConflictingVolumeTypeReason = "ConflictingVolumeType"
 )
 
-// existingVolumeError indicates that an existing volume cannot be used for injection because it does not match the expected spec.
-type existingVolumeError struct {
-	volumeName string
-}
+// ExistingVolumeError indicates that an existing volume cannot be used for injection because it does not match the expected spec.
+type ExistingVolumeError string
 
-func (e existingVolumeError) Error() string {
-	return "user-provided " + e.volumeName + " volume cannot be mounted due to invalid configuration"
+func (e ExistingVolumeError) Error() string {
+	return "user-provided " + string(e) + " volume cannot be mounted due to invalid configuration"
 }
 
 func AddConfigVolume(ctx context.Context, pod *corev1.Pod) error {
 	if vol := k8svolume.FindByName(pod.Spec.Volumes, ConfigVolumeName); vol != nil {
 		if vol.EmptyDir == nil {
 			return dtwebhook.MutatorError{
-				Err:      existingVolumeError{ConfigVolumeName},
-				Annotate: setNotInjectedReason(reasonConflictingVolumeType),
+				Err:      ExistingVolumeError(ConfigVolumeName),
+				Annotate: setNotInjectedReason(ConflictingVolumeTypeReason),
 			}
 		}
 
@@ -121,8 +119,8 @@ func AddInputVolume(pod *corev1.Pod) error {
 			vol.Projected.Sources[0].Secret == nil || vol.Projected.Sources[0].Secret.Name != consts.BootstrapperInitSecretName ||
 			vol.Projected.Sources[1].Secret == nil || vol.Projected.Sources[1].Secret.Name != consts.BootstrapperInitCertsSecretName {
 			return dtwebhook.MutatorError{
-				Err:      existingVolumeError{InputVolumeName},
-				Annotate: setNotInjectedReason(reasonConflictingVolumeType),
+				Err:      ExistingVolumeError(InputVolumeName),
+				Annotate: setNotInjectedReason(ConflictingVolumeTypeReason),
 			}
 		}
 

--- a/pkg/webhook/mutation/pod/volumes/volumes.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes.go
@@ -26,10 +26,10 @@ const (
 	// AnnotationConfigVolumeNameResource is used to specify the volume size for EmptyDir for dynatrace-config.
 	AnnotationConfigVolumeNameResource = AnnotationResourcePrefix + ConfigVolumeName
 
-	// annotationDynatraceInjected is set to "true" by the webhook to Pods to indicate that it has been injected.
-	annotationInjected = AnnotationResourcePrefix + "injected"
-	// annotationDynatraceReason is add to provide extra info why an injection didn't happen.
-	annotationReason = AnnotationResourcePrefix + "reason"
+	// AnnotationInjected is set to "true" by the webhook to Pods to indicate that it has been injected.
+	AnnotationInjected = AnnotationResourcePrefix + "injected"
+	// AnnotationReason is add to provide extra info why an injection didn't happen.
+	AnnotationReason = AnnotationResourcePrefix + "reason"
 	// ConflictingVolumeTypeReason indicates that the user provided a volume definition that conflicts with the one that would be added by the mutator.
 	ConflictingVolumeTypeReason = "ConflictingVolumeType"
 )
@@ -178,7 +178,7 @@ func setNotInjectedReason(reason string) func(*corev1.Pod) {
 			pod.Annotations = make(map[string]string)
 		}
 
-		pod.Annotations[annotationInjected] = "false"
-		pod.Annotations[annotationReason] = reason
+		pod.Annotations[AnnotationInjected] = "false"
+		pod.Annotations[AnnotationReason] = reason
 	}
 }

--- a/pkg/webhook/mutation/pod/volumes/volumes.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes.go
@@ -44,7 +44,7 @@ func (e existingVolumeError) Error() string {
 }
 
 func AddConfigVolume(ctx context.Context, pod *corev1.Pod) error {
-	if vol, _ := k8svolume.FindByName(pod.Spec.Volumes, ConfigVolumeName); vol != nil {
+	if vol := k8svolume.FindByName(pod.Spec.Volumes, ConfigVolumeName); vol != nil {
 		if vol.EmptyDir == nil {
 			return dtwebhook.MutatorError{
 				Err:      existingVolumeError{ConfigVolumeName},
@@ -116,7 +116,7 @@ func AddInitConfigVolumeMount(container *corev1.Container) {
 }
 
 func AddInputVolume(pod *corev1.Pod) error {
-	if vol, _ := k8svolume.FindByName(pod.Spec.Volumes, InputVolumeName); vol != nil {
+	if vol := k8svolume.FindByName(pod.Spec.Volumes, InputVolumeName); vol != nil {
 		if vol.Projected == nil || len(vol.Projected.Sources) != 2 ||
 			vol.Projected.Sources[0].Secret == nil || vol.Projected.Sources[0].Secret.Name != consts.BootstrapperInitSecretName ||
 			vol.Projected.Sources[1].Secret == nil || vol.Projected.Sources[1].Secret.Name != consts.BootstrapperInitCertsSecretName {

--- a/pkg/webhook/mutation/pod/volumes/volumes_test.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,9 +19,8 @@ func TestAddInputVolume(t *testing.T) {
 	t.Run("two projected volumes added to pod spec as single volume source", func(t *testing.T) {
 		pod := &corev1.Pod{}
 
-		AddInputVolume(pod)
-
-		assert.Len(t, pod.Spec.Volumes, 1)
+		require.NoError(t, AddInputVolume(pod))
+		require.Len(t, pod.Spec.Volumes, 1)
 
 		assert.Equal(t, corev1.Volume{
 			Name: "dynatrace-input",
@@ -48,6 +48,88 @@ func TestAddInputVolume(t *testing.T) {
 			},
 		}, pod.Spec.Volumes[0])
 	})
+
+	t.Run("existing volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{
+						Name: "dynatrace-input",
+						VolumeSource: corev1.VolumeSource{
+							Projected: &corev1.ProjectedVolumeSource{
+								Sources: []corev1.VolumeProjection{
+									{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: consts.BootstrapperInitSecretName,
+											},
+										},
+									},
+									{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: consts.BootstrapperInitCertsSecretName,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		expectPod := pod.DeepCopy()
+
+		require.NoError(t, AddInputVolume(pod))
+		assert.Equal(t, expectPod, pod)
+	})
+
+	t.Run("conflicting volume type", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			volume corev1.VolumeSource
+		}{
+			{
+				"emptyDir",
+				corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			},
+			{
+				"missing sources",
+				corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{}}}},
+			},
+			{
+				"invalid source types",
+				corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{ConfigMap: &corev1.ConfigMapProjection{}},
+							{ConfigMap: &corev1.ConfigMapProjection{}},
+						},
+					},
+				},
+			},
+			{
+				"invalid secret names",
+				corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "foo"}}},
+							{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "bar"}}},
+						},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				pod := &corev1.Pod{Spec: corev1.PodSpec{Volumes: []corev1.Volume{{Name: InputVolumeName, VolumeSource: test.volume}}}}
+
+				assert.Error(t, AddInputVolume(pod))
+			})
+		}
+	})
 }
 
 func TestAddConfigVolume(t *testing.T) {
@@ -69,7 +151,7 @@ func TestAddConfigVolume(t *testing.T) {
 			},
 		}
 
-		AddConfigVolume(t.Context(), pod)
+		require.NoError(t, AddConfigVolume(t.Context(), pod))
 
 		assert.Len(t, pod.Spec.Volumes, 1)
 		assert.Equal(t, corev1.Volume{
@@ -101,7 +183,7 @@ func TestAddConfigVolume(t *testing.T) {
 			},
 		}
 
-		AddConfigVolume(t.Context(), pod)
+		require.NoError(t, AddConfigVolume(t.Context(), pod))
 
 		assert.Len(t, pod.Spec.Volumes, 1)
 		assert.Equal(t, corev1.Volume{
@@ -110,6 +192,32 @@ func TestAddConfigVolume(t *testing.T) {
 				SizeLimit: new(resource.MustParse("300Mi")),
 			}},
 		}, pod.Spec.Volumes[0])
+	})
+
+	t.Run("existing volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: ConfigVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumHugePages}}},
+				},
+			},
+		}
+		expectPod := pod.DeepCopy()
+
+		require.NoError(t, AddConfigVolume(t.Context(), pod))
+		assert.Equal(t, expectPod, pod)
+	})
+
+	t.Run("conflicting volume", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: ConfigVolumeName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
+				},
+			},
+		}
+
+		require.Error(t, AddConfigVolume(t.Context(), pod))
 	})
 }
 

--- a/pkg/webhook/mutation/pod/webhook_integration_test.go
+++ b/pkg/webhook/mutation/pod/webhook_integration_test.go
@@ -33,6 +33,7 @@ import (
 	oneagentmutator "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/otlp/exporter"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/volumes"
 	"github.com/Dynatrace/dynatrace-operator/test/integrationtests"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -371,6 +372,163 @@ func PropagationTest(t *testing.T, clt client.Client, withoutDeprecatedAnnotatio
 	}
 
 	assert.Contains(t, pod.Spec.InitContainers[0].Args, "--attribute-container={\"container_image.registry\":\"docker.io\",\"container_image.repository\":\"myapp\",\"container_image.tags\":\"1.2.3\",\"k8s.container.name\":\"app\"}")
+}
+
+// TestConflictingVolumeType verifies that the webhook refuses to inject when a pod pre-defines one of the
+// operator-managed volumes with a source that conflicts with the one the mutators would add, and that the
+// corresponding not-injected reason is exposed on the pod. See ICP-6182.
+func TestConflictingVolumeType(t *testing.T) {
+	clt := integrationtests.SetupWebhookTestEnvironment(t,
+		getWebhookInstallOptions(),
+
+		func(mgr ctrl.Manager) error {
+			require.NoError(t, mgr.GetClient().Create(t.Context(), getNamespace(testNamespace)))
+
+			dummyWebhookPod := getDummyWebhookPod()
+			require.NoError(t, mgr.GetClient().Create(t.Context(), dummyWebhookPod))
+			t.Setenv(k8senv.PodName, dummyWebhookPod.Name)
+			t.Setenv(k8senv.DTOperatorImageEnvName, dummyWebhookPod.Spec.Containers[0].Image)
+
+			return podmutation.AddWebhookToManager(t.Context(), mgr, testNamespace, false)
+		},
+	)
+
+	// shared between test cases
+	createObject(t, clt, getBoostrapperSecret(testNamespace))
+	createObject(t, clt, getOTLPExporterSecret(testNamespace))
+	createObject(t, clt, getOTLPExporterCertsSecret(testNamespace))
+
+	// a volume with a source the mutators would never produce
+	hostPathVolume := func(name string) corev1.Volume {
+		return corev1.Volume{
+			Name:         name,
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}},
+		}
+	}
+
+	// a fully ready cloud-native DynaKube so injection proceeds up to the conflicting volume
+	oneAgentDynaKube := func() *dynakube.DynaKube {
+		return &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dynakube",
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					exp.InjectionAutomaticKey: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
+				},
+			},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: oneagent.Status{
+					ConnectionInfo: communication.ConnectionInfo{
+						TenantUUID: uuid.NewString(),
+					},
+				},
+				CodeModules: oneagent.CodeModulesStatus{
+					VersionStatus: status.VersionStatus{
+						Version: "1.2.3",
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("config volume", func(t *testing.T) {
+		createDynaKube(t, clt, oneAgentDynaKube())
+
+		pod := createPod(t, clt, func(pod *corev1.Pod) {
+			pod.Spec.Volumes = append(pod.Spec.Volumes, hostPathVolume(volumes.ConfigVolumeName))
+		})
+
+		assert.Equal(t, volumes.ConflictingVolumeTypeReason, pod.Annotations[volumes.AnnotationReason])
+	})
+
+	t.Run("input volume", func(t *testing.T) {
+		createDynaKube(t, clt, oneAgentDynaKube())
+
+		pod := createPod(t, clt, func(pod *corev1.Pod) {
+			pod.Spec.Volumes = append(pod.Spec.Volumes, hostPathVolume(volumes.InputVolumeName))
+		})
+
+		assert.Equal(t, volumes.ConflictingVolumeTypeReason, pod.Annotations[volumes.AnnotationReason])
+	})
+
+	t.Run("oneagent-bin emptyDir volume", func(t *testing.T) {
+		dk := oneAgentDynaKube()
+		// a code modules image lets the pod-level volume-type annotation force the emptyDir bin volume path
+		dk.Status.CodeModules.ImageID = "registry.example.com/codemodules@sha256:" + strings.Repeat("a", 64)
+		createDynaKube(t, clt, dk)
+
+		pod := createPod(t, clt, func(pod *corev1.Pod) {
+			pod.Annotations[oneagentmutator.AnnotationVolumeType] = oneagentmutator.EphemeralVolumeType
+			pod.Spec.Volumes = append(pod.Spec.Volumes, hostPathVolume(oneagentmutator.BinVolumeName))
+		})
+
+		assert.Equal(t, volumes.ConflictingVolumeTypeReason, pod.Annotations[oneagentmutator.AnnotationReason])
+	})
+
+	t.Run("oneagent-bin CSI volume", func(t *testing.T) {
+		dk := oneAgentDynaKube()
+		// a code modules image lets the pod-level volume-type annotation force the CSI bin volume path
+		dk.Status.CodeModules.ImageID = "registry.example.com/codemodules@sha256:" + strings.Repeat("a", 64)
+		createDynaKube(t, clt, dk)
+
+		pod := createPod(t, clt, func(pod *corev1.Pod) {
+			pod.Annotations[oneagentmutator.AnnotationVolumeType] = oneagentmutator.CSIVolumeType
+			pod.Spec.Volumes = append(pod.Spec.Volumes, hostPathVolume(oneagentmutator.BinVolumeName))
+		})
+
+		assert.Equal(t, volumes.ConflictingVolumeTypeReason, pod.Annotations[oneagentmutator.AnnotationReason])
+	})
+
+	t.Run("otlp activegate cert volume", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dynakube",
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					exp.InjectionAutomaticKey: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: "https://example.live.dynatrace.com",
+				ActiveGate: activegate.Spec{
+					Capabilities: []activegate.CapabilityDisplayName{
+						activegate.RoutingCapability.DisplayName,
+					},
+				},
+				OTLPExporterConfiguration: &otlpspec.ExporterConfigurationSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: podmutator.InjectionInstanceLabel, Operator: metav1.LabelSelectorOpExists},
+						},
+					},
+					Signals: otlpspec.SignalConfiguration{
+						Metrics: &otlpspec.MetricsSignal{},
+						Logs:    &otlpspec.LogsSignal{},
+						Traces:  &otlpspec.TracesSignal{},
+					},
+				},
+			},
+			Status: dynakube.DynaKubeStatus{
+				OneAgent: oneagent.Status{
+					ConnectionInfo: communication.ConnectionInfo{
+						TenantUUID: uuid.NewString(),
+					},
+				},
+			},
+		}
+		createDynaKube(t, clt, dk)
+
+		pod := createPod(t, clt, func(pod *corev1.Pod) {
+			pod.Spec.Volumes = append(pod.Spec.Volumes, hostPathVolume(exporter.ActiveGateTrustedCertVolumeName))
+		})
+
+		assert.Equal(t, volumes.ConflictingVolumeTypeReason, pod.Annotations[podmutator.AnnotationOTLPReason])
+	})
 }
 
 func TestOTLPWebhook(t *testing.T) { //nolint:revive
@@ -1267,6 +1425,18 @@ func getOTLPExporterSecret(namespace string) *corev1.Secret {
 		Data: map[string][]byte{
 			token.APIKey:        []byte(dataIngestToken),
 			token.DataIngestKey: []byte(dataIngestToken),
+		},
+	}
+}
+
+func getOTLPExporterCertsSecret(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consts.OTLPExporterCertsSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			dynakube.TLSCertKey: []byte("ag-cert-data"),
 		},
 	}
 }


### PR DESCRIPTION
## Description

Fail Pod injection when a volume with matching name, but conflicting configuration is already present.
Previously, we only looked at the name which could lead to a hostPath volume being mounted instead of an emptyDir.
This change adds checks to the volume type as well as some fields, e.g. the secret name in the case of a secret volume.

Add two new annotations related to failed injection:
* `volume.dynatrace.com/injected`
* `volume.dynatrace.com/reason`

ICP-6281

## How can this be tested?

* Run tests
* Deploy operator and check that invalid volumes are not mounted and annotations are present
