### PR TITLE
IsPublicRegistry feature flag supported by CSI driver provisioner installer selection function

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -225,6 +225,7 @@ test/e2e/usepublicregistry/activegate:
 ## Runs only use-public-registry CodeModules scenarios (with and without publicRegistryOverride, requires no-csi)
 test/e2e/usepublicregistry/codemodules:
 	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "use_public_registry_codemodules" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/standard -run "use_public_registry_codemodules_with_csi" $(SKIPCLEANUP)
 
 test/e2e/usepublicregistry/dbexecutor:
 	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "use_public_registry_db_executor" $(SKIPCLEANUP)

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -48,7 +48,7 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 
 	warningDeprecatedVersionIgnored = `version field is deprecated and ignored. Please remove the version field from the DynaKube specification.`
 
-	errorImagePullRequiresCodeModulesImage = `The DynaKube specification enables node image pull, but the code modules image is not set.`
+	errorImagePullRequiresCodeModulesImage = `The DynaKube specification enables node image pull, but neither a code modules image is set nor a public registry is used.`
 )
 
 func conflictingOneAgentConfiguration(ctx context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -47,6 +47,8 @@ Use a nodeSelector to avoid this conflict. Conflicting DynaKubes: %s`
 	warningDeprecatedVersion = `version field is deprecated. Please use "%s" field instead to set a version.`
 
 	warningDeprecatedVersionIgnored = `version field is deprecated and ignored. Please remove the version field from the DynaKube specification.`
+
+	errorImagePullRequiresCodeModulesImage = `The DynaKube specification enables node image pull, but the code modules image is not set.`
 )
 
 func conflictingOneAgentConfiguration(ctx context.Context, _ *Validator, dk *dynakube.DynaKube) string {
@@ -330,4 +332,14 @@ func findDuplicates[S ~[]E, E comparable](s S) []E {
 	}
 
 	return duplicates
+}
+
+func missingCodeModulesImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
+	if dk.OneAgent().IsAppInjectionNeeded() && dk.FF().IsNodeImagePull() {
+		if dk.OneAgent().GetCustomCodeModulesImage() == "" && !dk.FF().IsPublicRegistry() {
+			return errorImagePullRequiresCodeModulesImage
+		}
+	}
+
+	return ""
 }

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -1175,3 +1175,101 @@ func TestInvalidOneAgentArguments(t *testing.T) {
 		dk.Spec.OneAgent.CloudNativeFullStack.Args = []string{value}
 	}, errorInvalidOneAgentArgument)
 }
+
+func TestMissingCodeModulesImage(t *testing.T) {
+	baseDK := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dynakube",
+			Namespace: testNamespace,
+		},
+		Spec: dynakube.DynaKubeSpec{
+			APIURL: testAPIURL,
+		},
+	}
+
+	testcases := []struct {
+		name        string
+		oaSpec      oneagent.Spec
+		annotations map[string]string
+		isValid     bool
+	}{
+		{
+			"node-image-pull + application monitoring",
+			oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{}},
+			map[string]string{
+				exp.OANodeImagePullKey: "true",
+			},
+			false,
+		},
+		{
+			"node-image-pull + application monitoring + codemodules image",
+			oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+				AppInjectionSpec: oneagent.AppInjectionSpec{
+					CodeModulesImage: "test-image",
+				},
+			}},
+			map[string]string{
+				exp.OANodeImagePullKey: "true",
+			},
+			true,
+		},
+		{
+			"node-image-pull + application monitoring + public registry",
+			oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{
+				AppInjectionSpec: oneagent.AppInjectionSpec{},
+			}},
+			map[string]string{
+				exp.OANodeImagePullKey:   "true",
+				exp.UsePublicRegistryKey: "true",
+			},
+			true,
+		},
+		{
+			"node-image-pull + cloud native full stack",
+			oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{}},
+			map[string]string{
+				exp.OANodeImagePullKey: "true",
+			},
+			false,
+		},
+		{
+			"node-image-pull + cloud native full stack + codemodules image",
+			oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
+				AppInjectionSpec: oneagent.AppInjectionSpec{
+					CodeModulesImage: "test-image",
+				},
+			}},
+			map[string]string{
+				exp.OANodeImagePullKey: "true",
+			},
+			true,
+		},
+		{
+			"node-image-pull + cloud native full stack + public registry",
+			oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{
+				AppInjectionSpec: oneagent.AppInjectionSpec{},
+			}},
+			map[string]string{
+				exp.OANodeImagePullKey:   "true",
+				exp.UsePublicRegistryKey: "true",
+			},
+			true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dk := baseDK.DeepCopy()
+			dk.Annotations = tc.annotations
+			dk.Spec.OneAgent = tc.oaSpec
+
+			if tc.isValid {
+				warnings, err := assertAllowed(t, dk)
+				require.NoError(t, err)
+				assert.Empty(t, warnings)
+			} else {
+				assertDenied(t, []string{errorImagePullRequiresCodeModulesImage}, dk)
+			}
+		})
+	}
+}

--- a/pkg/api/validation/dynakube/oneagent_test.go
+++ b/pkg/api/validation/dynakube/oneagent_test.go
@@ -1264,9 +1264,7 @@ func TestMissingCodeModulesImage(t *testing.T) {
 			dk.Spec.OneAgent = tc.oaSpec
 
 			if tc.isValid {
-				warnings, err := assertAllowed(t, dk)
-				require.NoError(t, err)
-				assert.Empty(t, warnings)
+				assertAllowedWithoutWarnings(t, dk)
 			} else {
 				assertDenied(t, []string{errorImagePullRequiresCodeModulesImage}, dk)
 			}

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -75,6 +75,7 @@ var (
 		publicRegistryNotAllowedForClassic,
 		invalidOneAgentArguments,
 		invalidLogmonArguments,
+		missingCodeModulesImage,
 	}
 	validatorWarningFuncs = []validatorFunc{
 		missingActiveGateMemoryLimit,

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -57,9 +57,8 @@ type jobInstallerBuilder func(context.Context, *job.Properties) installer.Instal
 
 // OneAgentProvisioner reconciles a DynaKube object
 type OneAgentProvisioner struct {
-	apiReader         client.Reader
-	kubeClient        client.Client
-	buildDTClientFunc func(provisioner *OneAgentProvisioner, ctx context.Context, dk *dynakube.DynaKube) (*dynatrace.Client, error)
+	apiReader  client.Reader
+	kubeClient client.Client
 
 	urlInstallerBuilder   binaryInstallerBuilder
 	imageInstallerBuilder imageInstallerBuilder
@@ -75,7 +74,6 @@ func NewOneAgentProvisioner(mgr manager.Manager, opts dtcsi.CSIOptions) *OneAgen
 	return &OneAgentProvisioner{
 		apiReader:             mgr.GetAPIReader(),
 		kubeClient:            mgr.GetClient(),
-		buildDTClientFunc:     buildDtc,
 		path:                  path,
 		urlInstallerBuilder:   binary.NewInstaller,
 		imageInstallerBuilder: image.NewImageInstaller,

--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -57,8 +57,9 @@ type jobInstallerBuilder func(context.Context, *job.Properties) installer.Instal
 
 // OneAgentProvisioner reconciles a DynaKube object
 type OneAgentProvisioner struct {
-	apiReader  client.Reader
-	kubeClient client.Client
+	apiReader         client.Reader
+	kubeClient        client.Client
+	buildDTClientFunc func(provisioner *OneAgentProvisioner, ctx context.Context, dk *dynakube.DynaKube) (*dynatrace.Client, error)
 
 	urlInstallerBuilder   binaryInstallerBuilder
 	imageInstallerBuilder imageInstallerBuilder
@@ -74,6 +75,7 @@ func NewOneAgentProvisioner(mgr manager.Manager, opts dtcsi.CSIOptions) *OneAgen
 	return &OneAgentProvisioner{
 		apiReader:             mgr.GetAPIReader(),
 		kubeClient:            mgr.GetClient(),
+		buildDTClientFunc:     buildDtc,
 		path:                  path,
 		urlInstallerBuilder:   binary.NewInstaller,
 		imageInstallerBuilder: image.NewImageInstaller,

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
-	imageclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/provisioner/cleanup"
@@ -24,7 +22,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/job"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
-	imageclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
 	installermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/injection/codemodule/installer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -173,21 +170,9 @@ func TestReconcile(t *testing.T) {
 		assert.True(t, areFsDirsCreated(t, prov, dk))
 	})
 
-	t.Run("dynakube with public registry => image installer used, no error", func(t *testing.T) {
+	t.Run("dynakube with public registry => image installer used, dtClient not created, no error", func(t *testing.T) {
 		dk := createDynaKubeWithPublicRegistryFF(t)
-		prov := createProvisioner(t, dk, createToken(t, dk))
-
-		prov.buildDTClientFunc = func(provisioner *OneAgentProvisioner, ctx context.Context, dk *dynakube.DynaKube) (*dynatrace.Client, error) {
-			mockImageClient := imageclientmock.NewClient(t)
-			mockImageClient.EXPECT().GetComponentLatestInfo(ctx, imageclient.CodeModules, "").Return(
-				&imageclient.Info{URI: "public.ecr.aws/dynatrace/codemodules:1.0.0@sha256:0123"}, nil,
-			).Once()
-
-			return &dynatrace.Client{
-				Images: mockImageClient,
-			}, nil
-		}
-
+		prov := createProvisioner(t, dk)
 		prov.imageInstallerBuilder = mockImageInstallerBuilder(t, createSuccessfulInstaller(t))
 
 		result, err := prov.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(dk)})
@@ -302,10 +287,9 @@ func createProvisioner(t *testing.T, objs ...client.Object) OneAgentProvisioner 
 	apiReader := fake.NewClient(objs...)
 
 	return OneAgentProvisioner{
-		path:              path,
-		apiReader:         apiReader,
-		cleaner:           cleanup.New(apiReader, path, mount.NewFakeMounter(nil)),
-		buildDTClientFunc: buildDtc,
+		path:      path,
+		apiReader: apiReader,
+		cleaner:   cleanup.New(apiReader, path, mount.NewFakeMounter(nil)),
 	}
 }
 

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -170,6 +170,19 @@ func TestReconcile(t *testing.T) {
 		assert.True(t, areFsDirsCreated(t, prov, dk))
 	})
 
+	t.Run("dynakube with public registry => image installer used, dtClient not created, no error", func(t *testing.T) {
+		dk := createDynaKubeWithPublicRegistryFF(t)
+		prov := createProvisioner(t, dk)
+		prov.imageInstallerBuilder = mockImageInstallerBuilder(t, createSuccessfulInstaller(t))
+
+		result, err := prov.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(dk)})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, defaultRequeueDuration, result.RequeueAfter)
+
+		assert.True(t, areFsDirsCreated(t, prov, dk))
+	})
+
 	t.Run("dynakube with job => job installer used, dtClient not created, no error", func(t *testing.T) {
 		dk := createDynaKubeWithJobFF(t)
 		prov := createProvisioner(t, dk)
@@ -323,6 +336,22 @@ func createDynaKubeWithJobFF(t *testing.T) *dynakube.DynaKube {
 	dk.Status.CodeModules.ImageID = imageID
 	dk.Annotations = map[string]string{
 		exp.OANodeImagePullKey: "true",
+	}
+
+	return dk
+}
+
+func createDynaKubeWithPublicRegistryFF(t *testing.T) *dynakube.DynaKube {
+	t.Helper()
+
+	dk := createDynaKubeBase(t)
+	imageID := "test-image"
+	dk.Spec.OneAgent = oneagent.Spec{
+		CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},
+	}
+	dk.Status.CodeModules.ImageID = imageID
+	dk.Annotations = map[string]string{
+		exp.UsePublicRegistryKey: "true",
 	}
 
 	return dk

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -3,9 +3,7 @@ package csiprovisioner
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -14,7 +12,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
+	imageclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/provisioner/cleanup"
@@ -24,6 +24,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/job"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
+	imageclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
 	installermock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/injection/codemodule/installer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -173,15 +174,20 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("dynakube with public registry => image installer used, no error", func(t *testing.T) {
-		imageURI := "public.ecr.aws/dynatrace/codemodules:1.0.0"
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"components":[{"type":"codemodules","imageUri":%q}]}`, imageURI)
-		}))
-		t.Cleanup(server.Close)
-
-		dk := createDynaKubeWithPublicRegistryFF(t, server.URL)
+		dk := createDynaKubeWithPublicRegistryFF(t)
 		prov := createProvisioner(t, dk, createToken(t, dk))
