### PR TITLE
Sanitize OneAgent and Logmon args

### DIFF
--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 const (
@@ -113,7 +114,7 @@ func isNodeImagePullWithoutCSI(_ context.Context, v *Validator, dk *dynakube.Dyn
 }
 
 func invalidNoProxy(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if strings.ContainsFunc(dk.FF().GetNoProxy(), isWhiteSpaceCharacter) {
+	if strings.ContainsAny(dk.FF().GetNoProxy(), sanitize.InvalidCommandLineCharset) {
 		return errorInvalidNoProxy
 	}
 

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -14,6 +14,7 @@ const (
 	warningFeatureFlagDeprecated   = `Using deprecated feature flags: `
 	warningFeatureFlagUnknown      = `Using unknown feature flags: %s. Please remove them from Dynakube specification.`
 	warningNodeImagePullWithoutCSI = "The `" + exp.OANodeImagePullKey + "` annotation is set, but the CSI driver is not available on this cluster. This feature flag only affects the behavior of the CSI driver, so it will have no effect. Other previous `node-image-pull` related behavior has been defaulted."
+	errorInvalidNoProxy            = "The DynaKube's specification has an invalid value set using the " + exp.NoProxyKey + " annotation. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the value in your custom resource."
 )
 
 var deprecatedFeatureFlags = []string{
@@ -106,6 +107,14 @@ func unknownFeatureFlag(_ context.Context, _ *Validator, dk *dynakube.DynaKube) 
 func isNodeImagePullWithoutCSI(_ context.Context, v *Validator, dk *dynakube.DynaKube) string {
 	if !dk.OneAgent().IsCSIAvailable() && dk.FF().IsSet(exp.OANodeImagePullKey) {
 		return warningNodeImagePullWithoutCSI
+	}
+
+	return ""
+}
+
+func invalidNoProxy(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if strings.ContainsFunc(dk.FF().GetNoProxy(), isWhiteSpaceCharacter) {
+		return errorInvalidNoProxy
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -206,3 +206,23 @@ func TestIsNodeImagePullWithoutCSI(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidNoProxy(t *testing.T) {
+	invalidChars := []rune{
+		'\n',
+		'\t',
+		'\r',
+		'\x00',
+	}
+
+	for _, c := range invalidChars {
+		t.Run(fmt.Sprintf("reject %c", c), func(t *testing.T) {
+			dk := &dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{Name: "dynakube", Annotations: map[string]string{exp.NoProxyKey: "foo" + string(c) + "bar"}},
+				Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL},
+			}
+
+			assertDenied(t, []string{errorInvalidNoProxy}, dk)
+		})
+	}
+}

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -208,21 +208,10 @@ func TestIsNodeImagePullWithoutCSI(t *testing.T) {
 }
 
 func TestInvalidNoProxy(t *testing.T) {
-	invalidChars := []rune{
-		'\n',
-		'\t',
-		'\r',
-		'\x00',
+	dk := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{Name: "dynakube", Annotations: map[string]string{exp.NoProxyKey: "foo\nbar"}},
+		Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL},
 	}
 
-	for _, c := range invalidChars {
-		t.Run(fmt.Sprintf("reject %c", c), func(t *testing.T) {
-			dk := &dynakube.DynaKube{
-				ObjectMeta: metav1.ObjectMeta{Name: "dynakube", Annotations: map[string]string{exp.NoProxyKey: "foo" + string(c) + "bar"}},
-				Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL},
-			}
-
-			assertDenied(t, []string{errorInvalidNoProxy}, dk)
-		})
-	}
+	assertDenied(t, []string{errorInvalidNoProxy}, dk)
 }

--- a/pkg/api/validation/dynakube/featureflag_test.go
+++ b/pkg/api/validation/dynakube/featureflag_test.go
@@ -209,9 +209,11 @@ func TestIsNodeImagePullWithoutCSI(t *testing.T) {
 
 func TestInvalidNoProxy(t *testing.T) {
 	dk := &dynakube.DynaKube{
-		ObjectMeta: metav1.ObjectMeta{Name: "dynakube", Annotations: map[string]string{exp.NoProxyKey: "foo\nbar"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "dynakube", Annotations: map[string]string{}},
 		Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL},
 	}
 
-	assertDenied(t, []string{errorInvalidNoProxy}, dk)
+	assertSanitizeArg(t, dk, func(dk *dynakube.DynaKube, value string) {
+		dk.Annotations[exp.NoProxyKey] = value
+	}, errorInvalidNoProxy)
 }

--- a/pkg/api/validation/dynakube/hostgroup.go
+++ b/pkg/api/validation/dynakube/hostgroup.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 const (
@@ -13,11 +14,11 @@ const (
 )
 
 func invalidOneAgentHostGroup(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if strings.ContainsFunc(dk.OneAgent().HostGroup, isWhiteSpaceCharacter) {
+	if strings.ContainsAny(dk.OneAgent().HostGroup, sanitize.InvalidCommandLineCharset) {
 		return errorInvalidHostGroupProperty
 	}
 
-	if strings.ContainsFunc(dk.OneAgent().GetHostGroupAsParam(), isWhiteSpaceCharacter) {
+	if strings.ContainsAny(dk.OneAgent().GetHostGroupAsParam(), sanitize.InvalidCommandLineCharset) {
 		return errorInvalidHostGroupAsParam
 	}
 

--- a/pkg/api/validation/dynakube/hostgroup.go
+++ b/pkg/api/validation/dynakube/hostgroup.go
@@ -18,9 +18,5 @@ func invalidOneAgentHostGroup(_ context.Context, _ *Validator, dk *dynakube.Dyna
 		return errorInvalidHostGroupProperty
 	}
 
-	if strings.ContainsAny(dk.OneAgent().GetHostGroupAsParam(), sanitize.InvalidCommandLineCharset) {
-		return errorInvalidHostGroupAsParam
-	}
-
 	return ""
 }

--- a/pkg/api/validation/dynakube/hostgroup_test.go
+++ b/pkg/api/validation/dynakube/hostgroup_test.go
@@ -24,102 +24,17 @@ func TestInvalidOneAgentHostGroup(t *testing.T) {
 		})
 	})
 
-	t.Run("host group property with newline is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
+	t.Run("host group with invalid characters is denied", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
 			Spec: dynakube.DynaKubeSpec{
 				APIURL:   testAPIURL,
-				OneAgent: oneagent.Spec{HostGroup: "host\ngroup"},
+				OneAgent: oneagent.Spec{},
 			},
-		})
-	})
+		}
 
-	t.Run("host group property with tab is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL:   testAPIURL,
-				OneAgent: oneagent.Spec{HostGroup: "host\tgroup"},
-			},
-		})
-	})
-
-	t.Run("host group property with carriage return is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL:   testAPIURL,
-				OneAgent: oneagent.Spec{HostGroup: "host\rgroup"},
-			},
-		})
-	})
-
-	t.Run("host group property with null byte is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupProperty}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL:   testAPIURL,
-				OneAgent: oneagent.Spec{HostGroup: "host\x00group"},
-			},
-		})
-	})
-
-	t.Run("valid --set-host-group arg is allowed", func(t *testing.T) {
-		assertAllowed(t, &dynakube.DynaKube{
-			Spec: dynakube.DynaKubeSpec{
-				APIURL: testAPIURL,
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host-group"}},
-				},
-			},
-		})
-	})
-
-	t.Run("--set-host-group arg with newline is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL: testAPIURL,
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\ngroup"}},
-				},
-			},
-		})
-	})
-
-	t.Run("--set-host-group arg with tab is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL: testAPIURL,
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\tgroup"}},
-				},
-			},
-		})
-	})
-
-	t.Run("--set-host-group arg with carriage return is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL: testAPIURL,
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\rgroup"}},
-				},
-			},
-		})
-	})
-
-	t.Run("--set-host-group arg with null byte is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidHostGroupAsParam}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec: dynakube.DynaKubeSpec{
-				APIURL: testAPIURL,
-				OneAgent: oneagent.Spec{
-					HostMonitoring: &oneagent.HostInjectSpec{Args: []string{"--set-host-group=host\x00group"}},
-				},
-			},
-		})
+		assertSanitizeArg(t, dk, func(dk *dynakube.DynaKube, value string) {
+			dk.Spec.OneAgent.HostGroup = value
+		}, errorInvalidHostGroupProperty)
 	})
 }

