### PR TITLE
Simplify helm template boolean helper checks

### DIFF
--- a/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
+++ b/config/helm/chart/default/templates/Common/activegate/clusterrole-activegate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.activeGate.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if and .Values.rbac.activeGate.create (include "dynatrace-operator.openshiftOrOlm" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/crd/clusterrole-crd-storage-migration.yaml
+++ b/config/helm/chart/default/templates/Common/crd/clusterrole-crd-storage-migration.yaml
@@ -54,7 +54,7 @@ rules:
     verbs:
       - get
       - update
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/crd/job-crd-storage-migration.yaml
+++ b/config/helm/chart/default/templates/Common/crd/job-crd-storage-migration.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         {{- include "dynatrace-operator.crdStorageMigrationLabels" . | nindent 8 }}
       annotations:
-      {{- if and (.Values.operator.apparmor) (eq (include "kubernetes.appArmorSecurityContextSupported" .) "false") }}
+      {{- if and (.Values.operator.apparmor) (not (include "kubernetes.appArmorSecurityContextSupported" .)) }}
         container.apparmor.security.beta.kubernetes.io/crd-storage-migration: runtime/default
       {{- end }}
     spec:
@@ -53,7 +53,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $needsCertgen := not (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+      {{- $needsCertgen := not (include "dynatrace-operator.openshiftOrOlm" .) }}
       {{- if $needsCertgen }}
       initContainers:
         - name: webhook-cert-generator

--- a/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/clusterrole-csi.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+{{ if (include "dynatrace-operator.needCSI" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/csi/csidriver.yaml
+++ b/config/helm/chart/default/templates/Common/csi/csidriver.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+{{ if (include "dynatrace-operator.needCSI" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/csi/daemonset.yaml
+++ b/config/helm/chart/default/templates/Common/csi/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+{{ if (include "dynatrace-operator.needCSI" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ spec:
         dynatrace.com/inject: "false"
         kubectl.kubernetes.io/default-container: {{ if .Values.csidriver.migrationMode }}server{{ else }}provisioner{{ end }}
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
-        {{- if and (or .Values.csidriver.apparmor .Values.apparmor) (ne (include "kubernetes.appArmorSecurityContextSupported" .) "true") }}
+        {{- if and (or .Values.csidriver.apparmor .Values.apparmor) (not (include "kubernetes.appArmorSecurityContextSupported" .)) }}
         container.apparmor.security.beta.kubernetes.io/csi-init: runtime/default
         container.apparmor.security.beta.kubernetes.io/server: runtime/default
         container.apparmor.security.beta.kubernetes.io/provisioner: runtime/default
@@ -295,7 +295,7 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      {{- if and (or .Values.csidriver.apparmor .Values.apparmor) (eq (include "kubernetes.appArmorSecurityContextSupported" .) "true") }}
+      {{- if and (or .Values.csidriver.apparmor .Values.apparmor) (include "kubernetes.appArmorSecurityContextSupported" .) }}
       securityContext:
         {{- include "kubernetes.defaultAppArmorProfile" . | nindent 8 }}
       {{- else }}

--- a/config/helm/chart/default/templates/Common/csi/priority-class.yaml
+++ b/config/helm/chart/default/templates/Common/csi/priority-class.yaml
@@ -1,4 +1,4 @@
-{{ if (eq (include "dynatrace-operator.needPriorityClass" .) "true") }}
+{{ if (include "dynatrace-operator.needPriorityClass" .) }}
 
 # Copyright 2021 Dynatrace LLC
 

--- a/config/helm/chart/default/templates/Common/csi/role-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/role-csi.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+{{ if (include "dynatrace-operator.needCSI" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/csi/serviceaccount-csi.yaml
+++ b/config/helm/chart/default/templates/Common/csi/serviceaccount-csi.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "dynatrace-operator.needCSI" .) "true" }}
+{{ if (include "dynatrace-operator.needCSI" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/edge-connect/clusterrole-edgeconnect.yaml
+++ b/config/helm/chart/default/templates/Common/edge-connect/clusterrole-edgeconnect.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.edgeConnect.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if and .Values.rbac.edgeConnect.create (include "dynatrace-operator.openshiftOrOlm" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/extensions/clusterrole-extension-controller.yaml
+++ b/config/helm/chart/default/templates/Common/extensions/clusterrole-extension-controller.yaml
@@ -27,7 +27,7 @@ rules:
     verbs:
       - list
       - watch
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/extensions/database/role-extensions-database.yaml
+++ b/config/helm/chart/default/templates/Common/extensions/database/role-extensions-database.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     {{- include "dynatrace-operator.databaseDatasourceLabels" . | nindent 4 }}
 rules:
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/extensions/prometheus/clusterole-extensions-prometheus.yaml
+++ b/config/helm/chart/default/templates/Common/extensions/prometheus/clusterole-extensions-prometheus.yaml
@@ -44,7 +44,7 @@ rules:
       - get
       - list
       - watch
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/extensions/role-extension-controller-database.yaml
+++ b/config/helm/chart/default/templates/Common/extensions/role-extension-controller-database.yaml
@@ -23,7 +23,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list"]
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/extensions/role-extension-controller-prometheus.yaml
+++ b/config/helm/chart/default/templates/Common/extensions/role-extension-controller-prometheus.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.rbac.extensions.prometheus.create .Values.rbac.extensions.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true")) }}
+{{- if (and .Values.rbac.extensions.prometheus.create .Values.rbac.extensions.create (include "dynatrace-operator.openshiftOrOlm" .)) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/kspm/clusterrole-node-config-collector.yaml
+++ b/config/helm/chart/default/templates/Common/kspm/clusterrole-node-config-collector.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.kspm.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if and .Values.rbac.kspm.create (include "dynatrace-operator.openshiftOrOlm" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/logmonitoring/clusterrole-logmonitoring.yaml
+++ b/config/helm/chart/default/templates/Common/logmonitoring/clusterrole-logmonitoring.yaml
@@ -26,7 +26,7 @@ rules:
     - nodes/pods
   verbs:
     - get
-{{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
 - apiGroups:
     - security.openshift.io
   resourceNames:

--- a/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
+++ b/config/helm/chart/default/templates/Common/oneagent/clusterrole-oneagent.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.oneAgent.create (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+{{- if and .Values.rbac.oneAgent.create (include "dynatrace-operator.openshiftOrOlm" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/operator/allowlistsynchronizer.yaml
+++ b/config/helm/chart/default/templates/Common/operator/allowlistsynchronizer.yaml
@@ -1,4 +1,4 @@
-{{ if eq (include "dynatrace-operator.needAutopilotAllowlisting" .) "true" }}
+{{ if (include "dynatrace-operator.needAutopilotAllowlisting" .) }}
 # Copyright 2021 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -87,7 +87,7 @@ rules:
     verbs:
       - get
       - update
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         dynatrace.com/inject: "false"
         kubectl.kubernetes.io/default-container: operator
-      {{- if and (.Values.operator.apparmor) (eq (include "kubernetes.appArmorSecurityContextSupported" .) "false") }}
+      {{- if and (.Values.operator.apparmor) (not (include "kubernetes.appArmorSecurityContextSupported" .)) }}
         container.apparmor.security.beta.kubernetes.io/operator: runtime/default
       {{- end }}
       {{- if .Values.operator.annotations }}
@@ -52,7 +52,7 @@ spec:
         {{- toYaml .Values.operator.labels | nindent 8 }}
         {{- end }}
     spec:
-      {{- $needsCertgen := not (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+      {{- $needsCertgen := not (include "dynatrace-operator.openshiftOrOlm" .) }}
       {{- $needsMigrator := and .Release.IsUpgrade .Values.operator.crdStorageMigrationInitManager }}
       {{- if or $needsCertgen $needsMigrator }}
       initContainers:

--- a/config/helm/chart/default/templates/Common/otel-collector/clusterole-telemetry-endpoints.yaml
+++ b/config/helm/chart/default/templates/Common/otel-collector/clusterole-telemetry-endpoints.yaml
@@ -38,7 +38,7 @@ rules:
       - get
       - list
       - watch
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/clusterrole-webhook.yaml
@@ -76,7 +76,7 @@ rules:
       - deploymentconfigs
     verbs:
       - get
-  {{- if (eq (include "dynatrace-operator.openshiftOrOlm" .) "true") }}
+  {{- if (include "dynatrace-operator.openshiftOrOlm" .) }}
   - apiGroups:
       - security.openshift.io
     resourceNames:

--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         dynatrace.com/inject: "false"
         kubectl.kubernetes.io/default-container: webhook
-        {{- if and (.Values.webhook.apparmor) (eq (include "kubernetes.appArmorSecurityContextSupported" .) "false") }}
+        {{- if and (.Values.webhook.apparmor) (not (include "kubernetes.appArmorSecurityContextSupported" .)) }}
         container.apparmor.security.beta.kubernetes.io/webhook: runtime/default
         {{- end }}
         {{- if .Values.webhook.annotations}}

--- a/config/helm/chart/default/templates/_csidriver.tpl
+++ b/config/helm/chart/default/templates/_csidriver.tpl
@@ -32,7 +32,7 @@ CSI PriorityClassName
 Check if we need the csi default priority class
 */}}
 {{- define "dynatrace-operator.needPriorityClass" -}}
-	{{- if and (eq (include "dynatrace-operator.needCSI" .) "true") (not .Values.csidriver.existingPriorityClassName) -}}
+	{{- if and (include "dynatrace-operator.needCSI" .) (not .Values.csidriver.existingPriorityClassName) -}}
 		{{- printf "true" -}}
 	{{- end -}}
 {{- end -}}

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -149,15 +149,13 @@ The common envs that inform the component about what is configured in its pod
 {{- end -}}
 
 {{- define "kubernetes.appArmorSecurityContextSupported" -}}
-{{- if semverCompare ">=1.31.0" .Capabilities.KubeVersion.Version  -}}
+{{- if semverCompare ">=1.31.0" .Capabilities.KubeVersion.Version -}}
     true
-{{- else -}}
-    false
 {{- end -}}
 {{- end -}}
 
 {{- define "kubernetes.defaultAppArmorProfile" -}}
-{{- if eq (include "kubernetes.appArmorSecurityContextSupported" .) "true" -}}
+{{- if (include "kubernetes.appArmorSecurityContextSupported" .) -}}
 appArmorProfile:
   type: RuntimeDefault
 {{- end -}}


### PR DESCRIPTION
## Description

Cleanup of boolean helper usage in the helm chart templates.

- Replace redundant `eq (include "helper" .) "true"` with a naked `(include "helper" .)` — the helpers already return empty string when the condition doesn't match, so the `eq` comparison is unnecessary.
- Modify `kubernetes.appArmorSecurityContextSupported` to fit the same pattern by dropping the `else "false"` branch; `eq ... "false"` / `ne ... "true"` call sites become `not (include ...)`.
- Enforce consistent parentheses around all `include` calls used directly in `if` conditions.

## How can this be tested?

- `make test/helm/unit` — all 301 unit tests pass.