### PR TITLE
Don't pin asset dockerfiles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,6 +107,16 @@
     },
     {
       matchManagers: [
+        "dockerfile",
+      ],
+      matchFileNames: [
+        "assets/docker/codeModulesAMD.Dockerfile",
+        "assets/docker/codeModulesARM.Dockerfile",
+      ],
+      enabled: false,
+    },
+    {
+      matchManagers: [
         "gomod",
       ],
       matchBaseBranches: [


### PR DESCRIPTION
## Description

Renovate is configure to pin all images, but the asset docker images are more like samples so they should not be held to the same standard.
