### PR TITLE
refactor (dk) which cause some e2e tests flakiness

### DIFF
--- a/pkg/controllers/dynakube/phase.go
+++ b/pkg/controllers/dynakube/phase.go
@@ -17,12 +17,11 @@ func (controller *Controller) determineDynaKubePhase(ctx context.Context, dk *dy
 	components := []func(ctx context.Context, dk *dynakube.DynaKube) status.DeploymentPhase{
 		controller.determineActiveGatePhase,
 		controller.determineExtensionsExecutionControllerPhase,
-		controller.determineExtensionsCollectorPhase,
 		controller.determineExtensionsDatabasesPhase,
 		controller.determineOneAgentPhase,
 		controller.determineLogAgentPhase,
 		controller.determineKSPMPhase,
-		controller.determineTelemetryIngestPhase,
+		controller.determineOTELCollectorPhase,
 	}
 	for _, component := range components {
 		if phase := component(ctx, dk); phase != status.Running {
@@ -61,24 +60,16 @@ func (controller *Controller) determineActiveGatePhase(ctx context.Context, dk *
 }
 
 func (controller *Controller) determineExtensionsExecutionControllerPhase(ctx context.Context, dk *dynakube.DynaKube) status.DeploymentPhase {
-	return controller.determinePrometheusStatefulsetPhase(ctx, dk, dk.Extensions().GetExecutionControllerStatefulsetName())
-}
-
-func (controller *Controller) determineExtensionsCollectorPhase(ctx context.Context, dk *dynakube.DynaKube) status.DeploymentPhase {
-	return controller.determinePrometheusStatefulsetPhase(ctx, dk, dk.OtelCollectorStatefulsetName())
-}
-
-func (controller *Controller) determineTelemetryIngestPhase(ctx context.Context, dk *dynakube.DynaKube) status.DeploymentPhase {
-	if dk.TelemetryIngest().IsEnabled() {
-		return controller.determineStatefulSetPhase(ctx, dk, dk.OtelCollectorStatefulsetName())
+	if dk.Extensions().IsAnyEnabled() {
+		return controller.determineStatefulSetPhase(ctx, dk, dk.Extensions().GetExecutionControllerStatefulsetName())
 	}
 
 	return status.Running
 }
 
-func (controller *Controller) determinePrometheusStatefulsetPhase(ctx context.Context, dk *dynakube.DynaKube, statefulsetName string) status.DeploymentPhase {
-	if dk.Extensions().IsPrometheusEnabled() {
-		return controller.determineStatefulSetPhase(ctx, dk, statefulsetName)
+func (controller *Controller) determineOTELCollectorPhase(ctx context.Context, dk *dynakube.DynaKube) status.DeploymentPhase {
+	if dk.Extensions().IsPrometheusEnabled() || dk.TelemetryIngest().IsEnabled() {
+		return controller.determineStatefulSetPhase(ctx, dk, dk.OtelCollectorStatefulsetName())
 	}
 
 	return status.Running

--- a/pkg/controllers/dynakube/phase_test.go
+++ b/pkg/controllers/dynakube/phase_test.go
@@ -224,125 +224,125 @@ func TestExtensionsExecutionControllerPhaseChanges(t *testing.T) {
 	})
 }
 
-func TestExtensionsCollectorPhaseChanges(t *testing.T) {
-	dk := &dynakube.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
-		},
-		Spec: dynakube.DynaKubeSpec{
-			Extensions: &extensions.Spec{Prometheus: &extensions.PrometheusSpec{}},
-		},
-	}
+func TestOTELCollectorPhaseChanges(t *testing.T) {
+	t.Run("prometheus enabled", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				Extensions: &extensions.Spec{Prometheus: &extensions.PrometheusSpec{}},
+			},
+		}
 
-	t.Run("no otelc statefulsets in cluster -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient()
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
+		t.Run("no otelc statefulsets in cluster -> deploying", func(t *testing.T) {
+			fakeClient := fake.NewClient()
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Deploying, phase)
+		})
+		t.Run("error accessing k8s api -> error", func(t *testing.T) {
+			fakeClient := errorClient{}
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Error, phase)
+		})
+		t.Run("otelc pods not ready -> deploying", func(t *testing.T) {
+			fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2, 1))
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Deploying, phase)
+		})
+		t.Run("otelc deployed -> running", func(t *testing.T) {
+			fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2, 2))
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Running, phase)
+		})
+		t.Run("otelc pods ready but generation outdated -> deploying", func(t *testing.T) {
+			fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2))
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Deploying, phase)
+		})
 	})
