### PR TITLE
Fix update csv bundles workflow for RC tags

### DIFF
--- a/.github/actions/update-csv-bundles/action.yml
+++ b/.github/actions/update-csv-bundles/action.yml
@@ -40,7 +40,8 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
       run: |
-        MAJOR_MINOR="${VERSION%.*}"
+        BASE_VERSION="${VERSION%%-*}"
+        MAJOR_MINOR="${BASE_VERSION%.*}"
         echo "major_minor=${MAJOR_MINOR}" >> "$GITHUB_OUTPUT"
     - name: Checkout release branch
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/update-csv-bundles.yaml
+++ b/.github/workflows/update-csv-bundles.yaml
@@ -49,7 +49,6 @@ jobs:
           echo "dry-run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ steps.vars.outputs.tag }}
           persist-credentials: false
       - name: Fetch image digest
         id: digest


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-6931](https://dt-rnd.atlassian.net/browse/ICP-6931)

When a pre-release tag (e.g. `v1.10.0-rc.1`) is published, the `Update CSV Bundles` workflow fails immediately with:

```
A branch or tag with the name 'release-1.10.0-rc' could not be found
```


In `.github/actions/update-csv-bundles/action.yml`, `MAJOR_MINOR` is derived using `${VERSION%.*}`, which strips from the **last dot** to the end of the string. For a normal release like `1.10.0` this correctly yields `1.10`. For an RC version like `1.10.0-rc.1`, the last dot-segment is `.1`, so the result is `1.10.0-rc` instead of `1.10`

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Trigger `Update CSV Bundles` via `workflow_dispatch` with an RC tag (e.g. `v1.10.0-rc.1`) and verify the workflow reaches the bundle generation step without failing on the `Checkout release branch` step.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-6931]: https://dt-rnd.atlassian.net/browse/ICP-6931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