### PR TITLE
Fix pull-secret helper

### DIFF
--- a/pkg/api/latest/dynakube/dynakube_props.go
+++ b/pkg/api/latest/dynakube/dynakube_props.go
@@ -132,7 +132,7 @@ func (dk *DynaKube) CustomPullSecretReferences() []corev1.LocalObjectReference {
 func (dk *DynaKube) ImagePullSecretReferences() []corev1.LocalObjectReference {
 	var refs []corev1.LocalObjectReference
 
-	if !ptr.Deref(dk.Status.APIToken.Platform, false) || !dk.FF().IsPublicRegistry() {
+	if !dk.FF().IsPublicRegistry() {
 		refs = append(refs, dk.TenantRegistryPullSecretReferences()...)
 	}
 

--- a/pkg/api/latest/dynakube/dynakube_props_test.go
+++ b/pkg/api/latest/dynakube/dynakube_props_test.go
@@ -157,6 +157,17 @@ func TestImagePullSecretReferences(t *testing.T) {
 		refs := dk.ImagePullSecretReferences()
 		assert.Empty(t, refs)
 	})
+	t.Run("don't return tenant pull secret if use-public-registry annotation without platform token", func(t *testing.T) {
+		t.Setenv(k8senv.DTOperatorPullSecretEnvName, "")
+		dk := DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        testDKName,
+				Annotations: map[string]string{exp.UsePublicRegistryKey: "true"},
+			},
+		}
+		refs := dk.ImagePullSecretReferences()
+		assert.Empty(t, refs)
+	})
 }
 
 func TestPullSecretNames(t *testing.T) {

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -33,7 +33,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	ctx, log := logd.NewFromContext(ctx, "dynakube-pullsecret")
 
-	if tokens.HasPlatformToken() || dk.FF().IsPublicRegistry() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
+	if dk.FF().IsPublicRegistry() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled()) {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -225,8 +225,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		require.NoError(t, err)
 
-		platformTrue := true
-		dk.Status.APIToken.Platform = &platformTrue
+		dk.Status.APIToken.Platform = new(true)
 		err = r.Reconcile(t.Context(), dk, token.Tokens{
 			token.APIKey: &token.Token{Value: testPlatformToken},
 		})

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -302,8 +302,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 	t.Run("Don't create if platform token", func(t *testing.T) {
 		dk := createTestDynakube()
-		platformTrue := true
-		dk.Status.APIToken.Platform = &platformTrue
+		dk.Status.APIToken.Platform = new(true)
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
 			token.APIKey: &token.Token{Value: testPlatformToken},

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -225,6 +225,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		require.NoError(t, err)
 
+		platformTrue := true
+		dk.Status.APIToken.Platform = &platformTrue
 		err = r.Reconcile(t.Context(), dk, token.Tokens{
 			token.APIKey: &token.Token{Value: testPlatformToken},
 		})
@@ -301,6 +303,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 	t.Run("Don't create if platform token", func(t *testing.T) {
 		dk := createTestDynakube()
+		platformTrue := true
+		dk.Status.APIToken.Platform = &platformTrue
 		fakeClient := fake.NewClient()
 		tokens := token.Tokens{
 			token.APIKey: &token.Token{Value: testPlatformToken},

--- a/pkg/controllers/dynakube/extension/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/reconciler_test.go
@@ -120,7 +120,7 @@ func TestReconciler_ReconcileSecret(t *testing.T) {
 		})
 		r := NewReconciler(fake.NewClient(), errorReader)
 		err := r.Reconcile(t.Context(), nil, dk)
-		require.Error(t, err)
+		require.ErrorIs(t, err, expectedErr)
 
 		// assert extensions token condition is added
 		require.NotEmpty(t, dk.Conditions())

--- a/pkg/controllers/dynakube/extension/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/reconciler_test.go
@@ -1,6 +1,8 @@
 package extension
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -20,8 +22,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -110,8 +112,13 @@ func TestReconciler_ReconcileSecret(t *testing.T) {
 		dk := createDynakube()
 		dk.Spec.Extensions = &extensions.Spec{Prometheus: &extensions.PrometheusSpec{}}
 
-		misconfiguredReader, _ := client.New(&rest.Config{}, client.Options{})
-		r := NewReconciler(fake.NewClient(), misconfiguredReader)
+		expectedErr := errors.New("get error")
+		errorReader := fake.NewClientWithInterceptors(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return expectedErr
+			},
+		})
+		r := NewReconciler(fake.NewClient(), errorReader)
 		err := r.Reconcile(t.Context(), nil, dk)
 		require.Error(t, err)
 


### PR DESCRIPTION
## Description

[ICP-7075](https://dt-rnd.atlassian.net/browse/ICP-7075) (again 😓 )

The previous PR (#6926) only fixed the pull-secret reconciler but not the actual helper.
(+ cosmetic changes)

## How can this be tested?

Check the the pull-secret is not created AND that it is not attached to the OneAgent / ActiveGate

[ICP-7075]: https://dt-rnd.atlassian.net/browse/ICP-7075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