+
+		prov.buildDTClientFunc = func(provisioner *OneAgentProvisioner, ctx context.Context, dk *dynakube.DynaKube) (*dynatrace.Client, error) {
+			mockImageClient := imageclientmock.NewClient(t)
+			mockImageClient.EXPECT().GetComponentLatestInfo(ctx, imageclient.CodeModules, "").Return(
+				&imageclient.Info{URI: "public.ecr.aws/dynatrace/codemodules:1.0.0@sha256:0123"}, nil,
+			).Once()
+
+			return &dynatrace.Client{
+				Images: mockImageClient,
+			}, nil
+		}
+
 		prov.imageInstallerBuilder = mockImageInstallerBuilder(t, createSuccessfulInstaller(t))
 
 		result, err := prov.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(dk)})
@@ -296,9 +302,10 @@ func createProvisioner(t *testing.T, objs ...client.Object) OneAgentProvisioner 
 	apiReader := fake.NewClient(objs...)
 
 	return OneAgentProvisioner{
-		path:      path,
-		apiReader: apiReader,
-		cleaner:   cleanup.New(apiReader, path, mount.NewFakeMounter(nil)),
+		path:              path,
+		apiReader:         apiReader,
+		cleaner:           cleanup.New(apiReader, path, mount.NewFakeMounter(nil)),
+		buildDTClientFunc: buildDtc,
 	}
 }
 
