### PR TITLE
Fix API URL handling for 3rd gen

### DIFF
--- a/pkg/api/latest/dynakube/activegate_props.go
+++ b/pkg/api/latest/dynakube/activegate_props.go
@@ -5,7 +5,10 @@ import (
 )
 
 func (dk *DynaKube) ActiveGate() *activegate.ActiveGate {
-	dk.Spec.ActiveGate.SetAPIURL(dk.APIURL())
+	// The stored API URL is only used to derive the tenant image registry host, which is only
+	// available on 2nd gen URLs. Pass the raw value so a 3rd gen URL yields a non-functional
+	// registry host on purpose (see DynaKube.APIURLHost).
+	dk.Spec.ActiveGate.SetAPIURL(dk.Spec.APIURL)
 	dk.Spec.ActiveGate.SetName(dk.Name)
 	dk.Spec.ActiveGate.SetAutomaticTLSCertificate(dk.FF().IsActiveGateAutomaticTLSCertificate())
 	dk.Spec.ActiveGate.SetExtensionsDependency(dk.Extensions().IsAnyEnabled())

--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/conversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtapiurl"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -40,18 +41,29 @@ func (dk *DynaKube) RemovedFields() *conversion.RemovedFields {
 	return conversion.NewRemovedFields(dk.Annotations)
 }
 
-// APIURL is a getter for dk.Spec.APIURL.
+// APIURL returns the API URL that the operator and its components should communicate with.
+//
+// The returned value is normalized to its 2nd gen equivalent: a 3rd gen URL (*.apps.*) is
+// remapped to its 2nd gen form, while a 2nd gen URL is returned unchanged. This is required
+// because the Environment V2 API (ingest, settings, tenant registry, ...) is only served on
+// 2nd gen URLs. Use dk.Spec.APIURL directly when the raw, user-provided value is needed
+// (e.g. validation).
 func (dk *DynaKube) APIURL() string {
-	return dk.Spec.APIURL
+	return dtapiurl.ToSecondGen(dk.Spec.APIURL)
 }
 
 func (dk *DynaKube) Conditions() *[]metav1.Condition { return &dk.Status.Conditions }
 
-// APIURLHost returns the host of dk.Spec.APIURL
+// APIURLHost returns the host of the raw dk.Spec.APIURL.
 // E.g. if the APIURL is set to "https://my-tenant.dynatrace.com/api", it returns "my-tenant.dynatrace.com"
 // If the URL cannot be parsed, it returns an empty string.
+//
+// Unlike APIURL(), this intentionally uses the raw, un-normalized value: it is used to derive
+// the tenant image registry host, which is only available on 2nd gen URLs. A 3rd gen URL
+// (*.apps.*) therefore yields a non-functional registry host on purpose, instead of silently
+// pointing at a 2nd gen host that does not serve a registry for that tenant either.
 func (dk *DynaKube) APIURLHost() string {
-	parsedURL, err := url.Parse(dk.APIURL())
+	parsedURL, err := url.Parse(dk.Spec.APIURL)
 	if err != nil {
 		return ""
 	}

--- a/pkg/api/latest/dynakube/dynakube_props_test.go
+++ b/pkg/api/latest/dynakube/dynakube_props_test.go
@@ -47,6 +47,29 @@ func TestTokens(t *testing.T) {
 	})
 }
 
