### PR TITLE
Always read token secret for validation

### DIFF
--- a/pkg/api/validation/dynakube/databases.go
+++ b/pkg/api/validation/dynakube/databases.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/extension/databases"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -32,12 +31,6 @@ func missingDatabaseExecutorImage(ctx context.Context, dv *Validator, dk *dynaku
 	}
 
 	if dk.FF().IsPublicRegistry() {
-		return ""
-	}
-
-	// For new DynaKubes (status not yet set), check the token secret directly.
-	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-	if err == nil && hasPlatformToken {
 		return ""
 	}
 

--- a/pkg/api/validation/dynakube/eec.go
+++ b/pkg/api/validation/dynakube/eec.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -24,12 +23,6 @@ func extensionControllerImage(ctx context.Context, dv *Validator, dk *dynakube.D
 	}
 
 	if dk.FF().IsPublicRegistry() {
-		return ""
-	}
-
-	// For new DynaKubes (status not yet set), check the token secret directly.
-	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-	if err == nil && hasPlatformToken {
 		return ""
 	}
 

--- a/pkg/api/validation/dynakube/logmonitoring.go
+++ b/pkg/api/validation/dynakube/logmonitoring.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
@@ -33,12 +32,6 @@ func missingLogMonitoringImage(ctx context.Context, dv *Validator, dk *dynakube.
 	}
 
 	if dk.FF().IsPublicRegistry() {
-		return ""
-	}
-
-	// For new DynaKubes (status not yet set), check the token secret directly.
-	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-	if err == nil && hasPlatformToken {
 		return ""
 	}
 

--- a/pkg/api/validation/dynakube/oneagent.go
+++ b/pkg/api/validation/dynakube/oneagent.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -300,12 +299,6 @@ func deprecatedOneAgentVersionField(ctx context.Context, dv *Validator, dk *dyna
 
 	if oa.GetCustomVersion() != "" {
 		if dk.FF().IsPublicRegistry() {
-			return warningDeprecatedVersionIgnored
-		}
-
-		// For new DynaKubes (status not yet set), check the token secret directly.
-		hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-		if err == nil && hasPlatformToken {
 			return warningDeprecatedVersionIgnored
 		}
 

--- a/pkg/api/validation/dynakube/public_registry.go
+++ b/pkg/api/validation/dynakube/public_registry.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -20,12 +20,6 @@ func publicRegistryOverrideWithoutPublicRegistry(ctx context.Context, dv *Valida
 		return ""
 	}
 
-	// For new DynaKubes (status not yet set), check the token secret directly.
-	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-	if err == nil && hasPlatformToken {
-		return ""
-	}
-
 	return fmt.Sprintf(errorPublicRegistryOverrideWithoutPublicRegistry, exp.UsePublicRegistryKey)
 }
 
@@ -34,8 +28,7 @@ func publicRegistryFlagIgnoredForPlatformToken(ctx context.Context, dv *Validato
 		return ""
 	}
 
-	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-	if err != nil || !hasPlatformToken {
+	if !ptr.Deref(dk.Status.APIToken.Platform, false) {
 		return ""
 	}
 
@@ -48,12 +41,6 @@ func publicRegistryNotAllowedForClassic(ctx context.Context, dv *Validator, dk *
 	}
 
 	if dk.PublicRegistryOverride() != "" || dk.FF().IsPublicRegistry() {
-		return errorClassicFullStackIncompatibleWithPublicRegistry
-	}
-
-	// For new DynaKubes (status not yet set), check the token secret directly.
-	hasPlatformToken, err := token.NewReader(dv.apiReader, dk).HasPlatformToken(ctx)
-	if err == nil && hasPlatformToken {
 		return errorClassicFullStackIncompatibleWithPublicRegistry
 	}
 

--- a/pkg/api/validation/dynakube/validation.go
+++ b/pkg/api/validation/dynakube/validation.go
@@ -9,6 +9,7 @@ import (
 	v1beta4 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta4/dynakube"
 	v1beta5 "github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta5/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/validation"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/installconfig"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -125,6 +126,9 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (war
 		return
 	}
 
+	hasPlatformToken, _ := token.NewReader(v.apiReader, dk).HasPlatformToken(ctx)
+	dk.Status.APIToken.Platform = new(hasPlatformToken)
+
 	errMessages := v.runValidators(ctx, validatorErrorFuncs, dk)
 	warnings = v.runValidators(ctx, validatorWarningFuncs, dk)
 
@@ -147,6 +151,9 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	if err != nil {
 		return
 	}
+
+	hasPlatformToken, _ := token.NewReader(v.apiReader, newDK).HasPlatformToken(ctx)
+	newDK.Status.APIToken.Platform = new(hasPlatformToken)
 
 	errMessages := v.runValidators(ctx, validatorErrorFuncs, newDK)
 	warnings = v.runValidators(ctx, validatorWarningFuncs, newDK)


### PR DESCRIPTION
## Description

Read the token secret before running validators and set the value of `status.apiToken.platform` accordingly for the individual admission request.
Do this once per entrypoint, so that the validators themselves don't do duplicate work.

This is needed to prevent users switching from a platform token to a classic token from keeping features that are exclusive to platform tokens.

ICP-7129

## How can this be tested?

Deploy DynaKubes with platform token and switch back to classic token while enabling features that require a platform token