@@ -350,11 +357,10 @@ func createDynaKubeWithJobFF(t *testing.T) *dynakube.DynaKube {
 	return dk
 }
 
-func createDynaKubeWithPublicRegistryFF(t *testing.T, apiURL string) *dynakube.DynaKube {
+func createDynaKubeWithPublicRegistryFF(t *testing.T) *dynakube.DynaKube {
 	t.Helper()
 
 	dk := createDynaKubeBase(t)
-	dk.Spec.APIURL = apiURL
 	imageID := "test-image"
 	dk.Spec.OneAgent = oneagent.Spec{
 		CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},

--- a/pkg/controllers/csi/provisioner/controller_test.go
+++ b/pkg/controllers/csi/provisioner/controller_test.go
@@ -3,7 +3,9 @@ package csiprovisioner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -170,9 +172,16 @@ func TestReconcile(t *testing.T) {
 		assert.True(t, areFsDirsCreated(t, prov, dk))
 	})
 
-	t.Run("dynakube with public registry => image installer used, dtClient not created, no error", func(t *testing.T) {
-		dk := createDynaKubeWithPublicRegistryFF(t)
-		prov := createProvisioner(t, dk)
+	t.Run("dynakube with public registry => image installer used, no error", func(t *testing.T) {
+		imageURI := "public.ecr.aws/dynatrace/codemodules:1.0.0"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"components":[{"type":"codemodules","imageUri":%q}]}`, imageURI)
+		}))
+		t.Cleanup(server.Close)
+
+		dk := createDynaKubeWithPublicRegistryFF(t, server.URL)
+		prov := createProvisioner(t, dk, createToken(t, dk))
 		prov.imageInstallerBuilder = mockImageInstallerBuilder(t, createSuccessfulInstaller(t))
 
 		result, err := prov.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(dk)})
@@ -341,10 +350,11 @@ func createDynaKubeWithJobFF(t *testing.T) *dynakube.DynaKube {
 	return dk
 }
 
-func createDynaKubeWithPublicRegistryFF(t *testing.T) *dynakube.DynaKube {
+func createDynaKubeWithPublicRegistryFF(t *testing.T, apiURL string) *dynakube.DynaKube {
 	t.Helper()
 
 	dk := createDynaKubeBase(t)
+	dk.Spec.APIURL = apiURL
 	imageID := "test-image"
 	dk.Spec.OneAgent = oneagent.Spec{
 		CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{},

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -73,7 +73,7 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 
 		return imageInstaller, nil
 	case dk.FF().IsPublicRegistry():
-		dtClient, err := buildDtc(provisioner, ctx, dk)
+		dtClient, err := provisioner.buildDTClientFunc(provisioner, ctx, dk)
 		if err != nil {
 			return nil, err
 		}
@@ -101,7 +101,7 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 
 		return imageInstaller, nil
 	default:
-		dtClient, err := buildDtc(provisioner, ctx, dk)
+		dtClient, err := provisioner.buildDTClientFunc(provisioner, ctx, dk)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -71,6 +71,26 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 		}
 
 		return imageInstaller, nil
+	case dk.FF().IsPublicRegistry():
+		imageURI := dk.OneAgent().GetCodeModulesImage()
+
+		if imageURI == "" {
+			imageURI = "public.ecr.aws/dynatrace/dynatrace-codemodules:" + dk.OneAgent().GetCodeModulesVersion()
+		}
+
+		props := &image.Properties{
+			ImageURI:     imageURI,
+			APIReader:    provisioner.apiReader,
+			Dynakube:     dk,
+			PathResolver: provisioner.path,
+		}
+
+		imageInstaller, err := provisioner.imageInstallerBuilder(ctx, props)
+		if err != nil {
+			return nil, err
+		}
+
+		return imageInstaller, nil
 	default:
 		dtClient, err := buildDtc(provisioner, ctx, dk)
 		if err != nil {

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
-	imageclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	installerclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/binary"
@@ -58,7 +57,7 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 	switch {
 	case dk.FF().IsNodeImagePull():
 		return provisioner.getJobInstaller(ctx, dk), nil
-	case dk.OneAgent().GetCustomCodeModulesImage() != "":
+	case dk.OneAgent().GetCodeModulesImage() != "":
 		props := &image.Properties{
 			ImageURI:     dk.OneAgent().GetCodeModulesImage(),
 			APIReader:    provisioner.apiReader,
@@ -72,36 +71,8 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 		}
 
 		return imageInstaller, nil
-	case dk.FF().IsPublicRegistry():
-		dtClient, err := provisioner.buildDTClientFunc(provisioner, ctx, dk)
-		if err != nil {
-			return nil, err
-		}
-
-		imageInfo, err := dtClient.Images.GetComponentLatestInfo(ctx, imageclient.CodeModules, dk.PublicRegistryOverride())
-		if err != nil {
-			return nil, err
-		}
-
-		if imageInfo.URI == "" {
-			return nil, errors.New("codemodules public image not available")
-		}
-
-		props := &image.Properties{
-			ImageURI:     imageInfo.URI,
-			APIReader:    provisioner.apiReader,
-			Dynakube:     dk,
-			PathResolver: provisioner.path,
-		}
-
-		imageInstaller, err := provisioner.imageInstallerBuilder(ctx, props)
-		if err != nil {
-			return nil, err
-		}
-
-		return imageInstaller, nil
 	default:
-		dtClient, err := provisioner.buildDTClientFunc(provisioner, ctx, dk)
+		dtClient, err := buildDtc(provisioner, ctx, dk)
 		if err != nil {
 			return nil, err
 		}
@@ -124,19 +95,8 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 }
 
 func (provisioner *OneAgentProvisioner) getJobInstaller(ctx context.Context, dk *dynakube.DynaKube) installer.Installer {
-	imageURI := dk.OneAgent().GetCustomCodeModulesImage()
-
-	if imageURI == "" && dk.FF().IsPublicRegistry() {
-		// Resolved by the version updater; respects PublicRegistryOverride
-		imageURI = dk.OneAgent().GetCodeModulesImage()
-	}
-
-	if imageURI == "" {
-		imageURI = "public.ecr.aws/dynatrace/dynatrace-codemodules:" + dk.OneAgent().GetCodeModulesVersion()
-	}
-
 	props := &job.Properties{
-		ImageURI:        imageURI,
+		ImageURI:        dk.OneAgent().GetCodeModulesImage(),
 		ImagePullPolicy: dk.OneAgent().GetCodeModulesImagePullPolicy(),
 		Owner:           dk,
 		PullSecrets:     dk.PullSecretNames(),

--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/arch"
+	imageclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	installerclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/binary"
@@ -72,14 +73,22 @@ func (provisioner *OneAgentProvisioner) getInstaller(ctx context.Context, dk *dy
 
 		return imageInstaller, nil
 	case dk.FF().IsPublicRegistry():
-		imageURI := dk.OneAgent().GetCodeModulesImage()
+		dtClient, err := buildDtc(provisioner, ctx, dk)
+		if err != nil {
+			return nil, err
+		}
 
-		if imageURI == "" {
-			imageURI = "public.ecr.aws/dynatrace/dynatrace-codemodules:" + dk.OneAgent().GetCodeModulesVersion()
+		imageInfo, err := dtClient.Images.GetComponentLatestInfo(ctx, imageclient.CodeModules, dk.PublicRegistryOverride())
+		if err != nil {
+			return nil, err
+		}
+
+		if imageInfo.URI == "" {
+			return nil, errors.New("codemodules public image not available")
 		}
 
 		props := &image.Properties{
-			ImageURI:     imageURI,
+			ImageURI:     imageInfo.URI,
 			APIReader:    provisioner.apiReader,
 			Dynakube:     dk,
 			PathResolver: provisioner.path,

--- a/test/e2e/features/usepublicregistry/deploy.go
+++ b/test/e2e/features/usepublicregistry/deploy.go
@@ -297,7 +297,7 @@ func isProvisionerUsingPublicRegistry(namespace string, imageID *string) feature
 		err := k8sdaemonset.NewQuery(ctx, resource, client.ObjectKey{
 			Name:      csi.DaemonSetName,
 			Namespace: namespace,
-		}).ForEachPod(checkProvisionerLog(ctx, t, envConfig, imageID))
+		}).ForEachPod(checkProvisionerLog(ctx, t, envConfig, *imageID))
 
 		assert.NoError(t, err)
 
@@ -305,7 +305,7 @@ func isProvisionerUsingPublicRegistry(namespace string, imageID *string) feature
 	}
 }
 
-func checkProvisionerLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, imageID *string) k8sdaemonset.PodConsumer {
+func checkProvisionerLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, imageID string) k8sdaemonset.PodConsumer {
 	return func(pod corev1.Pod) {
 		provisionerLog := logs.ReadLog(ctx, t, envConfig, pod.Namespace, pod.Name, "provisioner")
 
@@ -318,7 +318,7 @@ func checkProvisionerLog(ctx context.Context, t *testing.T, envConfig *envconf.C
 			String string `json:"ref.String"`
 		}
 		require.NoError(t, json.Unmarshal([]byte(msg), &ref))
-		assert.Equal(t, *imageID, ref.String)
+		assert.Equal(t, imageID, ref.String)
 	}
 }
 

--- a/test/e2e/features/usepublicregistry/deploy.go
+++ b/test/e2e/features/usepublicregistry/deploy.go
@@ -4,6 +4,7 @@ package usepublicregistry
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/csi"
 	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sdaemonset"
@@ -24,6 +26,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8snamespace"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8ssecret"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/logs"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/platform"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/registry"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/sample"
@@ -33,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -97,6 +101,14 @@ func CodeModulesWithOverride(t *testing.T) features.Feature {
 		"use-public-registry-cm-ovrd",
 		"use-public-registry-cm-sample-ovrd",
 		publicRegistryOverride(t))
+}
+
+func CodeModulesWithCSI(t *testing.T) features.Feature {
+	return codeModulesWithCSIFeature(t,
+		"use-public-registry-codemodules-with-csi",
+		"use-public-registry-cm",
+		"use-public-registry-cm-sample",
+		"")
 }
 
 func DBExecutor(t *testing.T) features.Feature {
@@ -228,6 +240,86 @@ func codeModulesFeature(t *testing.T, featureName, dkName, sampleNamespaceName, 
 	builder.Teardown(sampleApp.Uninstall())
 
 	return builder.Feature()
+}
+
+func codeModulesWithCSIFeature(t *testing.T, featureName, dkName, sampleNamespaceName, override string) features.Feature {
+	builder := features.New(featureName)
+	builder.Assess("devregistry pull secret exists", requireDevRegistrySecret())
+
+	secretConfig := tenant.GetSingleTenantSecret(t)
+
+	options := []dynakubeComponents.Option{
+		dynakubeComponents.WithName(dkName),
+		dynakubeComponents.WithAPIURL(secretConfig.APIURL),
+		dynakubeComponents.WithApplicationMonitoringSpec(&oneagent.ApplicationMonitoringSpec{}),
+	}
+	if override != "" {
+		options = append(options, dynakubeComponents.WithPublicRegistryOverride(override))
+	}
+	if !tenant.UsePlatformToken() {
+		options = append(options, dynakubeComponents.WithUsePublicRegistryFF())
+	}
+
+	testDynakube := *dynakubeComponents.New(options...)
+
+	sampleNamespace := *k8snamespace.New(sampleNamespaceName)
+	sampleApp := sample.NewApp(t, &testDynakube,
+		sample.AsDeployment(),
+		sample.WithNamespace(sampleNamespace),
+		// The injected init container image is pulled by kubelet from the user's
+		// namespace, so the user's pod must reference the registry pull secret.
+		sample.WithImagePullSecret(consts.DevRegistryPullSecretName),
+	)
+
+	builder.Assess("create sample namespace", sampleApp.InstallNamespace())
+
+	dynakubeComponents.Install(builder, &secretConfig, testDynakube)
+
+	builder.Assess("install sample app", sampleApp.Install())
+	builder.Assess("CodeModules status reports public-registry source",
+		statusSourceIsPublicRegistry(testDynakube, image.CodeModules))
+
+	var imageID string
+
+	builder.Assess("get CodeModules imageID", getStatusImageID(testDynakube, image.CodeModules, &imageID))
+
+	builder.Assess("verify if CSI provisioner uses public-registry image", isProvisionerUsingPublicRegistry(testDynakube.Namespace, &imageID))
+
+	builder.Teardown(sampleApp.Uninstall())
+
+	return builder.Feature()
+}
+
+func isProvisionerUsingPublicRegistry(namespace string, imageID *string) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resource := envConfig.Client().Resources()
+
+		err := k8sdaemonset.NewQuery(ctx, resource, client.ObjectKey{
+			Name:      csi.DaemonSetName,
+			Namespace: namespace,
+		}).ForEachPod(checkProvisionerLog(ctx, t, envConfig, imageID))
+
+		assert.NoError(t, err)
+
+		return ctx
+	}
+}
+
+func checkProvisionerLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, imageID *string) k8sdaemonset.PodConsumer {
+	return func(pod corev1.Pod) {
+		provisionerLog := logs.ReadLog(ctx, t, envConfig, pod.Namespace, pod.Name, "provisioner")
+
+		// expected message: `{"level":"info",...,"msg":"pullOciImage",...,"ref.String":"<registry>:<version>@sha256:<sha256>"}`
+
+		msg := logs.FindLineContainingText(provisionerLog, "pullOciImage")
+		require.NotEmpty(t, msg, "pullOciImage message not found in the provisioner log for %s", pod.Name)
+
+		var ref struct {
+			String string `json:"ref.String"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(msg), &ref))
+		assert.Equal(t, *imageID, ref.String)
+	}
 }
 
 func dbExecutorFeature(t *testing.T, featureName, dkName, override string) features.Feature {
@@ -421,6 +513,29 @@ func statusSourceIs(dk dynakube.DynaKube, component image.ComponentType, expecte
 
 		assert.Equalf(t, expected, actual,
 			"expected %s status.source == %q, got %q", component, expected, actual)
+
+		return ctx
+	}
+}
+
+func getStatusImageID(dk dynakube.DynaKube, component image.ComponentType, imageID *string) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var current dynakube.DynaKube
+		require.NoError(t,
+			envConfig.Client().Resources().Get(ctx, dk.Name, dk.Namespace, &current))
+
+		switch component {
+		case image.OneAgent:
+			*imageID = current.Status.OneAgent.ImageID
+		case image.ActiveGate:
+			*imageID = current.Status.ActiveGate.ImageID
+		case image.CodeModules:
+			*imageID = current.Status.CodeModules.ImageID
+		default:
+			require.Failf(t, "unknown component", "unknown component %q", component)
+
+			return ctx
+		}
 
 		return ctx
 	}

