### PR TITLE
Fix Renovate go package lookup failure for golangci-lint/v2

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -192,6 +192,12 @@
       enabled: true,
     },
     {
+      matchPackageNames: [
+        "github.com/golangci/golangci-lint/v2",
+      ],
+      sourceUrl: "https://github.com/golangci/golangci-lint",
+    },
+    {
       matchDatasources: [
         "github-runners",
       ],


### PR DESCRIPTION
## Summary
- Renovate logs a package lookup failure for `github.com/golangci/golangci-lint/v2`. The warning is visible on our dashboard: https://developer.mend.io/github/Dynatrace/dynatrace-operator
- `golangci-lint` v2 doesn't use a `v2/` subdirectory — the whole repo was bumped to major version 2, with `go.mod` at the repo root declaring `module github.com/golangci/golangci-lint/v2`. When Renovate falls back to resolving the module path as a literal VCS/source URL, appending `/v2` to the GitHub repo path doesn't resolve (no such path exists on GitHub), producing a `no-result` lookup failure.
- This adds an explicit `sourceUrl` override in `packageRules` so Renovate maps the module path to the correct GitHub repository (`https://github.com/golangci/golangci-lint`) instead of trying to derive it from the Go module path.

## Renovate warning
```
WARN: Package lookup failures
{
  "baseBranch": "main",
  "warnings": [
    "Failed to look up go package github.com/golangci/golangci-lint/v2: no-result"
  ],
  "files": [
    "hack/make/prerequisites.mk"
  ]
}
```