### PR TITLE
Do not create/attach tenant pull-secret when public-registry FF is used (#6926)

### DIFF
--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -132,7 +132,7 @@ func (dk *DynaKube) CustomPullSecretReferences() []corev1.LocalObjectReference {
 func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
 	var refs []corev1.LocalObjectReference
 
-	if !ptr.Deref(dk.Status.APIToken.Platform, false) {
+	if !ptr.Deref(dk.Status.APIToken.Platform, false) || !dk.FF().IsPublicRegistry() {
 		refs = append(refs, dk.TenantRegistryPullSecretReferences()...)
 	}
 

--- a/pkg/api/latest/dynakube/dynakube_props_test.go
+++ b/pkg/api/latest/dynakube/dynakube_props_test.go
@@ -19,6 +19,7 @@ package dynakube
 import (
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,6 +144,18 @@ func TestImagePullSecretReferences(t *testing.T) {
 		refs := dk.ImagePullSecretReferences()
 		assert.Len(t, refs, 1)
 		assert.Equal(t, testCustomPullSecret, refs[0].Name)
+	})
+	t.Run("don't return tenant pull secret if use-public-registry annotation with platform token", func(t *testing.T) {
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        testDKName,
+				Annotations: map[string]string{exp.UsePublicRegistryKey: "true"},
+			},
+			Status: DynaKubeStatus{APIToken: APITokenStatus{Platform: new(true)}},
+		}
+		refs := dk.ImagePullSecretReferences()
+		assert.Empty(t, refs)
 	})
 }
 

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -33,7 +33,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	ctx, log := logd.NewFromContext(ctx, "pullsecret")
 
-	if tokens.HasPlatformToken() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
+	if tokens.HasPlatformToken() || dk.FF().IsPublicRegistry() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
@@ -226,6 +227,68 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		err = r.Reconcile(t.Context(), dk, token.Tokens{
 			token.APIKey: &token.Token{Value: testPlatformToken},
+		})
+		require.NoError(t, err)
+
+		err = fakeClient.Get(t.Context(),
+			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
+			&pullSecret)
+
+		assert.True(t, k8serrors.IsNotFound(err))
+		assert.Empty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
+	})
+	t.Run("Don't create if use-public-registry annotation", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   testNamespace,
+				Name:        testName,
+				Annotations: map[string]string{exp.UsePublicRegistryKey: "true"},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL:   testAPIURL,
+				OneAgent: oneagent.Spec{CloudNativeFullStack: &oneagent.CloudNativeFullStackSpec{}},
+			},
+		}
+		fakeClient := fake.NewClient()
+		tokens := token.Tokens{
+			token.APIKey: &token.Token{Value: testValue},
+		}
+
+		r := NewReconciler(fakeClient, fakeClient)
+		err := r.Reconcile(t.Context(), dk, tokens)
+		require.NoError(t, err)
+
+		assert.Empty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
+
+		var pullSecret corev1.Secret
+		err = fakeClient.Get(t.Context(),
+			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
+			&pullSecret)
+
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+	t.Run("Cleanup if use-public-registry annotation works", func(t *testing.T) {
+		dk := createTestDynakube()
+		fakeClient := fake.NewClient()
+
+		r := NewReconciler(fakeClient, fakeClient)
+		err := r.Reconcile(t.Context(), dk, token.Tokens{
+			token.APIKey: &token.Token{Value: testValue},
+		})
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType))
+
+		var pullSecret corev1.Secret
+		err = fakeClient.Get(t.Context(),
+			client.ObjectKey{Name: testName + "-pull-secret", Namespace: testNamespace},
+			&pullSecret)
+
+		require.NoError(t, err)
+
+		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+		err = r.Reconcile(t.Context(), dk, token.Tokens{
+			token.APIKey: &token.Token{Value: testValue},
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Description

[ICP-7075](https://dt-rnd.atlassian.net/browse/ICP-7075)

cherry pick of #6926

## How can this be tested?

same as #6926

[ICP-7075]: https://dt-rnd.atlassian.net/browse/ICP-7075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