### PR TITLE
Add usage of JSON metadata annoation to OTelC config.

### DIFF
--- a/pkg/otelcgen/processors.go
+++ b/pkg/otelcgen/processors.go
@@ -63,6 +63,11 @@ func (c *Config) buildProcessors() map[component.ID]component.Config {
 						"key_regex": "metadata.dynatrace.com/(.*)",
 						"tag_name":  "$$1",
 					},
+					{
+						"from":     "pod",
+						"key":      "metadata.dynatrace.com",
+						"tag_name": "metadata.dynatrace.com",
+					},
 				},
 			},
 			"pod_association": []map[string]any{
@@ -140,6 +145,8 @@ func (c *Config) dynatraceTransformations() []map[string]any {
 		{
 			"context": "resource",
 			"statements": []string{
+				`merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")`,
+				`delete_key(attributes, "metadata.dynatrace.com")`,
 				"set(attributes[\"k8s.workload.name\"], attributes[\"k8s.statefulset.name\"]) where IsString(attributes[\"k8s.statefulset.name\"])",
 				"set(attributes[\"k8s.workload.name\"], attributes[\"k8s.replicaset.name\"]) where IsString(attributes[\"k8s.replicaset.name\"])",
 				"set(attributes[\"k8s.workload.name\"], attributes[\"k8s.job.name\"]) where IsString(attributes[\"k8s.job.name\"])",

--- a/pkg/otelcgen/processors_test.go
+++ b/pkg/otelcgen/processors_test.go
@@ -24,3 +24,69 @@ func TestNewConfigWithProcessors(t *testing.T) {
 
 	assert.YAMLEq(t, string(expectedOutput), string(c))
 }
+
+func TestK8sAttributesJSONAnnotation(t *testing.T) {
+	cfg := &Config{}
+	processors := cfg.buildProcessors()
+
+	k8sAttr, ok := processors[k8sattributes].(map[string]any)
+	require.True(t, ok)
+
+	extract, ok := k8sAttr["extract"].(map[string]any)
+	require.True(t, ok)
+
+	annotations, ok := extract["annotations"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, annotations, 2)
+
+	t.Run("regex rule kept", func(t *testing.T) {
+		rule := annotations[0]
+		assert.Equal(t, "pod", rule["from"])
+		assert.Equal(t, "metadata.dynatrace.com/(.*)", rule["key_regex"])
+		assert.Equal(t, "$$1", rule["tag_name"])
+		assert.NotContains(t, rule, "key")
+	})
+
+	t.Run("exact-key rule added", func(t *testing.T) {
+		rule := annotations[1]
+		assert.Equal(t, "pod", rule["from"])
+		assert.Equal(t, "metadata.dynatrace.com", rule["key"])
+		assert.Equal(t, "metadata.dynatrace.com", rule["tag_name"])
+		assert.NotContains(t, rule, "key_regex")
+	})
+}
+
+func TestDynatraceTransformationsJSONAnnotation(t *testing.T) {
+	cfg := &Config{}
+	transformations := cfg.dynatraceTransformations()
+	require.Len(t, transformations, 1)
+
+	statements, ok := transformations[0]["statements"].([]string)
+	require.True(t, ok)
+	require.GreaterOrEqual(t, len(statements), 2)
+
+	t.Run("merge_maps statement is first", func(t *testing.T) {
+		assert.Contains(t, statements[0], "merge_maps(attributes, ParseJSON(attributes[\"metadata.dynatrace.com\"]), \"insert\")")
+		assert.Contains(t, statements[0], `IsMatch(attributes["metadata.dynatrace.com"], "^\\{")`)
+	})
+
+	t.Run("delete_key statement is second", func(t *testing.T) {
+		assert.Equal(t, `delete_key(attributes, "metadata.dynatrace.com")`, statements[1])
+	})
+
+	t.Run("all signal types carry JSON annotation statements", func(t *testing.T) {
+		cfg2 := &Config{}
+		transform := cfg2.buildTransform()
+
+		for _, signalKey := range []string{"log_statements", "metric_statements", "trace_statements"} {
+			stmts, ok := transform[signalKey].([]map[string]any)
+			require.True(t, ok, "expected []map[string]any for %s", signalKey)
+			require.Len(t, stmts, 1)
+
+			block, ok := stmts[0]["statements"].([]string)
+			require.True(t, ok)
+			assert.Contains(t, block[0], "merge_maps", "%s missing merge_maps", signalKey)
+			assert.Equal(t, `delete_key(attributes, "metadata.dynatrace.com")`, block[1], "%s missing delete_key", signalKey)
+		}
+	})
+}

--- a/pkg/otelcgen/testdata/full_config.yaml
+++ b/pkg/otelcgen/testdata/full_config.yaml
@@ -18,6 +18,9 @@ processors:
         - from: pod
           key_regex: metadata.dynatrace.com/(.*)
           tag_name: $$1
+        - from: pod
+          key: metadata.dynatrace.com
+          tag_name: metadata.dynatrace.com
       metadata:
         - k8s.cluster.uid
         - k8s.node.name
@@ -50,6 +53,8 @@ processors:
     log_statements:
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])
@@ -76,6 +81,8 @@ processors:
     metric_statements:
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])
@@ -102,6 +109,8 @@ processors:
     trace_statements:
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])

