### PR TITLE
Do not use `timeprovider.Freeze()` in live code.

### DIFF
--- a/pkg/controllers/dynakube/activegate/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/reconciler.go
@@ -85,7 +85,7 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 		authTokenReconciler:        authtoken.NewReconciler(clt, apiReader),
 		istioReconciler:            istio.NewReconciler(clt, apiReader),
 		connectionReconciler:       agconnectioninfo.NewReconciler(clt, apiReader),
-		versionReconciler:          version.NewReconciler(apiReader, timeprovider.New().Freeze()),
+		versionReconciler:          version.NewReconciler(apiReader, timeprovider.New()),
 		pullSecretReconciler:       dtpullsecret.NewReconciler(clt, apiReader),
 		customPropertiesReconciler: customproperties.NewReconciler(clt, apiReader),
 		statefulsetReconciler:      statefulset.NewReconciler(clt, apiReader),

--- a/pkg/controllers/dynakube/injection/reconciler.go
+++ b/pkg/controllers/dynakube/injection/reconciler.go
@@ -59,7 +59,7 @@ func NewReconciler(
 		client:                    client,
 		apiReader:                 apiReader,
 		istioReconciler:           istio.NewReconciler(client, apiReader),
-		versionReconciler:         version.NewReconciler(apiReader, timeprovider.New().Freeze()),
+		versionReconciler:         version.NewReconciler(apiReader, timeprovider.New()),
 		connectionInfoReconciler:  oaconnectioninfo.NewReconciler(client, apiReader),
 		enrichmentRulesReconciler: rules.NewReconciler(),
 	}

--- a/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
+++ b/pkg/controllers/dynakube/oneagent/oneagent_reconciler.go
@@ -67,7 +67,7 @@ func NewReconciler(
 		configmap:                k8sconfigmap.Query(client, apiReader),
 		daemonset:                k8sdaemonset.Query(client, apiReader),
 		connectionInfoReconciler: oaconnectioninfo.NewReconciler(client, apiReader),
-		versionReconciler:        version.NewReconciler(apiReader, timeprovider.New().Freeze()),
+		versionReconciler:        version.NewReconciler(apiReader, timeprovider.New()),
 	}
 }
 


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/ICP-7580

The less code change version of https://github.com/Dynatrace/dynatrace-operator/pull/6970, this also fixes the autoUpdate bug.

Note: There are no adjustments in the unit-tests, as I can't really test if `Freeze` was called or not. (could have turned it into a testing func with `t.Testing` as a param, but that would have went against the "minimal change" idea.)

## How can this be tested?

So, as this would be a long running test, here is the hacky way to check fast:

1. Create DynaKube with OA/AG/CM and set the `spec.dynatraceApiRequestThreshold: 1`
2. Check the logs that the `updating version status` doesn't only happen on the first reconcile