--- a/test/e2e/features/usepublicregistry/deploy.go
+++ b/test/e2e/features/usepublicregistry/deploy.go
@@ -281,7 +281,7 @@ func codeModulesWithCSIFeature(t *testing.T, featureName, dkName, sampleNamespac
 
 	var imageID string
 
-	builder.Assess("get CodeModules imageID", getStatusImageID(testDynakube, image.CodeModules, &imageID))
+	builder.Assess("get CodeModules imageID", getStatusCodeModulesImageID(testDynakube, &imageID))
 
 	builder.Assess("verify if CSI provisioner uses public-registry image", isProvisionerUsingPublicRegistry(testDynakube.Namespace, &imageID))
 
@@ -518,24 +518,15 @@ func statusSourceIs(dk dynakube.DynaKube, component image.ComponentType, expecte
 	}
 }
 
-func getStatusImageID(dk dynakube.DynaKube, component image.ComponentType, imageID *string) features.Func {
+func getStatusCodeModulesImageID(dk dynakube.DynaKube, imageID *string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		var current dynakube.DynaKube
 		require.NoError(t,
 			envConfig.Client().Resources().Get(ctx, dk.Name, dk.Namespace, &current))
 
-		switch component {
-		case image.OneAgent:
-			*imageID = current.Status.OneAgent.ImageID
-		case image.ActiveGate:
-			*imageID = current.Status.ActiveGate.ImageID
-		case image.CodeModules:
-			*imageID = current.Status.CodeModules.ImageID
-		default:
-			require.Failf(t, "unknown component", "unknown component %q", component)
+		*imageID = current.Status.CodeModules.ImageID
 
-			return ctx
-		}
+		assert.NotEmpty(t, *imageID)
 
 		return ctx
 	}

--- a/test/e2e/scenarios/standard/standard_test.go
+++ b/test/e2e/scenarios/standard/standard_test.go
@@ -91,6 +91,10 @@ func TestStandard_use_public_registry_activegate_with_override(t *testing.T) {
 	testEnv.Test(t, usepublicregistry.ActiveGateWithOverride(t))
 }
 
+func TestStandard_use_public_registry_codemodules_with_csi(t *testing.T) {
+	testEnv.Test(t, usepublicregistry.CodeModulesWithCSI(t))
+}
+
 func TestStandard_cloudnative_disabled_auto_inject(t *testing.T) {
 	testEnv.Test(t, noInjection.Feature(t))
 }


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-6944)

## Description

The CSI driver provisioner's getInstaller function uses a public registry image when IsPublicRegistry is enabled (via feature flag or platform token).

The node-image-pull FF only allowed when codeModulesImage is set or public registry is enabled.

The case
```
	case dk.OneAgent().GetCodeModulesImage() != "":
```
covers `dk.OneAgent().GetCustomCodeModulesImage() != ""` and ` dk.FF().IsPublicRegistry` conditions. In both cases status.ImageID is set.

## How can this be tested?

unittests

standard e2e tests
```
go test -v -count 1 -tags e2e -timeout 200m ./test/e2e/scenarios/standard -run "use_public_registry_codemodules_with_csi" 
 ```