--- a/pkg/api/validation/dynakube/logmonitoring.go
+++ b/pkg/api/validation/dynakube/logmonitoring.go
@@ -2,14 +2,17 @@ package validation
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 const (
 	warningLogMonitoringIgnoredTemplate = "The Dynakube's `spec.templates.logMonitoring` section is skipped as the `spec.oneagent` section is also configured."
 	errorLogMonitoringMissingImage      = `The Dynakube's specification specifies standalone Log monitoring, but no image repository/tag is configured.`
+	errorInvalidLogmonArgument          = "The DynaKube' spec.templates.logMonitoring.args contains invalid arguments. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the value in your custom resource."
 )
 
 func ignoredLogMonitoringTemplate(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
@@ -41,6 +44,17 @@ func missingLogMonitoringImage(ctx context.Context, dv *Validator, dk *dynakube.
 
 	if dk.LogMonitoring().TemplateSpec == nil || !dk.LogMonitoring().ImageRef.HasImage() {
 		return errorLogMonitoringMissingImage
+	}
+
+	return ""
+}
+
+func invalidLogmonArguments(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	args := dk.LogMonitoring().Template().Args
+	for _, arg := range args {
+		if strings.ContainsAny(arg, sanitize.InvalidCommandLineCharset) {
+			return errorInvalidLogmonArgument
+		}
 	}
 
 	return ""

--- a/pkg/api/validation/dynakube/logmonitoring_test.go
+++ b/pkg/api/validation/dynakube/logmonitoring_test.go
@@ -200,7 +200,8 @@ func TestConflictingMaxUnavailableAnnotationWithRollingUpdateLogMonitoring(t *te
 			},
 		}
 		// warning amount 2: deprecated flag + conflict with rolling update
-		assertAllowedWithWarnings(t, 2, &dynakube.DynaKube{ObjectMeta: meta,
+		assertAllowedWithWarnings(t, 2, &dynakube.DynaKube{
+			ObjectMeta: meta,
 			Spec: dynakube.DynaKubeSpec{
 				APIURL: testAPIURL,
 				Templates: dynakube.TemplatesSpec{
@@ -213,4 +214,26 @@ func TestConflictingMaxUnavailableAnnotationWithRollingUpdateLogMonitoring(t *te
 			},
 		})
 	})
+}
+
+func TestInvalidLogmonArguments(t *testing.T) {
+	dk := &dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL:        testAPIURL,
+			LogMonitoring: &logmonitoring.Spec{},
+			Templates: dynakube.TemplatesSpec{
+				LogMonitoring: &logmonitoring.TemplateSpec{
+					ImageRef: image.Ref{
+						Repository: "repo/image",
+						Tag:        "version",
+					},
+				},
+			},
+		},
+	}
+
+	assertSanitizeArg(t, dk, func(dk *dynakube.DynaKube, value string) {
+		dk.Spec.Templates.LogMonitoring.Args = []string{value}
+	}, errorInvalidLogmonArgument)
 }

