### PR TITLE
Remove hard limit from resource attributes

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -5871,7 +5871,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       codeModulesImage:
                         type: string
@@ -5949,7 +5948,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6138,7 +6136,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6396,7 +6393,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6585,7 +6581,6 @@ spec:
                   additionalResourceAttributes:
                     additionalProperties:
                       type: string
-                    maxProperties: 10
                     type: object
                   namespaceSelector:
                     properties:
@@ -6639,7 +6634,6 @@ spec:
               resourceAttributes:
                 additionalProperties:
                   type: string
-                maxProperties: 10
                 type: object
               skipCertCheck:
                 type: boolean

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -5884,7 +5884,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       codeModulesImage:
                         type: string
@@ -5962,7 +5961,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6151,7 +6149,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6409,7 +6406,6 @@ spec:
                       additionalResourceAttributes:
                         additionalProperties:
                           type: string
-                        maxProperties: 10
                         type: object
                       annotations:
                         additionalProperties:
@@ -6598,7 +6594,6 @@ spec:
                   additionalResourceAttributes:
                     additionalProperties:
                       type: string
-                    maxProperties: 10
                     type: object
                   namespaceSelector:
                     properties:
@@ -6652,7 +6647,6 @@ spec:
               resourceAttributes:
                 additionalProperties:
                   type: string
-                maxProperties: 10
                 type: object
               skipCertCheck:
                 type: boolean

--- a/pkg/api/latest/dynakube/dynakube_types.go
+++ b/pkg/api/latest/dynakube/dynakube_types.go
@@ -104,7 +104,6 @@ type DynaKubeSpec struct { //nolint:revive
 	// Global default resource attributes applied to every component that supports resource attributes.
 	// Per-component additionalResourceAttributes take precedence over these values when the same key is present in both.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:MaxProperties=10
 	ResourceAttributes map[string]string `json:"resourceAttributes,omitempty"`
 
 	// Configuration for OTLP Exporter Configuration

--- a/pkg/api/latest/dynakube/oneagent/spec.go
+++ b/pkg/api/latest/dynakube/oneagent/spec.go
@@ -145,7 +145,6 @@ type HostInjectSpec struct {
 	// Additional resource attributes that are merged on top of the global spec.resourceAttributes.
 	// If the same key exists in both, the value from additionalResourceAttributes takes precedence.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:MaxProperties=10
 	AdditionalResourceAttributes map[string]string `json:"additionalResourceAttributes,omitempty"`
 }
 
@@ -163,7 +162,6 @@ type ApplicationMonitoringSpec struct {
 	// Additional resource attributes that are merged on top of the global spec.resourceAttributes.
 	// If the same key exists in both, the value from additionalResourceAttributes takes precedence.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:MaxProperties=10
 	AdditionalResourceAttributes map[string]string `json:"additionalResourceAttributes,omitempty"`
 }
 

--- a/pkg/api/latest/dynakube/otlp/spec.go
+++ b/pkg/api/latest/dynakube/otlp/spec.go
@@ -42,7 +42,6 @@ type ExporterConfigurationSpec struct {
 	// Additional resource attributes that are merged on top of the global spec.resourceAttributes.
 	// If the same key exists in both, the value from additionalResourceAttributes takes precedence.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:MaxProperties=10
 	AdditionalResourceAttributes map[string]string `json:"additionalResourceAttributes,omitempty"`
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Remove the hard limit on resource attributes. 

The validation should work like this:
- If global resource attr > 10 -> throw warning (soft validation)
- If global resource attr + additional resource attr > 10 throw warning (soft validation) 

[Jira ICP-7265](https://dt-rnd.atlassian.net/browse/ICP-7265)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Apply DK with more than 10 global/additional resource attr

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->