### PR TITLE
cherry-pick: rename database-datasource-executor to dynatrace-sql-extension-executor

### DIFF
--- a/pkg/clients/dynatrace/image/client.go
+++ b/pkg/clients/dynatrace/image/client.go
@@ -18,7 +18,7 @@ const (
 	ActiveGate  ComponentType = "activegate"
 	EEC         ComponentType = "eec"
 	LogModule   ComponentType = "logmodule"
-	DBExecutor  ComponentType = "database-datasource-executor"
+	DBExecutor  ComponentType = "dynatrace-sql-extension-executor"
 )
 
 type Info struct {

--- a/test/e2e/features/usepublicregistry/deploy.go
+++ b/test/e2e/features/usepublicregistry/deploy.go
@@ -96,8 +96,6 @@ func CodeModulesWithOverride(t *testing.T) features.Feature {
 }
 
 func DBExecutor(t *testing.T) features.Feature {
-	t.Skip("Skip test until we find out why the db executor image is missing from some tenants registry")
-
 	return dbExecutorFeature(t,
 		"use-public-registry-db-executor",
 		"use-public-registry-db-exec",
@@ -105,8 +103,6 @@ func DBExecutor(t *testing.T) features.Feature {
 }
 
 func DBExecutorOverride(t *testing.T) features.Feature {
-	t.Skip("Skip test until we find out why the db executor image is missing from some tenants registry")
-
 	return dbExecutorFeature(t,
 		"use-public-registry-db-executor-with-override",
 		"use-public-registry-db-exec-ovrd",


### PR DESCRIPTION
same as https://github.com/Dynatrace/dynatrace-operator/pull/6855

resolves [ICP-6392](https://dt-rnd.atlassian.net/browse/ICP-6392)

How can this be tested?
make test/e2e/usepublicregistry
and specifically
make test/e2e/usepublicregistry/dbexecutor

[ICP-6392]: https://dt-rnd.atlassian.net/browse/ICP-6392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