### PR TITLE
Add data ingest platform token to the tests

### DIFF
--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -41,6 +41,9 @@ inputs:
   tenant1-platform-token-nosettings:
     description: The platform token of Tenant 1 without settings scope
     required: true
+  tenant1-dataingest-platform-token:
+    description: The data ingest platform token of Tenant 1
+    required: true
   tenant2-name:
     description: The name of Tenant 2
     required: true
@@ -136,6 +139,7 @@ runs:
         TENANT1_OAUTH_URN: ${{ inputs.tenant1-oauth-urn }}
         TENANT1_PLATFORM_TOKEN: ${{ inputs.tenant1-platform-token }}
         TENANT1_PLATFORM_TOKEN_NOSETTINGS: ${{ inputs.tenant1-platform-token-nosettings }}
+        TENANT1_DATAINGEST_PLATFORM_TOKEN: ${{ inputs.tenant1-dataingest-platform-token }}
         TENANT2_NAME: ${{ inputs.tenant2-name }}
         TENANT2_APITOKEN: ${{ inputs.tenant2-apitoken }}
         TENANT2_DATAINGESTTOKEN: ${{ inputs.tenant2-dataingesttoken }}

--- a/.github/scripts/prepare-e2e-secrets.sh
+++ b/.github/scripts/prepare-e2e-secrets.sh
@@ -15,6 +15,7 @@ apiTokenNoSettings: $TENANT1_APITOKEN_NOSETTINGS
 dataIngestToken: $TENANT1_DATAINGESTTOKEN
 platformToken: $TENANT1_PLATFORM_TOKEN
 platformTokenNoSettings: $TENANT1_PLATFORM_TOKEN_NOSETTINGS
+dataIngestPlatformToken: $TENANT1_DATAINGEST_PLATFORM_TOKEN
 EOF
 
   cat << EOF > multi-tenant.yaml

--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -101,6 +101,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -93,6 +93,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
@@ -142,6 +143,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
@@ -191,6 +193,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
@@ -239,6 +242,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
@@ -288,6 +292,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
@@ -336,6 +341,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}
@@ -384,6 +390,7 @@ jobs:
           tenant1-oauth-urn: ${{ secrets.TENANT1_OAUTH_URN }}
           tenant1-platform-token: ${{ secrets.TENANT1_PLATFORM_TOKEN }}
           tenant1-platform-token-nosettings: ${{ secrets.TENANT1_PLATFORM_TOKEN_NOSETTINGS }}
+          tenant1-dataingest-platform-token: ${{ secrets.TENANT1_DATAINGEST_PLATFORM_TOKEN }}
           tenant2-name: ${{ secrets.TENANT2_NAME }}
           tenant2-apitoken: ${{ secrets.TENANT2_APITOKEN }}
           tenant2-dataingesttoken: ${{ secrets.TENANT2_DATAINGESTTOKEN }}

--- a/test/e2e/helpers/tenant/secrets.go
+++ b/test/e2e/helpers/tenant/secrets.go
@@ -38,6 +38,7 @@ type Secret struct {
 	APITokenNoSettings      string `yaml:"apiTokenNoSettings"`
 	PlatformToken           string `yaml:"platformToken"`
 	PlatformTokenNoSettings string `yaml:"platformTokenNoSettings"`
+	DataIngestPlatformToken string `yaml:"dataIngestPlatformToken"`
 }
 
 type Tokens struct {
@@ -56,7 +57,7 @@ type EdgeConnectSecret struct {
 
 func (s Secret) TokensWithSettingsScope() Tokens {
 	if UsePlatformToken() {
-		return Tokens{APIToken: s.PlatformToken, DataIngestToken: s.DataIngestToken}
+		return Tokens{APIToken: s.PlatformToken, DataIngestToken: s.DataIngestPlatformToken}
 	}
 
 	return Tokens{APIToken: s.APIToken, DataIngestToken: s.DataIngestToken}
@@ -64,14 +65,14 @@ func (s Secret) TokensWithSettingsScope() Tokens {
 
 func (s Secret) TokensWithoutSettingsScope() Tokens {
 	if UsePlatformToken() {
-		return Tokens{APIToken: s.PlatformTokenNoSettings, DataIngestToken: s.DataIngestToken}
+		return Tokens{APIToken: s.PlatformTokenNoSettings, DataIngestToken: s.DataIngestPlatformToken}
 	}
 
 	return Tokens{APIToken: s.APITokenNoSettings, DataIngestToken: s.DataIngestToken}
 }
 
 func (s Secret) PlatformTokens() Tokens {
-	return Tokens{APIToken: s.PlatformToken, DataIngestToken: s.DataIngestToken}
+	return Tokens{APIToken: s.PlatformToken, DataIngestToken: s.DataIngestPlatformToken}
 }
 
 func (s Secret) ClassicTokens() Tokens {

--- a/test/e2e/testdata/secrets-samples/single-tenant.yaml
+++ b/test/e2e/testdata/secrets-samples/single-tenant.yaml
@@ -5,3 +5,4 @@ apiTokenNoSettings: <apiToken without settings scopes>
 dataIngestToken: <apiToken>
 platformToken: <platformToken>
 platformTokenNoSettings: <platformToken without settings scopes>
+dataIngestPlatformToken: <platformToken>


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
The data ingest token can be either type, also platform token. Currently the test suite doesn't cover the platform token case for data ingest. This PR adapts the pipeline and code to run tests with data ingest platform token aswell.
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Trigger e2e tests
`make test/e2e/telemetryingest/platform-token`
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->