--- a/pkg/api/validation/dynakube/networkzone.go
+++ b/pkg/api/validation/dynakube/networkzone.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 const (
@@ -12,18 +13,9 @@ const (
 )
 
 func invalidNetworkZone(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
-	if strings.ContainsFunc(dk.Spec.NetworkZone, isWhiteSpaceCharacter) {
+	if strings.ContainsAny(dk.Spec.NetworkZone, sanitize.InvalidCommandLineCharset) {
 		return errorInvalidNetworkZone
 	}
 
 	return ""
-}
-
-func isWhiteSpaceCharacter(r rune) bool {
-	switch r {
-	case '\n', '\t', '\r', '\x00':
-		return true
-	}
-
-	return false
 }

--- a/pkg/api/validation/dynakube/networkzone_test.go
+++ b/pkg/api/validation/dynakube/networkzone_test.go
@@ -20,31 +20,14 @@ func TestInvalidNetworkZone(t *testing.T) {
 		})
 	})
 
-	t.Run("network zone with newline is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
+	t.Run("network zone with invalid characters is denied", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\nzone"},
-		})
-	})
+			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL},
+		}
 
-	t.Run("network zone with tab is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\tzone"},
-		})
-	})
-
-	t.Run("network zone with carriage return is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\rzone"},
-		})
-	})
-
-	t.Run("network zone with null byte is denied", func(t *testing.T) {
-		assertDenied(t, []string{errorInvalidNetworkZone}, &dynakube.DynaKube{
-			ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
-			Spec:       dynakube.DynaKubeSpec{APIURL: testAPIURL, NetworkZone: "network\x00zone"},
-		})
+		assertSanitizeArg(t, dk, func(dk *dynakube.DynaKube, value string) {
+			dk.Spec.NetworkZone = value
+		}, errorInvalidNetworkZone)
 	})
 }

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,6 +42,8 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 	errorHostIDSourceArgumentInCloudNative = "Setting --set-host-id-source in CloudNativFullstack mode is not allowed."
 
 	errorSameHostTagMultipleTimes = "Providing the same tag(s) (%s) multiple times with --set-host-tag is not allowed."
