### PR TITLE
e2e: Add ocp 4.22 to slack message, update script to render platform token

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -75,6 +75,8 @@ jobs:
             token: platform
           - version: 4-22
             platform: ocp
+          # when you update this matrix, please also update the slack payload in hack/slack/slack-e2e-ondemand-payload.json
+          # `python3 hack/slack/update_e2e_ondemand.py > hack/slack/slack-e2e-ondemand-payload.json`
     environment: E2E
     runs-on:
       - operator-e2e

--- a/hack/slack/slack-e2e-ondemand-payload.json
+++ b/hack/slack/slack-e2e-ondemand-payload.json
@@ -675,6 +675,69 @@
               }
             ]
           }
+        ],
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "n/a"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "n/a"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "ocp_4-22"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "link",
+                    "url": "${{ env.OCP_4_22_RUN_ID_URL }}",
+                    "text": "tests "
+                  },
+                  {
+                    "type": "emoji",
+                    "name": "${{ env.OCP_4_22_EMOJI }}"
+                  }
+                ]
+              }
+            ]
+          }
         ]
       ]
     },

--- a/hack/slack/update_e2e_ondemand.py
+++ b/hack/slack/update_e2e_ondemand.py
@@ -106,6 +106,15 @@ table_section = {"type": "table", "rows": []}
 rows = [table_header]
 
 
+def format_platform_version(platform_version):
+    for item in matrix:
+        token = item.get("token")
+        pv = f"{item['platform']}_{item['version']}"
+        if pv == platform_version and token:
+            return f"{platform_version} ({token} token)"
+    return platform_version
+
+
 # In case we have different number of supported k8s and ocp environments
 for k8s_env, ocp_env in zip_longest(supported_k8s, supported_ocps):
     k8s_env = k8s_env or "n/a"
@@ -149,7 +158,7 @@ for k8s_env, ocp_env in zip_longest(supported_k8s, supported_ocps):
             "elements": [
                 {
                     "type": "rich_text_section",
-                    "elements": [{"type": "text", "text": k8s_env}],
+                    "elements": [{"type": "text", "text": format_platform_version(k8s_env)}],
                 }
             ],
         },
@@ -167,7 +176,7 @@ for k8s_env, ocp_env in zip_longest(supported_k8s, supported_ocps):
             "elements": [
                 {
                     "type": "rich_text_section",
-                    "elements": [{"type": "text", "text": ocp_env}],
+                    "elements": [{"type": "text", "text": format_platform_version(ocp_env)}],
                 }
             ],
         },


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

`python3 hack/slack/update_e2e_ondemand.py > hack/slack/slack-e2e-ondemand-payload.json`