### PR TITLE
fix EdgeConnect imageRef.digest having no effect on image selected

### DIFF
--- a/pkg/api/v1alpha2/edgeconnect/edgeconnect_types_test.go
+++ b/pkg/api/v1alpha2/edgeconnect/edgeconnect_types_test.go
@@ -3,9 +3,33 @@ package edgeconnect
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestImage(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		ec := EdgeConnect{}
+		require.Equal(t, defaultEdgeConnectRepository+":"+api.LatestTag, ec.Image())
+	})
+
+	t.Run("custom repository and tag", func(t *testing.T) {
+		ec := EdgeConnect{Spec: EdgeConnectSpec{ImageRef: image.Ref{Repository: "my.registry/edgeconnect", Tag: "1.2.3"}}}
+		require.Equal(t, "my.registry/edgeconnect:1.2.3", ec.Image())
+	})
+
+	t.Run("digest takes precedence over tag", func(t *testing.T) {
+		ec := EdgeConnect{Spec: EdgeConnectSpec{ImageRef: image.Ref{Repository: "my.registry/edgeconnect", Tag: "1.2.3", Digest: "sha256:abc123"}}}
+		require.Equal(t, "my.registry/edgeconnect@sha256:abc123", ec.Image())
+	})
+
+	t.Run("digest with default repository", func(t *testing.T) {
+		ec := EdgeConnect{Spec: EdgeConnectSpec{ImageRef: image.Ref{Digest: "sha256:abc123"}}}
+		require.Equal(t, defaultEdgeConnectRepository+"@sha256:abc123", ec.Image())
+	})
+}
 
 func TestHostMappings(t *testing.T) {
 	t.Run("Get HostMappings", func(t *testing.T) {

--- a/pkg/api/v1alpha2/edgeconnect/properties.go
+++ b/pkg/api/v1alpha2/edgeconnect/properties.go
@@ -1,7 +1,6 @@
 package edgeconnect
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
@@ -18,18 +17,7 @@ const (
 )
 
 func (ec *EdgeConnect) Image() string {
-	repository := defaultEdgeConnectRepository
-	tag := api.LatestTag
-
-	if ec.Spec.ImageRef.Repository != "" {
-		repository = ec.Spec.ImageRef.Repository
-	}
-
-	if ec.Spec.ImageRef.Tag != "" {
-		tag = ec.Spec.ImageRef.Tag
-	}
-
-	return fmt.Sprintf("%s:%s", repository, tag)
+	return ec.Spec.ImageRef.StringWithDefaults(defaultEdgeConnectRepository, api.LatestTag)
 }
 
 func (ec *EdgeConnect) IsCustomImage() bool {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-6629](https://dt-rnd.atlassian.net/browse/ICP-6629)

Follow-up to #6681.

`EdgeConnect.Image()` only ever built `repository:tag` and never read `imageRef.digest`, so the field had no effect.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

`make go/test`

Unit tests added for all four cases: defaults, custom repo+tag, digest overriding tag, digest with default repository.

[ICP-6629]: https://dt-rnd.atlassian.net/browse/ICP-6629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