+
+	errorInvalidOneAgentArgument = "The DynaKube's OneAgent specification contains invalid arguments. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the value in your custom resource."
 
 	warningDeprecatedVersion = `version field is deprecated. Please use "%s" field instead to set a version.`
 
@@ -275,6 +278,17 @@ func forbiddenHostIDSourceArgument(_ context.Context, _ *Validator, dk *dynakube
 	for key := range args {
 		if dk.OneAgent().IsCloudNativeFullstackMode() && key == "--set-host-id-source" {
 			return errorHostIDSourceArgumentInCloudNative
+		}
+	}
+
+	return ""
+}
+
+func invalidOneAgentArguments(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	args := dk.OneAgent().GetArguments()
+	for _, arg := range args {
+		if strings.ContainsAny(arg, sanitize.InvalidCommandLineCharset) {
+			return errorInvalidOneAgentArgument
 		}
 	}
 

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -1111,7 +1111,10 @@ func TestConflictingMaxUnavailableAnnotationWithRollingUpdate(t *testing.T) {
 			oaspec: oneagent.Spec{
 				ClassicFullStack: &oneagent.HostInjectSpec{
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
-						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2}}}},
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					},
+				},
+			},
 			expectedWarnings: 0,
 		},
 		{
@@ -1155,4 +1158,20 @@ func TestConflictingMaxUnavailableAnnotationWithRollingUpdate(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestInvalidOneAgentArguments(t *testing.T) {
+	dk := &dynakube.DynaKube{
+		ObjectMeta: defaultDynakubeObjectMeta,
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testAPIURL,
+			OneAgent: oneagent.Spec{
+				CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
+			},
+		},
+	}
+
+	assertSanitizeArg(t, dk, func(dk *dynakube.DynaKube, value string) {
+		dk.Spec.OneAgent.CloudNativeFullStack.Args = []string{value}
+	}, errorInvalidOneAgentArgument)
 }

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -70,6 +70,7 @@ var (
 		publicRegistryOverrideWithoutPublicRegistry,
 		invalidNetworkZone,
 		invalidOneAgentHostGroup,
+		invalidNoProxy,
 		publicRegistryNotAllowedForClassic,
 	}
 	validatorWarningFuncs = []validatorFunc{

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -72,6 +72,8 @@ var (
 		invalidOneAgentHostGroup,
 		invalidNoProxy,
 		publicRegistryNotAllowedForClassic,
+		invalidOneAgentArguments,
+		invalidLogmonArguments,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,

--- a/pkg/api/validation/dynakube/validation_test.go
+++ b/pkg/api/validation/dynakube/validation_test.go
@@ -11,6 +11,7 @@ import (
 	v1beta4 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	v1beta5 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta5/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -110,7 +111,8 @@ func TestDynakubeValidator_Handle(t *testing.T) {
 				errorNoAPIURL,
 				errorConflictingNamespaceSelector,
 				fmt.Sprintf(errorInvalidActiveGateCapability, "me dumb"),
-				fmt.Sprintf(errorNodeSelectorConflict, "conflict2")},
+				fmt.Sprintf(errorNodeSelectorConflict, "conflict2"),
+			},
 			&dynakube.DynaKube{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testName,
@@ -320,4 +322,14 @@ func runUpdateValidators(t *testing.T, oldDK *dynakube.DynaKube, newDK *dynakube
 	}
 
 	return validator.ValidateUpdate(t.Context(), oldDK, newDK)
+}
+
+func assertSanitizeArg(t *testing.T, baseDK *dynakube.DynaKube, modify func(*dynakube.DynaKube, string), expectError string) {
+	t.Helper()
+	for _, c := range sanitize.InvalidCommandLineCharset {
+		value := "foo" + string(c) + "bar"
+		dk := baseDK.DeepCopy()
+		modify(dk, value)
+		assertDenied(t, []string{expectError}, dk)
+	}
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 func getInitArgs(dk dynakube.DynaKube) []string {
@@ -28,8 +29,8 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 
 	attrs := dk.GetResourceAttributes()
 	for _, key := range slices.Sorted(maps.Keys(attrs)) {
-		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", key, attrs[key]))
+		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", sanitize.CommandLineArg(key), sanitize.CommandLineArg(attrs[key])))
 	}
 
-	return append(baseArgs, dk.LogMonitoring().Template().Args...)
+	return append(baseArgs, sanitize.CommandLineArgs(dk.LogMonitoring().Template().Args)...)
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -110,6 +110,22 @@ func Test_getInitArgs(t *testing.T) {
 				"-p team=platform",
 			},
 		},
+		{
+			name:        "sanitize args",
+			expectedLen: expectedBaseInitArgsLen,
+			resourceAttrs: map[string]string{
+				"foo": "a\ntest",
+			},
+			templateArgs: []string{
+				"-p bar=b\ntest",
+			},
+			mustContain: []string{
+				"-p bar=btest",
+			},
+			expectedAttrArgs: []string{
+				"-p foo=atest",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -21,6 +21,7 @@ func (b *builder) arguments() ([]string, error) {
 		prioritymap.WithAvoidDuplicates(),
 		prioritymap.WithAllowDuplicatesFor("--set-host-property"),
 		prioritymap.WithAllowDuplicatesFor("--set-host-tag"),
+		prioritymap.WithTrimInvalidStringChars(),
 	)
 
 	isProxyAsEnvDeprecated, err := isProxyAsEnvVarDeprecated(b.dk.OneAgent().GetVersion())

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments.go
@@ -21,7 +21,7 @@ func (b *builder) arguments() ([]string, error) {
 		prioritymap.WithAvoidDuplicates(),
 		prioritymap.WithAllowDuplicatesFor("--set-host-property"),
 		prioritymap.WithAllowDuplicatesFor("--set-host-tag"),
-		prioritymap.WithTrimInvalidStringChars(),
+		prioritymap.WithSanitizeCommandLineArg(),
 	)
 
 	isProxyAsEnvDeprecated, err := isProxyAsEnvVarDeprecated(b.dk.OneAgent().GetVersion())

--- a/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/arguments_test.go
@@ -321,6 +321,45 @@ func TestArguments(t *testing.T) {
 		}
 		assert.Equal(t, expectedDefaultArguments, arguments)
 	})
+
+	t.Run("sanitize args", func(t *testing.T) {
+		custArgs := []string{
+			"--1\nfoo",
+		}
+		builder := builder{
+			dk: &dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						exp.NoProxyKey: "4\x00qux",
+					},
+				},
+				Spec: dynakube.DynaKubeSpec{
+					Proxy: &value.Source{Value: "test"},
+					OneAgent: oneagent.Spec{
+						ClassicFullStack: &oneagent.HostInjectSpec{},
+						HostGroup:        "2\tbar",
+					},
+					NetworkZone: "3\rbaz",
+				},
+			},
+			hostInjectSpec: &oneagent.HostInjectSpec{Args: custArgs},
+			deploymentType: deploymentmetadata.CloudNativeDeploymentType,
+		}
+
+		arguments, _ := builder.arguments()
+
+		expectedDefaultArguments := []string{
+			"--1foo",
+			"--set-host-group=2bar",
+			"--set-host-id-source=auto",
+			"--set-host-property=OperatorVersion=$(DT_OPERATOR_VERSION)",
+			"--set-network-zone=3baz",
+			"--set-no-proxy=4qux",
+			"--set-server={$(DT_SERVER)}",
+			"--set-tenant=$(DT_TENANT)",
+		}
+		assert.Equal(t, expectedDefaultArguments, arguments)
+	})
 }
 
 func TestPodSpec_Arguments(t *testing.T) {

--- a/pkg/util/prioritymap/cmdline_parser.go
+++ b/pkg/util/prioritymap/cmdline_parser.go
@@ -9,7 +9,7 @@ const DefaultSeparator = "="
 // ParseCommandLineArgument splits strings in the format of "--param=value" up in its components "--param", "=" and "value".
 // The separator is returned to let the caller know if it was there
 func ParseCommandLineArgument(arg string) (string, string, string) {
-	arg, value, foundSeparator := strings.Cut(arg, DefaultSeparator)
+	arg, value, foundSeparator := strings.Cut(sanitizeArgs.Replace(arg), DefaultSeparator)
 
 	if foundSeparator {
 		return arg, DefaultSeparator, value

--- a/pkg/util/prioritymap/cmdline_parser.go
+++ b/pkg/util/prioritymap/cmdline_parser.go
@@ -9,7 +9,7 @@ const DefaultSeparator = "="
 // ParseCommandLineArgument splits strings in the format of "--param=value" up in its components "--param", "=" and "value".
 // The separator is returned to let the caller know if it was there
 func ParseCommandLineArgument(arg string) (string, string, string) {
-	arg, value, foundSeparator := strings.Cut(sanitizeArgs.Replace(arg), DefaultSeparator)
+	arg, value, foundSeparator := strings.Cut(arg, DefaultSeparator)
 
 	if foundSeparator {
 		return arg, DefaultSeparator, value

--- a/pkg/util/prioritymap/conversion.go
+++ b/pkg/util/prioritymap/conversion.go
@@ -3,13 +3,14 @@ package prioritymap
 import (
 	"cmp"
 	"fmt"
+	"maps"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 func (m Map) AsEnvVars() []corev1.EnvVar {
-	keys := m.getSortedKeys()
+	keys := slices.Sorted(maps.Keys(m.entries))
 	envVars := make([]corev1.EnvVar, 0, len(keys))
 
 	for _, key := range keys {
@@ -42,8 +43,8 @@ func (m Map) AsEnvVars() []corev1.EnvVar {
 }
 
 func (m Map) AsKeyValueStrings() []string {
-	keys := m.getSortedKeys()
-	valStrings := make([]string, 0)
+	keys := slices.Sorted(maps.Keys(m.entries))
+	valStrings := make([]string, 0, len(keys))
 
 	for _, key := range keys {
 		slices.SortStableFunc(m.entries[key], func(a, b entry) int {
@@ -56,16 +57,4 @@ func (m Map) AsKeyValueStrings() []string {
 	}
 
 	return valStrings
-}
-
-func (m Map) getSortedKeys() []string {
-	// some unit tests rely on having the resulting env vars always being in the same order
-	keys := make([]string, 0, len(m.entries))
-	for key := range m.entries {
-		keys = append(keys, key)
-	}
-
-	slices.Sort(keys)
-
-	return keys
 }

--- a/pkg/util/prioritymap/map.go
+++ b/pkg/util/prioritymap/map.go
@@ -7,10 +7,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const DefaultPriority = LowPriority
-const LowPriority = 1
-const MediumPriority = 5
-const HighPriority = 10
+const (
+	DefaultPriority = LowPriority
+	LowPriority     = 1
+	MediumPriority  = 5
+	HighPriority    = 10
+)
+
+var sanitizeArgs = strings.NewReplacer("\n", "", "\t", "", "\r", "", "\x00", "")
 
 type Map struct {
 	entries        map[string][]entry
@@ -67,6 +71,14 @@ func WithAllowDuplicatesFor(key string) Option {
 	}
 }
 
+func WithTrimInvalidStringChars() Option {
+	return func(a *entry) {
+		if s, ok := a.value.(string); ok {
+			a.value = sanitizeArgs.Replace(s)
+		}
+	}
+}
+
 func New(defaultOptions ...Option) *Map {
 	m := &Map{
 		entries:        make(map[string][]entry),
@@ -104,7 +116,7 @@ func (m Map) Append(key string, value any, opts ...Option) {
 		}
 
 		if !slices.ContainsFunc(m.entries[key], func(e entry) bool {
-			return e.value == value
+			return e.value == newArg.value
 		}) {
 			m.entries[key] = append(m.entries[key], newArg)
 		}

--- a/pkg/util/prioritymap/map.go
+++ b/pkg/util/prioritymap/map.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -13,8 +14,6 @@ const (
 	MediumPriority  = 5
 	HighPriority    = 10
 )
-
-var sanitizeArgs = strings.NewReplacer("\n", "", "\t", "", "\r", "", "\x00", "")
 
 type Map struct {
 	entries        map[string][]entry
@@ -71,10 +70,10 @@ func WithAllowDuplicatesFor(key string) Option {
 	}
 }
 
-func WithTrimInvalidStringChars() Option {
+func WithSanitizeCommandLineArg() Option {
 	return func(a *entry) {
 		if s, ok := a.value.(string); ok {
-			a.value = sanitizeArgs.Replace(s)
+			a.value = sanitize.CommandLineArg(s)
 		}
 	}
 }
@@ -140,7 +139,7 @@ func Append[V ValueType](argMap *Map, value V, opts ...Option) {
 			argMap.Append(k, vv, opts...)
 		}
 	case []string:
-		for _, s := range typedValue {
+		for _, s := range sanitize.CommandLineArgs(typedValue) {
 			key, delim, value := ParseCommandLineArgument(s)
 
 			if len(key) > 0 {

--- a/pkg/util/prioritymap/map_test.go
+++ b/pkg/util/prioritymap/map_test.go
@@ -181,7 +181,7 @@ func TestDuplicateArguments(t *testing.T) {
 		"--set-host-property=custom-prop3",
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		title          string
 		expectedArgs   []string
 		defaultArgPrio int
@@ -286,4 +286,28 @@ func TestDuplicateArguments(t *testing.T) {
 			assert.Equal(t, tt.expectedArgs, argMap.AsKeyValueStrings())
 		})
 	}
+}
+
+func TestTrimInvalidStringChars(t *testing.T) {
+	t.Run("remove chars", func(t *testing.T) {
+		invalidChars := []rune{
+			'\n',
+			'\t',
+			'\r',
+			'\x00',
+		}
+
+		for _, c := range invalidChars {
+			m := New(WithSeparator("="), WithTrimInvalidStringChars())
+			m.Append("test", "foo"+string(c)+"bar")
+			assert.Equalf(t, []string{"test=foobar"}, m.AsKeyValueStrings(), "failed to remove %c", c)
+		}
+	})
+
+	t.Run("prevent duplicates", func(t *testing.T) {
+		m := New(WithAllowDuplicates(), WithSeparator("="), WithTrimInvalidStringChars())
+		m.Append("test", "foobar")
+		m.Append("test", "foo\nbar")
+		assert.Equal(t, []string{"test=foobar"}, m.AsKeyValueStrings())
+	})
 }

--- a/pkg/util/prioritymap/map_test.go
+++ b/pkg/util/prioritymap/map_test.go
@@ -290,22 +290,13 @@ func TestDuplicateArguments(t *testing.T) {
 
 func TestTrimInvalidStringChars(t *testing.T) {
 	t.Run("remove chars", func(t *testing.T) {
-		invalidChars := []rune{
-			'\n',
-			'\t',
-			'\r',
-			'\x00',
-		}
-
-		for _, c := range invalidChars {
-			m := New(WithSeparator("="), WithTrimInvalidStringChars())
-			m.Append("test", "foo"+string(c)+"bar")
-			assert.Equalf(t, []string{"test=foobar"}, m.AsKeyValueStrings(), "failed to remove %c", c)
-		}
+		m := New(WithSeparator("="), WithSanitizeCommandLineArg())
+		m.Append("test", "foo\nbar")
+		assert.Equal(t, []string{"test=foobar"}, m.AsKeyValueStrings())
 	})
 
 	t.Run("prevent duplicates", func(t *testing.T) {
-		m := New(WithAllowDuplicates(), WithSeparator("="), WithTrimInvalidStringChars())
+		m := New(WithAllowDuplicates(), WithSeparator("="), WithSanitizeCommandLineArg())
 		m.Append("test", "foobar")
 		m.Append("test", "foo\nbar")
 		assert.Equal(t, []string{"test=foobar"}, m.AsKeyValueStrings())

--- a/pkg/util/sanitize/sanitize.go
+++ b/pkg/util/sanitize/sanitize.go
@@ -1,0 +1,42 @@
+// Package sanitize provides functions to sanitize user input.
+package sanitize
+
+import (
+	"strings"
+	"sync"
+)
+
+var invalidCommandLineChars = [...]rune{
+	'\n',
+	'\t',
+	'\r',
+	'\x00',
+}
+
+// InvalidCommandLineCharset contains invalid command-line characters.
+// Can be used with [strings.ContainsAny].
+var InvalidCommandLineCharset = string(invalidCommandLineChars[:])
+
+var argSanitizer = sync.OnceValue(func() *strings.Replacer {
+	pairs := make([]string, 0, len(invalidCommandLineChars)*2) //nolint:mnd
+	for _, c := range invalidCommandLineChars {
+		pairs = append(pairs, string(c), "")
+	}
+
+	return strings.NewReplacer(pairs...)
+})
+
+// CommandLineArg removes invalid characters from command-line input.
+func CommandLineArg(arg string) string {
+	return argSanitizer().Replace(arg)
+}
+
+// CommandLineArgs returns a copy of args where each element was sanitized with [CommandLineArg].
+func CommandLineArgs(args []string) []string {
+	sanitized := make([]string, len(args))
+	for i, arg := range args {
+		sanitized[i] = CommandLineArg(arg)
+	}
+
+	return sanitized
+}

--- a/pkg/util/sanitize/sanitize_test.go
+++ b/pkg/util/sanitize/sanitize_test.go
@@ -1,0 +1,61 @@
+package sanitize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidCommandLineCharset(t *testing.T) {
+	assert.Equal(t, "\n\t\r\x00", InvalidCommandLineCharset)
+
+	// the charset must work with strings.ContainsAny, which validators rely on
+	assert.True(t, strings.ContainsAny("foo\nbar", InvalidCommandLineCharset))
+	assert.False(t, strings.ContainsAny("foobar", InvalidCommandLineCharset))
+}
+
+func TestCommandLineArg(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "empty string", in: "", out: ""},
+		{name: "clean string is unchanged", in: "foo=bar", out: "foo=bar"},
+		{name: "removes newline", in: "foo\nbar", out: "foobar"},
+		{name: "removes tab", in: "foo\tbar", out: "foobar"},
+		{name: "removes carriage return", in: "foo\rbar", out: "foobar"},
+		{name: "removes null", in: "foo\x00bar", out: "foobar"},
+		{name: "removes all invalid chars at once", in: "\nfoo\t\rbar\x00", out: "foobar"},
+		{name: "removes repeated invalid chars", in: "foo\n\n\nbar", out: "foobar"},
+		{name: "keeps regular whitespace", in: "foo bar", out: "foo bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, CommandLineArg(tt.in))
+		})
+	}
+}
+
+func TestCommandLineArgs(t *testing.T) {
+	t.Run("nil slice returns empty slice", func(t *testing.T) {
+		assert.Equal(t, []string{}, CommandLineArgs(nil))
+	})
+
+	t.Run("empty slice returns empty slice", func(t *testing.T) {
+		assert.Equal(t, []string{}, CommandLineArgs([]string{}))
+	})
+
+	t.Run("sanitizes every element", func(t *testing.T) {
+		in := []string{"foo\nbar", "clean", "a\tb\x00c"}
+		assert.Equal(t, []string{"foobar", "clean", "abc"}, CommandLineArgs(in))
+	})
+
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		in := []string{"foo\nbar"}
+		_ = CommandLineArgs(in)
+		assert.Equal(t, []string{"foo\nbar"}, in)
+	})
+}


### PR DESCRIPTION
## Description

Add validation for no-proxy feature flag to prevent invalid characters from being added in the command-line arguments.
Sanitize all OneAgent and logmon command-line arguments by removing invalid characters.

ICP-6481

## How can this be tested?

* Try using invalid characters for oneagent no-proxy, oneagent args, logmond args -> blocked
* Disable webhook and provide invalid characters in the args of oneagent and logmon -> sanitized
