### PR TITLE
Fix enrichment rules with conditions

### DIFF
--- a/pkg/clients/dynatrace/settings/enchrichment.go
+++ b/pkg/clients/dynatrace/settings/enchrichment.go
@@ -40,6 +40,7 @@ type ingestEnrichmentConfig struct {
 	Type        metadataenrichment.RuleType `json:"type"`
 	Target      string                      `json:"target"`
 	ValueSource string                      `json:"valueSource"`
+	Condition   string                      `json:"condition"`
 }
 
 // GetRules returns metadata enrichment rules.
@@ -129,6 +130,11 @@ func getRulesFromResponse(resp getRulesResponse) []metadataenrichment.Rule {
 	// The legacy schema put all rules into a single item's value.
 	for _, item := range resp.Items {
 		if cfg := item.Value.ingestEnrichmentConfig; metadataenrichment.IsSupportedType(cfg.Type) {
+			if cfg.Condition != "" {
+				// Skip rules with conditions for now
+				continue
+			}
+
 			rule := metadataenrichment.Rule{
 				Type:   cfg.Type,
 				Target: cfg.Target,

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -52,6 +52,7 @@ func TestGetRulesSetting(t *testing.T) {
 			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceLabelRule, ValueSource: "source-1", Target: "target-1"}}},
 			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.K8sNamespaceAnnotationRule, ValueSource: "source-2", Target: "target-2"}}},
 			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: "FOO", ValueSource: "source-3", Target: "target-3"}}},
+			{Value: ruleItemValue{ingestEnrichmentConfig: ingestEnrichmentConfig{Type: metadataenrichment.CustomRule, ValueSource: "source-4", Target: "target-4", Condition: "true"}}},
 		},
 	}
 


### PR DESCRIPTION
## Description

This was overlooked during #6678. Rules in the new schema can have conditions. For the time being rules that define a condition should not be used by the operator.

ICP-6623

## How can this be tested?

* Create a custom rule with a condition
* Deploy a DynaKube with metadata enrichment enabled
* Check the rule does not show up in the status
