### PR TITLE
e2e: fix: restoring csi driver after migration

### DIFF
--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -391,3 +391,7 @@ test/e2e/kspm/optionalscopes:
 
 test/e2e/token/migration:
 	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "token_migration" $(SKIPCLEANUP)
+
+test/e2e/cloudnative/migration_and_resilience:
+	$(GOTESTCMD) -timeout 40m ./test/e2e/scenarios/standard -run "cloudnative_csi_migration" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/istio -run "cloudnative_csi_resilience" $(SKIPCLEANUP)

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -391,7 +391,3 @@ test/e2e/kspm/optionalscopes:
 
 test/e2e/token/migration:
 	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "token_migration" $(SKIPCLEANUP)
-
-test/e2e/cloudnative/migration_and_resilience:
-	$(GOTESTCMD) -timeout 40m ./test/e2e/scenarios/standard -run "cloudnative_csi_migration" $(SKIPCLEANUP)
-	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/istio -run "cloudnative_csi_resilience" $(SKIPCLEANUP)

--- a/test/e2e/features/cloudnative/csimigration/migration.go
+++ b/test/e2e/features/cloudnative/csimigration/migration.go
@@ -73,6 +73,8 @@ func Feature(t *testing.T) features.Feature {
 	builder.Assess("dynakube reconciled after CSI disabled", dynakubeComponents.WaitForPhase(testDynakube, status.Running))
 
 	builder.Teardown(sampleApp.Uninstall())
+	// Restore operator with CSI enabled so subsequent tests don't inherit the disabled-CSI state.
+	builder.Teardown(restoreCSIDriver)
 
 	return builder.Feature()
 }
@@ -88,6 +90,14 @@ func enableMigrationMode(ctx context.Context, t *testing.T, cfg *envconf.Config)
 func disableCSIDriver(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	require.NoError(t, operator.InstallViaHelm("", false))
 	ctx, err := operator.VerifyInstall(ctx, cfg, false)
+	require.NoError(t, err)
+
+	return ctx
+}
+
+func restoreCSIDriver(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	require.NoError(t, operator.InstallViaHelm("", true))
+	ctx, err := operator.VerifyInstall(ctx, cfg, true)
 	require.NoError(t, err)
 
 	return ctx


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

- restores the operator back to a csi enabled state after running the `csi-migration` tests to not affect tests run after like seen [in this run](https://github.com/Dynatrace/dynatrace-operator/actions/runs/29379310466/job/87239310431)

- this fixes the failing test step `test/e2e/scenarios/istio TestIstio_cloudnative_csi_resilience/cloudnative-csi-resilience/check_for_dummy_volume` which is now passing in the latest [run](https://github.com/Dynatrace/dynatrace-operator/actions/runs/29492162232/job/87600630242#step:3:1004)
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->