+func TestAPIURL(t *testing.T) {
+	t.Run("2nd gen URL is returned unchanged", func(t *testing.T) {
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: "https://tenant.live.dynatrace.com/api"}}
+		assert.Equal(t, "https://tenant.live.dynatrace.com/api", dk.APIURL())
+		assert.Equal(t, "tenant.live.dynatrace.com", dk.APIURLHost())
+	})
+
+	t.Run("3rd gen URL is mapped to its 2nd gen equivalent", func(t *testing.T) {
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: "https://tenant.apps.dynatrace.com"}}
+		assert.Equal(t, "https://tenant.live.dynatrace.com/api", dk.APIURL())
+	})
+
+	t.Run("APIURLHost returns the raw host so a 3rd gen registry breaks on purpose", func(t *testing.T) {
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: "https://tenant.apps.dynatrace.com"}}
+		assert.Equal(t, "tenant.apps.dynatrace.com", dk.APIURLHost())
+	})
+
+	t.Run("Spec.APIURL keeps the raw user-provided value", func(t *testing.T) {
+		dk := DynaKube{Spec: DynaKubeSpec{APIURL: "https://tenant.apps.dynatrace.com"}}
+		assert.Equal(t, "https://tenant.apps.dynatrace.com", dk.Spec.APIURL)
+	})
+}
+
 func TestImagePullSecretReferences(t *testing.T) {
 	t.Run("only tenant pull secret when no custom pull secret is set", func(t *testing.T) {
 		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")

--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -6,8 +6,6 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/url"
-	"path"
-	"strings"
 	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/activegate"
@@ -75,12 +73,6 @@ func NewClient(options ...Option) (*Client, error) {
 
 	if dttoken.IsPlatform(config.APIToken) || config.PaasToken == "" {
 		config.PaasToken = config.APIToken
-	}
-
-	if strings.Contains(config.BaseURL.Hostname(), ".apps.") {
-		mapThirdGenAPIURL(config.BaseURL)
-	} else if path.Base(config.BaseURL.Path) != "api" {
-		config.BaseURL = config.BaseURL.JoinPath("api")
 	}
 
 	apiClient := core.NewClient(core.Config{
@@ -312,34 +304,4 @@ func proxyWrapper(proxyConfig httpproxy.Config) func(req *http.Request) (*url.UR
 	proxyFunc := proxyConfig.ProxyFunc()
 
 	return func(req *http.Request) (*url.URL, error) { return proxyFunc(req.URL) }
-}
-
-const thirdGenAPPSHostParts = 2
-
-// mapThirdGenAPIURL remaps a 3rd gen URL (*.apps.*) to its 2nd gen equivalent.
-func mapThirdGenAPIURL(u *url.URL) {
-	hostname := u.Hostname()
-
-	parts := strings.SplitN(hostname, ".apps.", thirdGenAPPSHostParts)
-	if len(parts) != thirdGenAPPSHostParts {
-		return
-	}
-
-	prefix, suffix := parts[0], parts[1]
-
-	var newHostname string
-
-	if !strings.Contains(prefix, ".") {
-		newHostname = prefix + ".live." + suffix
-	} else {
-		newHostname = prefix + "." + suffix
-	}
-
-	if port := u.Port(); port != "" {
-		u.Host = newHostname + ":" + port
-	} else {
-		u.Host = newHostname
-	}
-
-	u.Path = "/api"
 }

--- a/pkg/clients/dynatrace/client_test.go
+++ b/pkg/clients/dynatrace/client_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"path"
 	"testing"
 	"time"
 
@@ -305,81 +304,6 @@ func TestGetClientAndConfig(t *testing.T) {
 		require.True(t, ok)
 		assert.False(t, transport.DisableKeepAlives)
 	})
-}
-
-func TestMapThirdGenAPIURL(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{
-			input:    "https://tenant.apps.dynatrace.com",
-			expected: "https://tenant.live.dynatrace.com/api",
-		},
-		{
-			input:    "https://tenant.sprint.apps.dynatrace.com",
-			expected: "https://tenant.sprint.dynatrace.com/api",
-		},
-		{
-			input:    "https://tenant.dev.apps.dynatrace.com",
-			expected: "https://tenant.dev.dynatrace.com/api",
-		},
-		{
-			input:    "https://tenant.apps.dynatrace.com:8443",
-			expected: "https://tenant.live.dynatrace.com:8443/api",
-		},
-		{
-			input:    "https://tenant.sprint.apps.dynatrace.com:9090",
-			expected: "https://tenant.sprint.dynatrace.com:9090/api",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			u := mustParseURL(t, tc.input)
-			mapThirdGenAPIURL(u)
-			assert.Equal(t, tc.expected, u.String())
-		})
-	}
-}
-
-func TestNewClientAppendAPIPath(t *testing.T) {
-	tests := []struct {
-		name     string
-		inputURL string
-		expected string
-	}{
-		{
-			name:     "URL without /api gets it appended",
-			inputURL: "https://tenant.live.dynatrace.com",
-			expected: "https://tenant.live.dynatrace.com/api",
-		},
-		{
-			name:     "URL with trailing slash gets /api appended",
-			inputURL: "https://tenant.live.dynatrace.com/",
-			expected: "https://tenant.live.dynatrace.com/api",
-		},
-		{
-			name:     "URL with /api already is unchanged",
-			inputURL: "https://tenant.live.dynatrace.com/api",
-			expected: "https://tenant.live.dynatrace.com/api",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			client, err := NewClient(WithBaseURL(tc.inputURL), WithAPIToken("foo"))
-			require.NoError(t, err)
-			require.NotNil(t, client)
-
-			u := mustParseURL(t, tc.inputURL)
-			if path.Base(u.Path) != "api" {
-				u = u.JoinPath("api")
-			}
-
-			assert.Equal(t, tc.expected, u.String())
-		})
-	}
 }
 
 func mustParseURL(t *testing.T, raw string) *url.URL {

--- a/pkg/clients/dynatrace/dynakube.go
+++ b/pkg/clients/dynatrace/dynakube.go
@@ -23,7 +23,7 @@ func NewClientFromDynakube(ctx context.Context, apiReader client.Reader, dk *dyn
 
 func optionsFromDynakube(ctx context.Context, apiReader client.Reader, dk *dynakube.DynaKube, apiToken, paasToken, userAgentSuffix string) ([]Option, error) {
 	options := []Option{
-		WithBaseURL(dk.Spec.APIURL),
+		WithBaseURL(dk.APIURL()),
 		WithAPIToken(apiToken),
 		WithPaasToken(paasToken),
 		WithSkipCertificateValidation(dk.Spec.SkipCertCheck),

--- a/pkg/controllers/dynakube/dtpullsecret/generate.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate.go
@@ -40,7 +40,7 @@ func newDockerConfigWithAuth(username string, password string, registry string, 
 func (r *Reconciler) generateData(dk *dynakube.DynaKube, tokens token.Tokens) (map[string][]byte, error) {
 	var registryToken string
 
-	registry, err := getImageRegistryFromAPIURL(dk.Spec.APIURL)
+	registry, err := getImageRegistryFromAPIURL(dk.APIURL())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -65,7 +65,7 @@ func (r *Reconciler) ReconcileAPIURL(ctx context.Context, dk *dynakube.DynaKube)
 		return nil
 	}
 
-	apiCommunicationHost, err := connectioninfo.NewCommunicationHost(dk.Spec.APIURL)
+	apiCommunicationHost, err := connectioninfo.NewCommunicationHost(dk.APIURL())
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler.go
@@ -112,6 +112,8 @@ func (r *Reconciler) generateData(dk *dynakube.DynaKube) (map[string]string, err
 }
 
 func BuildOTLPEndpoint(dk dynakube.DynaKube) (string, error) {
+	// dk.APIURL() returns the 2nd gen URL, which is required because OTLP endpoints are
+	// served through the Environment V2 API that is only available on 2nd gen URLs.
 	dtEndpoint := dk.APIURL() + "/v2/otlp"
 
 	if dk.ActiveGate().IsEnabled() {

--- a/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
+++ b/pkg/controllers/dynakube/otelc/endpoint/reconciler_test.go
@@ -108,6 +108,12 @@ func Test_generateData(t *testing.T) {
 			inClusterAg:  false,
 			expectedData: map[string]string{"DT_ENDPOINT": "https://dynatrace.foobar.com/e/abcdefgh-1234-5678-9abc-deadbeef/api/v2/otlp"},
 		},
+		{
+			name:         "3rd gen API URL is mapped to 2nd gen",
+			apiURL:       fmt.Sprintf("https://%s.apps.dynatracelabs.com", testTenantUUID),
+			inClusterAg:  false,
+			expectedData: map[string]string{"DT_ENDPOINT": fmt.Sprintf("https://%s.live.dynatracelabs.com/api/v2/otlp", testTenantUUID)},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/injection/namespace/bootstrapperconfig/endpoints.go
+++ b/pkg/injection/namespace/bootstrapperconfig/endpoints.go
@@ -81,7 +81,7 @@ func ingestURLFor(dk *dynakube.DynaKube) (string, error) {
 }
 
 func metricsIngestURLForDynatraceActiveGate(dk *dynakube.DynaKube) (string, error) {
-	return dk.Spec.APIURL + "/v2/metrics/ingest", nil
+	return dk.APIURL() + "/v2/metrics/ingest", nil
 }
 
 func metricsIngestURLForClusterActiveGate(dk *dynakube.DynaKube) (string, error) {

--- a/pkg/util/dtapiurl/dtapiurl.go
+++ b/pkg/util/dtapiurl/dtapiurl.go
@@ -1,0 +1,64 @@
+// Package dtapiurl provides helpers for working with Dynatrace API URLs,
+// in particular for mapping between 2nd gen and 3rd gen URLs.
+package dtapiurl
+
+import (
+	"net/url"
+	"strings"
+)
+
+const thirdGenAppsHostParts = 2
+
+// isThirdGen reports whether the given hostname belongs to a 3rd gen environment,
+// i.e. it contains the ".apps." segment.
+func isThirdGen(hostname string) bool {
+	return strings.Contains(hostname, ".apps.")
+}
+
+// mapToSecondGen remaps a 3rd gen URL (*.apps.*) to its 2nd gen equivalent in place
+// and sets its path to "/api". URLs that are not 3rd gen are left untouched.
+func mapToSecondGen(u *url.URL) {
+	hostname := u.Hostname()
+
+	parts := strings.SplitN(hostname, ".apps.", thirdGenAppsHostParts)
+	if len(parts) != thirdGenAppsHostParts {
+		return
+	}
+
+	prefix, suffix := parts[0], parts[1]
+
+	var newHostname string
+
+	if !strings.Contains(prefix, ".") {
+		newHostname = prefix + ".live." + suffix
+	} else {
+		newHostname = prefix + "." + suffix
+	}
+
+	if port := u.Port(); port != "" {
+		u.Host = newHostname + ":" + port
+	} else {
+		u.Host = newHostname
+	}
+
+	u.Path = "/api"
+}
+
+// ToSecondGen returns the 2nd gen equivalent of the given API URL string.
+// A 3rd gen URL (*.apps.*) is remapped to its 2nd gen equivalent (including the
+// "/api" path), while a 2nd gen URL is returned unchanged. If the input cannot be
+// parsed, it is returned as-is.
+func ToSecondGen(apiURL string) string {
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return apiURL
+	}
+
+	if !isThirdGen(u.Hostname()) {
+		return apiURL
+	}
+
+	mapToSecondGen(u)
+
+	return u.String()
+}

--- a/pkg/util/dtapiurl/dtapiurl_test.go
+++ b/pkg/util/dtapiurl/dtapiurl_test.go
@@ -1,0 +1,94 @@
+package dtapiurl
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsThirdGen(t *testing.T) {
+	assert.True(t, isThirdGen("tenant.apps.dynatrace.com"))
+	assert.True(t, isThirdGen("tenant.dev.apps.dynatracelabs.com"))
+	assert.False(t, isThirdGen("tenant.live.dynatrace.com"))
+	assert.False(t, isThirdGen("tenant.dynatrace.com"))
+}
+
+func TestMapToSecondGen(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "https://tenant.apps.dynatrace.com",
+			expected: "https://tenant.live.dynatrace.com/api",
+		},
+		{
+			input:    "https://tenant.sprint.apps.dynatrace.com",
+			expected: "https://tenant.sprint.dynatrace.com/api",
+		},
+		{
+			input:    "https://tenant.dev.apps.dynatrace.com",
+			expected: "https://tenant.dev.dynatrace.com/api",
+		},
+		{
+			input:    "https://tenant.apps.dynatrace.com:8443",
+			expected: "https://tenant.live.dynatrace.com:8443/api",
+		},
+		{
+			input:    "https://tenant.sprint.apps.dynatrace.com:9090",
+			expected: "https://tenant.sprint.dynatrace.com:9090/api",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			u, err := url.Parse(tc.input)
+			require.NoError(t, err)
+
+			mapToSecondGen(u)
+			assert.Equal(t, tc.expected, u.String())
+		})
+	}
+}
+
+func TestMapToSecondGenLeavesSecondGenUntouched(t *testing.T) {
+	input := "https://tenant.live.dynatrace.com/api"
+
+	u, err := url.Parse(input)
+	require.NoError(t, err)
+
+	mapToSecondGen(u)
+	assert.Equal(t, input, u.String())
+}
+
+func TestToSecondGen(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "3rd gen url is remapped to 2nd gen",
+			input:    "https://tenant.apps.dynatrace.com",
+			expected: "https://tenant.live.dynatrace.com/api",
+		},
+		{
+			name:     "3rd gen url with subdomain is remapped to 2nd gen",
+			input:    "https://tenant.sprint.apps.dynatrace.com",
+			expected: "https://tenant.sprint.dynatrace.com/api",
+		},
+		{
+			name:     "2nd gen url is returned unchanged",
+			input:    "https://tenant.live.dynatrace.com/api",
+			expected: "https://tenant.live.dynatrace.com/api",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ToSecondGen(tc.input))
+		})
+	}
+}

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -32,7 +32,7 @@ func (h *Handler) createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube)
 	if bootstrapperconfig.NeedsDownloadConfig(&dk) {
 		args = append(args, arg.Arg{
 			Name:  bootstrapper.BaseURL,
-			Value: dk.Spec.APIURL,
+			Value: dk.APIURL(),
 		})
 	}
 

--- a/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/otlp/exporter/mutator_test.go
@@ -288,6 +288,32 @@ func TestMutator_Mutate(t *testing.T) { //nolint:revive // function-length
 		// verify DT_API_TOKEN secret ref env var
 		assertTokenEnvVarIsSet(t, containerEnvVars)
 	})
