### PR TITLE
Remove ineffective ImageDigest field

### DIFF
--- a/pkg/injection/codemodule/installer/image/installer.go
+++ b/pkg/injection/codemodule/installer/image/installer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi/metadata"
@@ -25,7 +24,6 @@ type Properties struct {
 	APIReader    client.Reader
 	Dynakube     *dynakube.DynaKube
 	PathResolver metadata.PathResolver
-	ImageDigest  string
 }
 
 func NewImageInstaller(ctx context.Context, props *Properties) (installer.Installer, error) {
@@ -107,18 +105,17 @@ func (installer *Installer) installAgentFromImage(ctx context.Context, targetDir
 	}
 
 	image := installer.props.ImageURI
-	imageCacheDir := getCacheDirPath(installer.props.ImageDigest)
 
 	err = installer.extractAgentBinariesFromImage(
 		ctx,
 		imagePullInfo{
-			imageCacheDir: imageCacheDir,
+			imageCacheDir: CacheDir,
 			targetDir:     targetDir,
 		},
 		installer.props.ImageURI,
 	)
 	if err != nil {
-		log.Info("failed to extract agent binaries from image via proxy", "image", image, "imageCacheDir", imageCacheDir, "err", err)
+		log.Info("failed to extract agent binaries from image via proxy", "image", image, "err", err)
 	}
 
 	return nil
@@ -128,8 +125,4 @@ func (installer *Installer) isAlreadyPresent(targetDir string) bool {
 	_, err := os.Stat(targetDir)
 
 	return !os.IsNotExist(err)
-}
-
-func getCacheDirPath(digest string) string {
-	return filepath.Join(CacheDir, digest)
 }

--- a/pkg/injection/codemodule/installer/image/installer_test.go
+++ b/pkg/injection/codemodule/installer/image/installer_test.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	testImageURL      = "test:5000/repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-	testImageDigest   = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 	emptyDockerConfig = "{\"auths\":{}}"
 )
 
@@ -40,7 +39,7 @@ func TestIsAlreadyPresent(t *testing.T) {
 	})
 	t.Run("returns true if path present", func(t *testing.T) {
 		path := metadata.PathResolver{RootDir: t.TempDir()}
-		_ = os.MkdirAll(path.AgentSharedBinaryDirForAgent(imageDigest), 0777)
+		_ = os.MkdirAll(path.AgentSharedBinaryDirForAgent(imageDigest), 0o777)
 		installer := Installer{
 			props: &Properties{
 				PathResolver: path,
@@ -76,7 +75,6 @@ func TestNewImageInstaller(t *testing.T) {
 		PathResolver: path,
 		ImageURI:     testImageURL,
 		Dynakube:     dk,
-		ImageDigest:  testImageDigest,
 		APIReader:    fakeClient,
 	}
 	in, err := NewImageInstaller(ctx, props)
@@ -132,7 +130,6 @@ func TestInstaller_InstallAgent(t *testing.T) {
 						},
 						Spec: dynakube.DynaKubeSpec{},
 					},
-					ImageDigest: testImageDigest,
 				},
 				transport: transport,
 			},


### PR DESCRIPTION
## Description

The image installer properties have an ImageDigest field that's no longer used.
It was introduced in #1954. At that time the field was populated by extracting the digest from the image URI. This functionality got removed in #2654, but the field remained.
The result is that the image cache directory has been the top-level cache directory ever since then (`filepath.Join` ignores empty elements).

## How can this be tested?

`make test/e2e/cloudnative/codemodules`
