### PR TITLE
Remove redundant dynakube logger names

### DIFF
--- a/pkg/api/latest/dynakube/dynakube_status.go
+++ b/pkg/api/latest/dynakube/dynakube_status.go
@@ -97,7 +97,7 @@ func (dk *DynaKubeStatus) SetPhase(phase status.DeploymentPhase) bool {
 }
 
 func (dk *DynaKube) UpdateStatus(ctx context.Context, client client.Client) error {
-	_, log := logd.NewFromContext(ctx, "dynakube-v1beta6")
+	_, log := logd.NewFromContext(ctx, "v1beta6")
 	dk.Status.UpdatedTimestamp = metav1.Now()
 	err := client.Status().Update(ctx, dk)
 

--- a/pkg/api/v1beta4/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta4/dynakube/dynakube_status.go
@@ -100,7 +100,7 @@ func (dk *DynaKubeStatus) SetPhase(phase status.DeploymentPhase) bool {
 }
 
 func (dk *DynaKube) UpdateStatus(ctx context.Context, client client.Client) error {
-	_, log := logd.NewFromContext(ctx, "dynakube-v1beta4")
+	_, log := logd.NewFromContext(ctx, "v1beta4")
 	dk.Status.UpdatedTimestamp = metav1.Now()
 	err := client.Status().Update(ctx, dk)
 

--- a/pkg/api/v1beta5/dynakube/dynakube_status.go
+++ b/pkg/api/v1beta5/dynakube/dynakube_status.go
@@ -105,7 +105,7 @@ func (dk *DynaKubeStatus) SetPhase(phase status.DeploymentPhase) bool {
 }
 
 func (dk *DynaKube) UpdateStatus(ctx context.Context, client client.Client) error {
-	_, log := logd.NewFromContext(ctx, "dynakube-v1beta5")
+	_, log := logd.NewFromContext(ctx, "v1beta5")
 	dk.Status.UpdatedTimestamp = metav1.Now()
 	err := client.Status().Update(ctx, dk)
 

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -115,7 +115,7 @@ func New(apiReader client.Reader) admission.Validator[runtime.Object] {
 }
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-validation")
+	ctx, _ = logd.NewFromContext(ctx, "validation")
 
 	dk, err := getDynakube(obj)
 	if err != nil {
@@ -133,7 +133,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-validation")
+	ctx, _ = logd.NewFromContext(ctx, "validation")
 
 	oldDK, err := getDynakube(oldObj)
 	if err != nil {

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -115,7 +115,7 @@ func New(apiReader client.Reader) admission.Validator[runtime.Object] {
 }
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube")
+	ctx, _ = logd.NewFromContext(ctx, "validation")
 
 	dk, err := getDynakube(obj)
 	if err != nil {
@@ -133,7 +133,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube")
+	ctx, _ = logd.NewFromContext(ctx, "validation")
 
 	oldDK, err := getDynakube(oldObj)
 	if err != nil {

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -115,7 +115,7 @@ func New(apiReader client.Reader) admission.Validator[runtime.Object] {
 }
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "validation")
+	ctx, _ = logd.NewFromContext(ctx, "dynakube")
 
 	dk, err := getDynakube(obj)
 	if err != nil {
@@ -133,7 +133,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "validation")
+	ctx, _ = logd.NewFromContext(ctx, "dynakube")
 
 	oldDK, err := getDynakube(oldObj)
 	if err != nil {

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -46,7 +46,7 @@ func New(apiReader client.Reader, cfg *rest.Config) admission.Validator[runtime.
 }
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (_ admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "edgeconnect")
+	ctx, _ = logd.NewFromContext(ctx, "validation")
 
 	ec, err := getEdgeConnect(obj)
 	if err != nil {
@@ -63,7 +63,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (_ a
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "edgeconnect")
+	ctx, _ = logd.NewFromContext(ctx, "validation")
 
 	ec, err := getEdgeConnect(newObj)
 	if err != nil {

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -46,7 +46,7 @@ func New(apiReader client.Reader, cfg *rest.Config) admission.Validator[runtime.
 }
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (_ admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "edgeconnect-validation")
+	ctx, _ = logd.NewFromContext(ctx, "edgeconnect")
 
 	ec, err := getEdgeConnect(obj)
 	if err != nil {
@@ -63,7 +63,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (_ a
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	ctx, _ = logd.NewFromContext(ctx, "edgeconnect-validation")
+	ctx, _ = logd.NewFromContext(ctx, "edgeconnect")
 
 	ec, err := getEdgeConnect(newObj)
 	if err != nil {

--- a/pkg/controllers/csi/provisioner/cleanup/run.go
+++ b/pkg/controllers/csi/provisioner/cleanup/run.go
@@ -37,7 +37,7 @@ func New(apiReader client.Reader, path metadata.PathResolver, mounter mount.Inte
 
 // Run will only execute the cleanup logic if enough time has passed from the previous run, to not overload the IO of the node
 func (c *Cleaner) Run(ctx context.Context) error {
-	ctx, _ = logd.NewFromContext(ctx, "csi-cleanup")
+	ctx, _ = logd.NewFromContext(ctx, "cleanup")
 
 	tickerResetFunc := checkTicker(ctx)
 	if tickerResetFunc == nil {
@@ -50,7 +50,7 @@ func (c *Cleaner) Run(ctx context.Context) error {
 
 // InstantRun will always execute the cleanup logic ignoring the time passed from previous run
 func (c *Cleaner) InstantRun(ctx context.Context) error {
-	ctx, _ = logd.NewFromContext(ctx, "csi-cleanup")
+	ctx, _ = logd.NewFromContext(ctx, "cleanup")
 
 	defer resetTickerAfterDelete(ctx)
 

--- a/pkg/controllers/csi/server/volumes/app/publisher.go
+++ b/pkg/controllers/csi/server/volumes/app/publisher.go
@@ -53,7 +53,7 @@ const (
 )
 
 func (pub *Publisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
-	ctx, log := logd.NewFromContext(ctx, "csi-appvolume")
+	ctx, log := logd.NewFromContext(ctx, "appvolume")
 
 	if !pub.isCodeModuleAvailable(ctx, volumeCfg) {
 		provisionerNotDoneErr := errors.Errorf("version or digest is not yet set, csi-provisioner hasn't finished setup yet for %s DynaKube", volumeCfg.DynakubeName)

--- a/pkg/controllers/csi/server/volumes/host/publisher.go
+++ b/pkg/controllers/csi/server/volumes/host/publisher.go
@@ -42,7 +42,7 @@ type Publisher struct {
 }
 
 func (pub *Publisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
-	ctx, _ = logd.NewFromContext(ctx, "csi-hostvolume")
+	ctx, _ = logd.NewFromContext(ctx, "hostvolume")
 
 	if err := pub.mountStorageVolume(ctx, volumeCfg); err != nil {
 		return nil, status.Error(codes.Internal, "failed to mount osagent volume: "+err.Error())

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -38,7 +38,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, agClient agclient.Client, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "activegate-authtoken")
+	ctx, _ = logd.NewFromContext(ctx, "authtoken")
 
 	if !dk.ActiveGate().IsEnabled() {
 		if meta.FindStatusCondition(*dk.Conditions(), ActiveGateAuthTokenSecretConditionType) == nil {

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -38,7 +38,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, agClient agclient.Client, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-activegate-authtoken")
+	ctx, _ = logd.NewFromContext(ctx, "activegate-authtoken")
 
 	if !dk.ActiveGate().IsEnabled() {
 		if meta.FindStatusCondition(*dk.Conditions(), ActiveGateAuthTokenSecretConditionType) == nil {

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
@@ -39,7 +39,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, customPropertiesOwnerName string, customPropertiesSource *value.Source) error {
-	ctx, log := logd.NewFromContext(ctx, "activegate-customproperties")
+	ctx, log := logd.NewFromContext(ctx, "customproperties")
 
 	if customPropertiesSource == nil && !dk.NeedsCustomNoProxy() {
 		if meta.FindStatusCondition(*dk.Conditions(), customPropertiesConditionType) == nil {

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/reconciler.go
@@ -37,7 +37,7 @@ func NewReconciler(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, agCapability capability.Capability) error {
-	ctx, log := logd.NewFromContext(ctx, "activegate-statefulset")
+	ctx, log := logd.NewFromContext(ctx, "statefulset")
 
 	err := r.manageStatefulSet(ctx, dk, agCapability)
 	if err != nil {

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
@@ -41,7 +41,7 @@ func NewReconciler(client client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "activegate-tls-secret")
+	ctx, _ = logd.NewFromContext(ctx, "tls-secret")
 
 	if dk.ActiveGate().IsEnabled() && dk.ActiveGate().IsAutomaticTLSSecretEnabled() && dk.ActiveGate().TLSSecretName == "" {
 		return r.reconcileSelfSignedTLSSecret(ctx, dk)

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
@@ -41,7 +41,7 @@ func NewReconciler(client client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-activegate-tls-secret")
+	ctx, _ = logd.NewFromContext(ctx, "activegate-tls-secret")
 
 	if dk.ActiveGate().IsEnabled() && dk.ActiveGate().IsAutomaticTLSSecretEnabled() && dk.ActiveGate().TLSSecretName == "" {
 		return r.reconcileSelfSignedTLSSecret(ctx, dk)

--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -95,7 +95,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, dtClient *dynatrace.Client, tokens token.Tokens) error {
-	ctx, log := logd.NewFromContext(ctx, "dynakube-activegate")
+	ctx, log := logd.NewFromContext(ctx, "activegate")
 	// If AG is not used or was not cleaned up due to being previously enabled
 	// Split the `if` for better logging.
 	if !dk.ActiveGate().IsEnabled() {

--- a/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/activegate/reconciler.go
@@ -34,7 +34,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, agClient agclient.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "activegate-connectioninfo")
+	ctx, log := logd.NewFromContext(ctx, "connectioninfo")
 
 	if !dk.ActiveGate().IsEnabled() {
 		if meta.FindStatusCondition(*dk.Conditions(), activeGateConnectionInfoConditionType) == nil {

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/reconciler.go
@@ -41,7 +41,7 @@ var (
 )
 
 func (r *Reconciler) Reconcile(ctx context.Context, oaClient oneagent.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "oneagent-connectioninfo")
+	ctx, log := logd.NewFromContext(ctx, "connectioninfo")
 
 	if !dk.OneAgent().IsAppInjectionNeeded() && !dk.OneAgent().IsDaemonsetRequired() && !dk.LogMonitoring().IsEnabled() {
 		if meta.FindStatusCondition(*dk.Conditions(), oaConnectionInfoConditionType) == nil {

--- a/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
+++ b/pkg/controllers/dynakube/deploymentmetadata/reconciler.go
@@ -25,7 +25,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader, clusterID string)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-deployment-metadata")
+	ctx, _ = logd.NewFromContext(ctx, "deployment-metadata")
 
 	configMapData := map[string]string{}
 

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -31,7 +31,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
-	ctx, log := logd.NewFromContext(ctx, "dynakube-pullsecret")
+	ctx, log := logd.NewFromContext(ctx, "pullsecret")
 
 	if tokens.HasPlatformToken() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {

--- a/pkg/controllers/dynakube/extension/databases/reconciler.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler.go
@@ -27,7 +27,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "extension-databases")
+	ctx, log := logd.NewFromContext(ctx, "databases")
 
 	log.Debug("reconciling deployments")
 

--- a/pkg/controllers/dynakube/extension/eec/reconciler.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler.go
@@ -28,7 +28,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, imageClient image.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "extension-eec")
+	ctx, log := logd.NewFromContext(ctx, "eec")
 
 	// TODO: Remove as part of ICP-1086
 	meta.RemoveStatusCondition(dk.Conditions(), "ExtensionsControllerStatefulSet")

--- a/pkg/controllers/dynakube/extension/tls/reconciler.go
+++ b/pkg/controllers/dynakube/extension/tls/reconciler.go
@@ -37,7 +37,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "extension-tls")
+	ctx, _ = logd.NewFromContext(ctx, "tls")
 
 	if ext := dk.Extensions(); ext.IsAnyEnabled() && ext.NeedsSelfSignedTLS() {
 		return r.reconcileSelfSignedTLSSecret(ctx, dk)

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -66,7 +66,7 @@ func NewReconciler(
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "dynakube-injection")
+	ctx, log := logd.NewFromContext(ctx, "injection")
 
 	err := r.reconcileSubReconcilers(ctx, dtClient, dk)
 	if err != nil {

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -43,7 +43,7 @@ func NewReconciler(kubeClient client.Client, apiReader client.Reader) *Reconcile
 	}
 }
 func (r *Reconciler) ReconcileAPIURL(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "dynakube-istio")
+	ctx, log := logd.NewFromContext(ctx, "istio")
 
 	log.Info("reconciling istio components for the Dynatrace API url")
 

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -34,7 +34,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "kspm-daemonset")
+	ctx, log := logd.NewFromContext(ctx, "daemonset")
 
 	if !dk.KSPM().IsEnabled() {
 		if meta.FindStatusCondition(*dk.Conditions(), conditionType) == nil {

--- a/pkg/controllers/dynakube/kspm/kspmsettings/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/kspmsettings/reconciler.go
@@ -28,7 +28,7 @@ func NewReconciler() *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dtClient dtsettings.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "kspm-settings")
+	ctx, log := logd.NewFromContext(ctx, "settings")
 	// Kubernetes Monitoring is REQUIRED for KSPM, so it is ok to just check for this.
 	if !dk.ActiveGate().IsKubernetesMonitoringEnabled() {
 		_ = meta.RemoveStatusCondition(dk.Conditions(), conditionType)

--- a/pkg/controllers/dynakube/kspm/token/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/token/reconciler.go
@@ -30,7 +30,7 @@ func NewReconciler(client client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "kspm-token-secret")
+	ctx, _ = logd.NewFromContext(ctx, "token-secret")
 
 	if dk.KSPM().IsEnabled() {
 		return r.ensureKSPMSecret(ctx, dk)

--- a/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/configsecret/reconciler.go
@@ -53,7 +53,7 @@ func NewReconciler(clt client.Client,
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "logmonitoring-config-secret")
+	ctx, log := logd.NewFromContext(ctx, "config-secret")
 
 	if !dk.LogMonitoring().IsStandalone() {
 		if meta.FindStatusCondition(*dk.Conditions(), LmcConditionType) == nil {

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/reconciler.go
@@ -38,7 +38,7 @@ func NewReconciler(clt client.Client,
 var KubernetesSettingsNotAvailableError = errors.New("the status of the DynaKube is missing information about the kubernetes monitored-entity, skipping LogMonitoring deployment until it is ready")
 
 func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "logmonitoring-daemonset")
+	ctx, log := logd.NewFromContext(ctx, "daemonset")
 
 	if !dk.LogMonitoring().IsStandalone() {
 		if meta.FindStatusCondition(*dk.Conditions(), ConditionType) == nil {

--- a/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/logmonsettings/reconciler.go
@@ -29,7 +29,7 @@ func NewReconciler() *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dtClient settings.Client, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "logmonitoring-settings")
+	ctx, log := logd.NewFromContext(ctx, "settings")
 
 	if !dk.LogMonitoring().IsEnabled() {
 		_ = meta.RemoveStatusCondition(dk.Conditions(), ConditionType)

--- a/pkg/controllers/dynakube/logmonitoring/reconciler.go
+++ b/pkg/controllers/dynakube/logmonitoring/reconciler.go
@@ -55,7 +55,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-logmonitoring")
+	ctx, _ = logd.NewFromContext(ctx, "logmonitoring")
 
 	err := r.oneAgentConnectionInfoReconciler.Reconcile(ctx, dtClient.OneAgent, dk)
 	if err != nil {

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -160,7 +160,7 @@ func (classic *classicFullStack) BuildDaemonSet(ctx context.Context) (*appsv1.Da
 }
 
 func (b *builder) BuildDaemonSet(ctx context.Context) (*appsv1.DaemonSet, error) {
-	ctx, _ = logd.NewFromContext(ctx, "oneagent-daemonset")
+	ctx, _ = logd.NewFromContext(ctx, "daemonset")
 	dk := b.dk
 
 	podSpec, err := b.podSpec(ctx)

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -90,7 +90,7 @@ type Reconciler struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, dtClient *dynatrace.Client, tokens token.Tokens) error {
-	ctx, log := logd.NewFromContext(ctx, "dynakube-oneagent")
+	ctx, log := logd.NewFromContext(ctx, "oneagent")
 	log.Info("reconciling OneAgent")
 
 	err := r.versionReconciler.ReconcileOneAgent(ctx, dk, dtClient.Images, dtClient.Version)

--- a/pkg/controllers/dynakube/otelc/configuration/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/configuration/reconciler.go
@@ -31,7 +31,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "otelc-config")
+	ctx, log := logd.NewFromContext(ctx, "config")
 
 	if !dk.TelemetryIngest().IsEnabled() {
 		if meta.FindStatusCondition(*dk.Conditions(), conditionType) == nil {

--- a/pkg/controllers/dynakube/otelc/service/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/service/reconciler.go
@@ -49,7 +49,7 @@ func NewReconciler(client client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "otelc-service")
+	ctx, _ = logd.NewFromContext(ctx, "service")
 	if !dk.TelemetryIngest().IsEnabled() {
 		r.removeServiceOnce(ctx, dk)
 

--- a/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/reconciler.go
@@ -48,7 +48,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, log := logd.NewFromContext(ctx, "otelc-statefulset")
+	ctx, log := logd.NewFromContext(ctx, "statefulset")
 	if dk.Extensions().IsPrometheusEnabled() || dk.TelemetryIngest().IsEnabled() {
 		return r.createOrUpdateStatefulset(ctx, dk)
 	} else { // do cleanup or

--- a/pkg/controllers/dynakube/proxy/reconciler.go
+++ b/pkg/controllers/dynakube/proxy/reconciler.go
@@ -24,7 +24,7 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-proxy")
+	ctx, _ = logd.NewFromContext(ctx, "proxy")
 	if dk.NeedsActiveGateProxy() || dk.NeedsOneAgentProxy() {
 		return r.generateForDynakube(ctx, dk)
 	}

--- a/pkg/controllers/dynakube/version/reconciler.go
+++ b/pkg/controllers/dynakube/version/reconciler.go
@@ -26,7 +26,7 @@ func NewReconciler(apiReader client.Reader, timeProvider *timeprovider.Provider)
 }
 
 func (r *Reconciler) ReconcileCodeModules(ctx context.Context, dk *dynakube.DynaKube, imageClient image.Client, versionClient version.Client) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-version")
+	ctx, _ = logd.NewFromContext(ctx, "version")
 
 	updater := newCodeModulesUpdater(dk, imageClient, versionClient)
 	if r.needsUpdate(ctx, updater, dk) {
@@ -37,7 +37,7 @@ func (r *Reconciler) ReconcileCodeModules(ctx context.Context, dk *dynakube.Dyna
 }
 
 func (r *Reconciler) ReconcileOneAgent(ctx context.Context, dk *dynakube.DynaKube, imageClient image.Client, versionClient version.Client) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-version")
+	ctx, _ = logd.NewFromContext(ctx, "version")
 
 	updater := newOneAgentUpdater(dk, r.apiReader, imageClient, versionClient)
 	if r.needsUpdate(ctx, updater, dk) {
@@ -48,7 +48,7 @@ func (r *Reconciler) ReconcileOneAgent(ctx context.Context, dk *dynakube.DynaKub
 }
 
 func (r *Reconciler) ReconcileActiveGate(ctx context.Context, dk *dynakube.DynaKube, imageClient image.Client, versionClient version.Client) error {
-	ctx, _ = logd.NewFromContext(ctx, "dynakube-version")
+	ctx, _ = logd.NewFromContext(ctx, "version")
 
 	updater := newActiveGateUpdater(dk, r.apiReader, imageClient, versionClient)
 	if r.needsUpdate(ctx, updater, dk) {

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -22,7 +22,7 @@ const (
 )
 
 func New(ctx context.Context, ec *edgeconnect.EdgeConnect) *appsv1.Deployment {
-	ctx, _ = logd.NewFromContext(ctx, "edgeconnect-deployment")
+	ctx, _ = logd.NewFromContext(ctx, "deployment")
 
 	return create(ctx, ec)
 }

--- a/pkg/controllers/edgeconnect/secret/secret.go
+++ b/pkg/controllers/edgeconnect/secret/secret.go
@@ -12,7 +12,7 @@ import (
 )
 
 func PrepareConfigFile(ctx context.Context, ec *edgeconnect.EdgeConnect, apiReader client.Reader, token string) ([]byte, error) {
-	_, log := logd.NewFromContext(ctx, "edgeconnect-secret")
+	_, log := logd.NewFromContext(ctx, "secret")
 
 	cfg := config.EdgeConnect{
 		Name:            ec.Name,

--- a/pkg/controllers/edgeconnect/version/reconciler.go
+++ b/pkg/controllers/edgeconnect/version/reconciler.go
@@ -28,7 +28,7 @@ func NewReconciler(apiReader client.Reader, registryClient registry.ImageGetter,
 }
 
 func (reconciler *Reconciler) Reconcile(ctx context.Context) error {
-	ctx, log := logd.NewFromContext(ctx, "edgeconnect-version")
+	ctx, log := logd.NewFromContext(ctx, "version")
 
 	updaters := []versionStatusUpdater{
 		newUpdater(reconciler.apiReader, reconciler.timeProvider, reconciler.registryClient, reconciler.edgeConnect),

--- a/pkg/injection/codemodule/installer/image/installer.go
+++ b/pkg/injection/codemodule/installer/image/installer.go
@@ -57,7 +57,7 @@ type Installer struct {
 }
 
 func (installer *Installer) InstallAgent(ctx context.Context, targetDir string) (bool, error) {
-	ctx, log := logd.NewFromContext(ctx, "oneagent-image")
+	ctx, log := logd.NewFromContext(ctx, "image")
 	log.Info("installing agent from image")
 
 	if installer.isAlreadyPresent(targetDir) {

--- a/pkg/injection/codemodule/installer/job/helmconfig/job.go
+++ b/pkg/injection/codemodule/installer/job/helmconfig/job.go
@@ -85,7 +85,7 @@ type Config struct {
 
 func Get(ctx context.Context) Config {
 	once.Do(func() {
-		_, log := logd.NewFromContext(ctx, "csi-job")
+		_, log := logd.NewFromContext(ctx, "helmconfig")
 
 		confJSON := os.Getenv(JSONEnv)
 		if confJSON == "" {

--- a/pkg/injection/codemodule/installer/job/installer.go
+++ b/pkg/injection/codemodule/installer/job/installer.go
@@ -44,7 +44,7 @@ type Installer struct {
 }
 
 func (inst *Installer) InstallAgent(ctx context.Context, targetDir string) (bool, error) {
-	ctx, log := logd.NewFromContext(ctx, "oneagent-job")
+	ctx, log := logd.NewFromContext(ctx, "job")
 	log.Info("installing agent via Job", "image", inst.props.ImageURI, "target dir", targetDir)
 
 	err := os.MkdirAll(inst.props.PathResolver.AgentSharedBinaryDirBase(), common.MkDirFileMode)

--- a/pkg/injection/codemodule/installer/symlink/symlink.go
+++ b/pkg/injection/codemodule/installer/symlink/symlink.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CreateForCurrentVersionIfNotExists(ctx context.Context, targetDir string) error {
-	ctx, log := logd.NewFromContext(ctx, "oneagent-symlink")
+	ctx, log := logd.NewFromContext(ctx, "symlink")
 
 	var err error
 
@@ -28,7 +28,7 @@ func CreateForCurrentVersionIfNotExists(ctx context.Context, targetDir string) e
 }
 
 func Create(ctx context.Context, targetDir, symlinkDir string) error {
-	ctx, _ = logd.NewFromContext(ctx, "oneagent-symlink")
+	ctx, _ = logd.NewFromContext(ctx, "symlink")
 
 	return create(ctx, targetDir, symlinkDir)
 }
@@ -55,7 +55,7 @@ func create(ctx context.Context, targetDir, symlinkDir string) error {
 }
 
 func Remove(ctx context.Context, symlinkPath string) error {
-	_, log := logd.NewFromContext(ctx, "oneagent-symlink")
+	_, log := logd.NewFromContext(ctx, "symlink")
 
 	if err := os.Remove(symlinkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Info("failed to remove symlink", "path", symlinkPath)

--- a/pkg/injection/codemodule/installer/zip/zip.go
+++ b/pkg/injection/codemodule/installer/zip/zip.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (extractor OneAgentExtractor) ExtractZip(ctx context.Context, sourceFile *os.File, targetDir string) error {
-	ctx, log := logd.NewFromContext(ctx, "oneagent-zip")
+	ctx, log := logd.NewFromContext(ctx, "zip")
 
 	extractor.cleanTempZipDir()
 

--- a/pkg/util/oci/dockerkeychain/docker_keychain.go
+++ b/pkg/util/oci/dockerkeychain/docker_keychain.go
@@ -23,7 +23,7 @@ type DockerKeychain struct {
 }
 
 func NewDockerKeychains(ctx context.Context, apiReader client.Reader, namespaceName string, pullSecretNames []string) (authn.Keychain, error) {
-	ctx, log := logd.NewFromContext(ctx, "docker-keychain")
+	ctx, log := logd.NewFromContext(ctx, "oci-keychain")
 	keychain := &DockerKeychain{}
 
 	if len(pullSecretNames) == 0 {
@@ -67,7 +67,7 @@ func NewDockerKeychains(ctx context.Context, apiReader client.Reader, namespaceN
 }
 
 func NewDockerKeychain(ctx context.Context, apiReader client.Reader, pullSecret corev1.Secret) (authn.Keychain, error) {
-	ctx, log := logd.NewFromContext(ctx, "oci-dockerkeychain")
+	ctx, log := logd.NewFromContext(ctx, "oci-keychain")
 	keychain := &DockerKeychain{}
 
 	if pullSecret.Name == "" {

--- a/pkg/webhook/mutation/pod/handler/injection/handle.go
+++ b/pkg/webhook/mutation/pod/handler/injection/handle.go
@@ -49,7 +49,7 @@ func New( //nolint:revive
 }
 
 func (h *Handler) Handle(mutationRequest *dtwebhook.MutationRequest) error {
-	ctx, log := logd.NewFromContext(mutationRequest.Context, "pod-mutation-injection")
+	ctx, log := logd.NewFromContext(mutationRequest.Context, "injection")
 	mutationRequest.Context = ctx
 
 	if !mutationRequest.DynaKube.OneAgent().IsAppInjectionNeeded() && !mutationRequest.DynaKube.MetadataEnrichment().IsEnabled() {

--- a/pkg/webhook/mutation/pod/handler/otlp/handle.go
+++ b/pkg/webhook/mutation/pod/handler/otlp/handle.go
@@ -36,7 +36,7 @@ func New(
 }
 
 func (h *Handler) Handle(mutationRequest *dtwebhook.MutationRequest) error {
-	ctx, log := logd.NewFromContext(mutationRequest.Context, "pod-mutation-otlp")
+	ctx, log := logd.NewFromContext(mutationRequest.Context, "otlp")
 	mutationRequest.Context = ctx
 
 	if !mutationRequest.DynaKube.OTLPExporterConfiguration().IsEnabled() {

--- a/pkg/webhook/mutation/pod/mutator/metadata/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/metadata/mutator.go
@@ -65,7 +65,7 @@ func initResources(dk dynakube.DynaKube) corev1.ResourceRequirements {
 }
 
 func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
-	_, log := logd.NewFromContext(request.Context, "metadata-enrichment-pod-common")
+	_, log := logd.NewFromContext(request.Context, "metadata-enrichment")
 	log.Info("adding metadata-enrichment to pod", "name", request.PodName())
 
 	request.InstallContainer.Resources = initResources(request.DynaKube)

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
@@ -95,7 +95,7 @@ func validateInstallPath(installPath string) error {
 }
 
 func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
-	_, log := logd.NewFromContext(request.Context, "oneagent-mutation")
+	_, log := logd.NewFromContext(request.Context, "oneagent")
 	installPath := maputils.GetField(request.Pod.Annotations, AnnotationInstallPath, DefaultInstallPath)
 
 	if err := validateInstallPath(installPath); err != nil {
@@ -116,7 +116,7 @@ func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
 }
 
 func (mut *Mutator) Reinvoke(ctx context.Context, request *dtwebhook.ReinvocationRequest) bool {
-	_, log := logd.NewFromContext(ctx, "oneagent-mutation")
+	_, log := logd.NewFromContext(ctx, "oneagent")
 
 	installPath := maputils.GetField(request.Pod.Annotations, AnnotationInstallPath, DefaultInstallPath)
 	if err := validateInstallPath(installPath); err != nil {

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
@@ -95,7 +95,7 @@ func validateInstallPath(installPath string) error {
 }
 
 func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
-	_, log := logd.NewFromContext(request.Context, "oa-mutation")
+	_, log := logd.NewFromContext(request.Context, "oneagent-mutation")
 	installPath := maputils.GetField(request.Pod.Annotations, AnnotationInstallPath, DefaultInstallPath)
 
 	if err := validateInstallPath(installPath); err != nil {
@@ -116,7 +116,7 @@ func (mut *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
 }
 
 func (mut *Mutator) Reinvoke(ctx context.Context, request *dtwebhook.ReinvocationRequest) bool {
-	_, log := logd.NewFromContext(ctx, "oa-mutation")
+	_, log := logd.NewFromContext(ctx, "oneagent-mutation")
 
 	installPath := maputils.GetField(request.Pod.Annotations, AnnotationInstallPath, DefaultInstallPath)
 	if err := validateInstallPath(installPath); err != nil {

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator.go
@@ -31,7 +31,7 @@ func New() dtwebhook.Mutator {
 }
 
 func (m Mutator) IsEnabled(ctx context.Context, request *dtwebhook.BaseRequest) bool {
-	_, log := logd.NewFromContext(ctx, "otlp-exporter-pod-mutation")
+	_, log := logd.NewFromContext(ctx, "exporter")
 	otlpExporterConfiguration := request.DynaKube.OTLPExporterConfiguration()
 
 	if !otlpExporterConfiguration.IsEnabled() {
@@ -58,21 +58,21 @@ func (m Mutator) IsEnabled(ctx context.Context, request *dtwebhook.BaseRequest) 
 }
 
 func (m Mutator) IsInjected(ctx context.Context, request *dtwebhook.BaseRequest) bool {
-	_, log := logd.NewFromContext(ctx, "otlp-exporter-pod-mutation")
+	_, log := logd.NewFromContext(ctx, "exporter")
 	log.Debug("checking if OTLP env vars have already been injected")
 
 	return maputils.GetFieldBool(request.Pod.Annotations, dtwebhook.AnnotationOTLPInjected, false)
 }
 
 func (m Mutator) Mutate(request *dtwebhook.MutationRequest) error {
-	_, log := logd.NewFromContext(request.Context, "otlp-exporter-pod-mutation")
+	_, log := logd.NewFromContext(request.Context, "exporter")
 	_, err := m.mutate(request.BaseRequest, log)
 
 	return err
 }
 
 func (m Mutator) Reinvoke(ctx context.Context, request *dtwebhook.ReinvocationRequest) bool {
-	_, log := logd.NewFromContext(ctx, "otlp-exporter-pod-mutation")
+	_, log := logd.NewFromContext(ctx, "exporter")
 	log.Info("reinvocation of OTLP env vars mutator")
 
 	mutated, err := m.mutate(request.BaseRequest, log)

--- a/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/resourceattributes/mutator.go
@@ -38,7 +38,7 @@ func (Mutator) IsInjected(_ context.Context, _ *dtwebhook.BaseRequest) bool {
 }
 
 func (m *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
-	ctx, _ := logd.NewFromContext(request.Context, "otlp-exporter-pod-mutation", "podName", request.PodName(), "namespace", request.Namespace.Name)
+	ctx, _ := logd.NewFromContext(request.Context, "resource-attributes", "podName", request.PodName(), "namespace", request.Namespace.Name)
 
 	_, err := m.mutate(ctx, request.BaseRequest)
 
@@ -46,7 +46,7 @@ func (m *Mutator) Mutate(request *dtwebhook.MutationRequest) error {
 }
 
 func (m *Mutator) Reinvoke(ctx context.Context, request *dtwebhook.ReinvocationRequest) bool {
-	ctx, log := logd.NewFromContext(ctx, "otlp-exporter-pod-mutation", "podName", request.PodName(), "namespace", request.Namespace.Name)
+	ctx, log := logd.NewFromContext(ctx, "resource-attributes", "podName", request.PodName(), "namespace", request.Namespace.Name)
 	log.Debug("reinvocation of OTLP resource attribute mutator")
 
 	mutated, _ := m.mutate(ctx, request.BaseRequest)

--- a/pkg/webhook/mutation/pod/volumes/volumes.go
+++ b/pkg/webhook/mutation/pod/volumes/volumes.go
@@ -37,7 +37,7 @@ func AddConfigVolume(ctx context.Context, pod *corev1.Pod) {
 	if r, ok := pod.Annotations[AnnotationConfigVolumeNameResource]; ok && r != "" {
 		sizeLimit, err := resource.ParseQuantity(r)
 		if err != nil {
-			_, log := logd.NewFromContext(ctx, "volumes-mutation")
+			_, log := logd.NewFromContext(ctx, "volumes")
 			log.Error(err, "failed to parse quantity from annotation "+AnnotationConfigVolumeNameResource, "value", r)
 		} else {
 			emptyDirVS = corev1.EmptyDirVolumeSource{


### PR DESCRIPTION
## Description

Removing redundant dynakube logger names since parent logger context already provides dynakube scope. Getting rid of unwanted duplication.
[ICP-4695](https://dt-rnd.atlassian.net/browse/ICP-4695)

## How can this be tested?

- Deploy operator
- Deploy any Dynakube
- Cosmetic change is visible in logs.

[ICP-4695]: https://dt-rnd.atlassian.net/browse/ICP-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