+	t.Run("3rd gen API URL is mapped to 2nd gen for OTLP exporter endpoints", func(t *testing.T) {
+		m := Mutator{}
+
+		request := createTestMutationRequest(t, getTestDynakube())
+
+		request.DynaKube.Spec.APIURL = "https://tenant.apps.dynatrace.com"
+
+		err := m.Mutate(request)
+
+		require.NoError(t, err)
+
+		containerEnvVars := request.Pod.Spec.Containers[0].Env
+
+		assert.Contains(t, containerEnvVars, corev1.EnvVar{
+			Name:  OTLPTraceEndpointEnv,
+			Value: "https://tenant.live.dynatrace.com/api/v2/otlp/v1/traces",
+		})
+		assert.Contains(t, containerEnvVars, corev1.EnvVar{
+			Name:  OTLPMetricsEndpointEnv,
+			Value: "https://tenant.live.dynatrace.com/api/v2/otlp/v1/metrics",
+		})
+		assert.Contains(t, containerEnvVars, corev1.EnvVar{
+			Name:  OTLPLogsEndpointEnv,
+			Value: "https://tenant.live.dynatrace.com/api/v2/otlp/v1/logs",
+		})
+	})
 	t.Run("no user defined env vars present, only metrics configured, add only metrics OTLP exporter env vars", func(t *testing.T) {
 		m := Mutator{}
 


### PR DESCRIPTION
## Description

We allow 3rd gen URLs, but most if not all components will keep using the 2nd gen form for a while.
Add a new package dtapiurl that handles the conversion and call it from the APIURL DynaKube helper. Validation and conversion will keep using the raw value, but everything else should use the helper to ensure the 2nd gen form is used throughout.
Keep dtapiurl outside the API to reduce the moving target when we introduce the next version.

Changes made by claude.

ICP-6861

## How can this be tested?

Deploy DynaKube with 3rd gen URL
* OTEL + metadata enrichment -> should work
* AG + OTEL + metadata enrichment -> should work
* Any other metrics ingest -> should work
