### PR TITLE
fix: don't call API for an image if no databases are used

### DIFF
--- a/pkg/controllers/dynakube/extension/databases/reconciler.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler.go
@@ -31,12 +31,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 
 	log.Debug("reconciling deployments")
 
-	imageURI, err := registry.ResolveImage(ctx, imageClient, dk.FF().IsPublicRegistry(), dk.PublicRegistryOverride(), dtimage.DBExecutor)
-	if err != nil {
-		return err
-	}
-
-	query := k8sdeployment.Query(r.client, r.apiReader)
 	ext := dk.Extensions()
 	expectedDeploymentNames := make([]string, len(ext.Databases))
 
@@ -49,6 +43,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 
 		return err
 	}
+
+	if !ext.IsDatabasesEnabled() {
+		_ = meta.RemoveStatusCondition(dk.Conditions(), conditionType)
+
+		return nil
+	}
+
+	imageURI, err := registry.ResolveImage(ctx, imageClient, dk.FF().IsPublicRegistry(), dk.PublicRegistryOverride(), dtimage.DBExecutor)
+	if err != nil {
+		return err
+	}
+
+	query := k8sdeployment.Query(r.client, r.apiReader)
 
 	for i, dbSpec := range ext.Databases {
 		replicas, err := k8sdeployment.ResolveReplicas(ctx, r.apiReader, client.ObjectKey{Name: expectedDeploymentNames[i], Namespace: dk.Namespace}, dbSpec.Replicas)
@@ -92,11 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 		}
 	}
 
-	if len(expectedDeploymentNames) > 0 {
-		k8sconditions.SetDeploymentsApplied(dk, conditionType, expectedDeploymentNames)
-	} else {
-		_ = meta.RemoveStatusCondition(dk.Conditions(), conditionType)
-	}
+	k8sconditions.SetDeploymentsApplied(dk, conditionType, expectedDeploymentNames)
 
 	return nil
 }

--- a/pkg/controllers/dynakube/extension/databases/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler_test.go
@@ -373,7 +373,6 @@ func TestPublicRegistryImage(t *testing.T) {
 		deployments := &appsv1.DeploymentList{}
 		require.NoError(t, clt.List(t.Context(), deployments))
 		require.Empty(t, deployments.Items)
-		imageClient.AssertNotCalled(t, "GetComponentLatestInfo")
 	})
 }
 

--- a/pkg/controllers/dynakube/extension/databases/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler_test.go
@@ -336,28 +336,45 @@ func TestAppArmorAnnotationHandling(t *testing.T) {
 }
 
 func TestPublicRegistryImage(t *testing.T) {
-	expectedImageURI := "my-public-registry:5000/my-test-repo:my-test-tag"
-	getReconciledDeployment := func(t *testing.T) *appsv1.Deployment {
-		t.Helper()
+	t.Run("imageURI from public registry", func(t *testing.T) {
+		expectedImageURI := "my-public-registry:5000/my-test-repo:my-test-tag"
+		getReconciledDeployment := func(t *testing.T) *appsv1.Deployment {
+			t.Helper()
 
+			dk := getTestDynakube()
+			dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+			dk.Spec.Templates = dynakube.TemplatesSpec{}
+			clt := fakeClient()
+
+			imageClient := imageclientmock.NewClient(t)
+			imageClient.EXPECT().GetComponentLatestInfo(mock.MatchedBy(func(context.Context) bool { return true }), dtimage.DBExecutor, "").Return(&dtimage.Info{URI: expectedImageURI}, nil)
+
+			require.NoError(t, NewReconciler(clt, clt).Reconcile(t.Context(), imageClient, dk))
+			deployments := &appsv1.DeploymentList{}
+			require.NoError(t, clt.List(t.Context(), deployments))
+			require.Len(t, deployments.Items, 1)
+
+			return &deployments.Items[0]
+		}
+
+		deployment := getReconciledDeployment(t)
+		require.Equal(t, expectedImageURI, deployment.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("no call to api when extensions are not used", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
-		dk.Spec.Templates = dynakube.TemplatesSpec{}
+		dk.Spec.Extensions.Databases = nil
 		clt := fakeClient()
 
 		imageClient := imageclientmock.NewClient(t)
-		imageClient.EXPECT().GetComponentLatestInfo(mock.MatchedBy(func(context.Context) bool { return true }), dtimage.DBExecutor, "").Return(&dtimage.Info{URI: expectedImageURI}, nil)
 
 		require.NoError(t, NewReconciler(clt, clt).Reconcile(t.Context(), imageClient, dk))
 		deployments := &appsv1.DeploymentList{}
 		require.NoError(t, clt.List(t.Context(), deployments))
-		require.Len(t, deployments.Items, 1)
-
-		return &deployments.Items[0]
-	}
-
-	deployment := getReconciledDeployment(t)
-	require.Equal(t, expectedImageURI, deployment.Spec.Template.Spec.Containers[0].Image)
+		require.Empty(t, deployments.Items)
+		imageClient.AssertNotCalled(t, "GetComponentLatestInfo")
+	})
 }
 
 func fakeClient() client.Client {


### PR DESCRIPTION
## Description
[ICP-6370](https://dt-rnd.atlassian.net/browse/ICP-6370)

## How can this be tested?
`make go/test`
`make test/e2e/usepublicregistry`

[ICP-6370]: https://dt-rnd.atlassian.net/browse/ICP-6370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