### PR TITLE
Change default AG TopologySpreadConstraint to ScheduleAnyway

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -201,7 +201,7 @@ func (statefulSetBuilder Builder) defaultTopologyConstraints() []corev1.Topology
 		{
 			MaxSkew:           1,
 			TopologyKey:       "kubernetes.io/hostname",
-			WhenUnsatisfiable: "DoNotSchedule",
+			WhenUnsatisfiable: "ScheduleAnyway",
 			NodeTaintsPolicy:  &nodeInclusionPolicyHonor,
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: appLabels.BuildMatchLabels()},
 		},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -194,14 +194,14 @@ func (statefulSetBuilder Builder) defaultTopologyConstraints() []corev1.Topology
 	return []corev1.TopologySpreadConstraint{
 		{
 			MaxSkew:           1,
-			TopologyKey:       "topology.kubernetes.io/zone",
-			WhenUnsatisfiable: "ScheduleAnyway",
+			TopologyKey:       corev1.LabelTopologyZone,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: appLabels.BuildMatchLabels()},
 		},
 		{
 			MaxSkew:           1,
-			TopologyKey:       "kubernetes.io/hostname",
-			WhenUnsatisfiable: "ScheduleAnyway",
+			TopologyKey:       corev1.LabelHostname,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
 			NodeTaintsPolicy:  &nodeInclusionPolicyHonor,
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: appLabels.BuildMatchLabels()},
 		},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[ICP-6540](https://dt-rnd.atlassian.net/browse/ICP-6540)

Changes the default `WhenUnsatisfiable` policy for the ActiveGate `TopologySpreadConstraint` on `kubernetes.io/hostname` from `DoNotSchedule` to `ScheduleAnyway`.

`DoNotSchedule` makes updates brittle on clusters with few nodes — pods can get stuck unschedulable if the constraint can't be satisfied. `ScheduleAnyway` keeps the spread preference without blocking scheduling.

Note: this will trigger a rolling restart of existing ActiveGate pods on upgrade. This is highlighted in the release notes.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

`make go/test`


[ICP-6540]: https://dt-rnd.atlassian.net/browse/ICP-6540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