--- a/pkg/otelcgen/testdata/open-signals.yaml
+++ b/pkg/otelcgen/testdata/open-signals.yaml
@@ -71,6 +71,9 @@ processors:
         - from: pod
           key_regex: metadata.dynatrace.com/(.*)
           tag_name: $$1
+        - from: pod
+          key: metadata.dynatrace.com
+          tag_name: metadata.dynatrace.com
     pod_association:
       - sources:
           - from: resource_attribute
@@ -90,6 +93,8 @@ processors:
     trace_statements: &dynatrace_transformations
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.kind"], "job") where IsString(attributes["k8s.job.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])
           - set(attributes["k8s.workload.kind"], "cronjob") where IsString(attributes["k8s.cronjob.name"])

--- a/pkg/otelcgen/testdata/processors_only.yaml
+++ b/pkg/otelcgen/testdata/processors_only.yaml
@@ -9,6 +9,9 @@ processors:
         - from: pod
           key_regex: metadata.dynatrace.com/(.*)
           tag_name: $$1
+        - from: pod
+          key: metadata.dynatrace.com
+          tag_name: metadata.dynatrace.com
       metadata:
         - k8s.cluster.uid
         - k8s.node.name
@@ -41,6 +44,8 @@ processors:
     log_statements:
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])
@@ -67,6 +72,8 @@ processors:
     metric_statements:
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])
@@ -93,6 +100,8 @@ processors:
     trace_statements:
       - context: resource
         statements:
+          - 'merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "insert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")'
+          - 'delete_key(attributes, "metadata.dynatrace.com")'
           - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
           - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])


### PR DESCRIPTION
## Description

The OpenTelemetry collector spawned for telemetry ingest shall utilize attributes provided in the JSON block in `metadata.dynatrace.com`.

[JIRA](https://dt-rnd.atlassian.net/browse/ICP-6439)

## How can this be tested?

* Deploy a DK with `.spec.telemetryIngest` and `.spec.metadataEnrichment` (or full CNFS) enabled
* Create a namespace that is annotated with `metadata.dynatrace.com/foo: bar`
* Create a workload in that namespace that emits traces, metrics and/or logs to Dynatrace via the telemetry ingest mechanism
* Check in tenant if the ingested data has the `foo: bar` attribute.

Here are some sample pods to generate data:
[telemetrygen-pods.yaml](https://github.com/user-attachments/files/29372787/telemetrygen-pods.yaml)