-	t.Run("error accessing k8s api -> error", func(t *testing.T) {
-		fakeClient := errorClient{}
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
-		assert.Equal(t, status.Error, phase)
-	})
-	t.Run("otelc pods not ready -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2, 1))
 
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
+	t.Run("telemetryingest enabled", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: dynakube.DynaKubeSpec{
+				TelemetryIngest: &telemetryingest.Spec{},
+			},
 		}
-		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
-	})
-	t.Run("otelc deployed -> running", func(t *testing.T) {
-		fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2, 2))
 
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
-		assert.Equal(t, status.Running, phase)
+		t.Run("no otelc statefulset in cluster -> deploying", func(t *testing.T) {
+			fakeClient := fake.NewClient()
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Deploying, phase)
+		})
+		t.Run("error accessing k8s api -> error", func(t *testing.T) {
+			fakeClient := errorClient{}
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Error, phase)
+		})
+		t.Run("otelc pods not ready -> deploying", func(t *testing.T) {
+			fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1, 0))
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Deploying, phase)
+		})
+		t.Run("otelc deployed -> running", func(t *testing.T) {
+			fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1, 1))
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Running, phase)
+		})
+		t.Run("otelc pods ready but generation outdated -> deploying", func(t *testing.T) {
+			fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1))
+			controller := &Controller{
+				client:    fakeClient,
+				apiReader: fakeClient,
+			}
+			phase := controller.determineOTELCollectorPhase(t.Context(), dk)
+			assert.Equal(t, status.Deploying, phase)
+		})
 	})
-	t.Run("otelc pods ready but generation outdated -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 2))
 
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineExtensionsCollectorPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
-	})
-}
-
-func TestTelemetryIngestPhaseChanges(t *testing.T) {
-	dk := &dynakube.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testName,
-			Namespace: testNamespace,
-		},
-		Spec: dynakube.DynaKubeSpec{
-			TelemetryIngest: &telemetryingest.Spec{},
-		},
-	}
-
-	t.Run("no otelc statefulset in cluster -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient()
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
-	})
-	t.Run("error accessing k8s api -> error", func(t *testing.T) {
-		fakeClient := errorClient{}
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
-		assert.Equal(t, status.Error, phase)
-	})
-	t.Run("otelc pods not ready -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1, 0))
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
-	})
-	t.Run("otelc deployed -> running", func(t *testing.T) {
-		fakeClient := fake.NewClient(createStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1, 1))
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
-		assert.Equal(t, status.Running, phase)
-	})
-	t.Run("otelc pods ready but generation outdated -> deploying", func(t *testing.T) {
-		fakeClient := fake.NewClient(createOutdatedStatefulset(testNamespace, dk.OtelCollectorStatefulsetName(), 1))
-		controller := &Controller{
-			client:    fakeClient,
-			apiReader: fakeClient,
-		}
-		phase := controller.determineTelemetryIngestPhase(t.Context(), dk)
-		assert.Equal(t, status.Deploying, phase)
-	})
-	t.Run("telemetryingest not enabled -> running", func(t *testing.T) {
-		dkNoTI := &dynakube.DynaKube{
+	t.Run("neither prometheus nor telemetryingest enabled -> running", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
 		}
 		fakeClient := fake.NewClient()
@@ -350,7 +350,7 @@ func TestTelemetryIngestPhaseChanges(t *testing.T) {
 			client:    fakeClient,
 			apiReader: fakeClient,
 		}
-		phase := controller.determineTelemetryIngestPhase(t.Context(), dkNoTI)
+		phase := controller.determineOTELCollectorPhase(t.Context(), dk)
 		assert.Equal(t, status.Running, phase)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

DK Phase -> running haviely and then usually we check STS replicas count and in some cases it doesn't match.
So here is PR: (the logic was keep determine phase per component not per dk,spec section) so few renames and merges were involed bc `determineExtensionsCollectorPhase` and `determineTelemetryIngestPhase` both check same sts, which is useless IMO.



Partitially fixes https://dt-rnd.atlassian.net/browse/ICP-6104



## How can this be tested?

unit tests/ run e2e tests (but it's tricky bc not always you can catch flaky tests)

related to NEW e2e tests for public registry (of EEC/DATABASE EXE) https://github.com/Dynatrace/dynatrace-operator/actions/runs/27754942769/job/82114339337 (example of failing run)

Will unblock https://github.com/Dynatrace/dynatrace-operator/pull/6844
related to https://github.com/Dynatrace/dynatrace-operator/pull/6838