### PR TITLE
Set permissions of dynakube-internal-proxy files to 0o640 (release-1.10)

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/proxy.go
@@ -42,7 +42,8 @@ func (mod ProxyModifier) getVolumes() []corev1.Volume {
 			Name: proxy.SecretVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: proxy.BuildSecretName(mod.dk.Name),
+					SecretName:  proxy.BuildSecretName(mod.dk.Name),
+					DefaultMode: new(int32(0o640)),
 				},
 			},
 		},


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-7427)

## Description

Files created by _< dynakube >-internal-proxy_ mount are not readable for _others_.

[PR on the main branch](https://github.com/Dynatrace/dynatrace-operator/pull/6957)

## How can this be tested?

make test/e2e/istio