### PR TITLE
Bump dynatrace-bootstrapper to v1.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Dynatrace/dynatrace-operator
 go 1.26.0
 
 require (
-	github.com/Dynatrace/dynatrace-bootstrapper v1.4.2
+	github.com/Dynatrace/dynatrace-bootstrapper v1.4.3
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/docker/cli v29.5.3+incompatible
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Dynatrace/dynatrace-bootstrapper v1.4.2 h1:LCckK0/SRsitPwt5lDaJsqxXr/PBPqM/huOqS9X7c1Q=
-github.com/Dynatrace/dynatrace-bootstrapper v1.4.2/go.mod h1:Ko38p3DlZ8RpDRlRs0jYKEd5tKaWl3hBRkEKmZZ8zIs=
+github.com/Dynatrace/dynatrace-bootstrapper v1.4.3 h1:k17pK70Ko4Ra+vI/2R4yj8UGcWqCcL1ImLaym2B+HGw=
+github.com/Dynatrace/dynatrace-bootstrapper v1.4.3/go.mod h1:zo0sNiv72TldWzem79AcKJ7hzvtUtNQFsmjNqtf78Bo=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-6460

Bumps the bootstrapper version to 1.4.3 to fix the linked bug. 

## How can this be tested?

Similar to  https://github.com/Dynatrace/dynatrace-bootstrapper/pull/187
- but use the CSI driver or no codemodules image