### PR TITLE
add cache-sync helpers for cached-client integration tests

### DIFF
--- a/.github/workflows/zz-temp-stress.yaml
+++ b/.github/workflows/zz-temp-stress.yaml
@@ -1,0 +1,59 @@
+# TEMPORARY — stress-tests the kubemon cached-client integration tests to flush out
+# informer-cache timing races. Revert before merging this PR.
+name: TEMP stress integration tests
+
+on:
+  push:
+    branches: [integration-test-cache]
+  workflow_dispatch:
+    inputs:
+      parallel:
+        description: concurrent test processes per shard (induces CPU contention)
+        default: "4"
+      count:
+        description: iterations per process
+        default: "50"
+
+permissions:
+  contents: read
+
+jobs:
+  stress:
+    name: stress (shard ${{ matrix.shard }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup Golang
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+          cache: false
+      - name: Setup envtest binaries
+        run: make prerequisites/setup-envtest
+      - name: Stress
+        env:
+          PARALLEL: ${{ github.event.inputs.parallel || '4' }}
+          COUNT: ${{ github.event.inputs.count || '50' }}
+        run: |
+          set -u
+          rc=0
+          for pkg in \
+            ./pkg/controllers/dynakube/kubemon/statefulset \
+            ./pkg/controllers/dynakube/kubemon/connectioninfo; do
+            echo "::group::stress $pkg ($PARALLEL x $COUNT)"
+            pids=()
+            for _ in $(seq 1 "$PARALLEL"); do
+              go test "$pkg" -run TestReconcileLifecycle -count="$COUNT" -failfast &
+              pids+=($!)
+            done
+            for p in "${pids[@]}"; do wait "$p" || rc=1; done
+            echo "::endgroup::"
+          done
+          exit $rc

--- a/.github/workflows/zz-temp-stress.yaml
+++ b/.github/workflows/zz-temp-stress.yaml
@@ -1,5 +1,5 @@
-# TEMPORARY — stress-tests the kubemon cached-client integration tests to flush out
-# informer-cache timing races. Revert before merging this PR.
+# TEMPORARY — smoke/stress the kubemon cached-client integration tests for informer-cache
+# races. Defaults to a single run; tune parallel/count via manual dispatch. Revert before merge.
 name: TEMP stress integration tests
 
 on:
@@ -8,52 +8,37 @@ on:
   workflow_dispatch:
     inputs:
       parallel:
-        description: concurrent test processes per shard (induces CPU contention)
-        default: "4"
+        description: concurrent test processes (raise to induce CPU contention)
+        default: "1"
       count:
         description: iterations per process
-        default: "50"
+        default: "1"
 
 permissions:
   contents: read
 
 jobs:
   stress:
-    name: stress (shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4, 5, 6]
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Setup Golang
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
           cache: false
-      - name: Setup envtest binaries
-        run: make prerequisites/setup-envtest
-      - name: Stress
-        env:
-          PARALLEL: ${{ github.event.inputs.parallel || '4' }}
-          COUNT: ${{ github.event.inputs.count || '50' }}
+      - run: make prerequisites/setup-envtest
+      - env:
+          PARALLEL: ${{ github.event.inputs.parallel || '1' }}
+          COUNT: ${{ github.event.inputs.count || '1' }}
         run: |
           set -u
           rc=0
-          for pkg in \
-            ./pkg/controllers/dynakube/kubemon/statefulset \
-            ./pkg/controllers/dynakube/kubemon/connectioninfo; do
-            echo "::group::stress $pkg ($PARALLEL x $COUNT)"
-            pids=()
-            for _ in $(seq 1 "$PARALLEL"); do
-              go test "$pkg" -run TestReconcileLifecycle -count="$COUNT" -failfast &
-              pids+=($!)
-            done
-            for p in "${pids[@]}"; do wait "$p" || rc=1; done
-            echo "::endgroup::"
+          pids=()
+          for _ in $(seq 1 "$PARALLEL"); do
+            go test ./pkg/controllers/dynakube/kubemon/... -run TestReconcileLifecycle -count="$COUNT" -failfast &
+            pids+=($!)
           done
+          for p in "${pids[@]}"; do wait "$p" || rc=1; done
           exit $rc

--- a/.github/workflows/zz-temp-stress.yaml
+++ b/.github/workflows/zz-temp-stress.yaml
@@ -11,13 +11,13 @@ permissions:
   contents: read
 
 env:
-  PARALLEL: "1"   # concurrent test processes — raise (e.g. 4) to induce CPU contention
-  COUNT: "50"      # iterations per process — raise (e.g. 50) to hunt the race
+  PARALLEL: "6"   # concurrent test processes — raise to induce CPU contention (runner ~4 vCPU)
+  COUNT: "40"     # iterations per process — race needs contention more than raw count
 
 jobs:
   stress:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/zz-temp-stress.yaml
+++ b/.github/workflows/zz-temp-stress.yaml
@@ -1,25 +1,23 @@
-# TEMPORARY — smoke/stress the kubemon cached-client integration tests for informer-cache
-# races. Defaults to a single run; tune parallel/count via manual dispatch. Revert before merge.
+# TEMPORARY — stress the kubemon cached-client integration tests for informer-cache races.
+# Tune by editing PARALLEL/COUNT below and pushing (workflow_dispatch needs the file on main,
+# so this is push-driven). Revert before merge.
 name: TEMP stress integration tests
 
 on:
   push:
     branches: [integration-test-cache]
-  workflow_dispatch:
-    inputs:
-      parallel:
-        description: concurrent test processes (raise to induce CPU contention)
-        default: "1"
-      count:
-        description: iterations per process
-        default: "1"
 
 permissions:
   contents: read
 
+env:
+  PARALLEL: "1"   # concurrent test processes — raise (e.g. 4) to induce CPU contention
+  COUNT: "50"      # iterations per process — raise (e.g. 50) to hunt the race
+
 jobs:
   stress:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -27,12 +25,9 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
-          cache: false
+          cache: true
       - run: make prerequisites/setup-envtest
-      - env:
-          PARALLEL: ${{ github.event.inputs.parallel || '1' }}
-          COUNT: ${{ github.event.inputs.count || '1' }}
-        run: |
+      - run: |
           set -u
           rc=0
           pids=()

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -681,6 +681,14 @@ func TestMyFunction(t *testing.T) {
 
 - **Inline single-use timeouts.** Do not define a package-level `const` for a timeout that is only used in one test. Specify it inline to keep the test self-contained and consistent with the rest of the codebase.
 
+### Integration tests (envtest) with a cached client
+
+When a reconciler reads owned/watched resources through the manager's cached client, its integration
+test must handle the cache's eventual consistency: ensure the cache reflects a setup write before
+reconciling, using the `WaitForCached*` helpers documented in
+[`test/integrationtests/cache.go`](../test/integrationtests/cache.go); the reference examples are
+`pkg/controllers/dynakube/kubemon/statefulset` and `.../kubemon/connectioninfo`.
+
 ## E2E testing guide
 
 We are using the [e2e-framework](https://github.com/kubernetes-sigs/e2e-framework) package to write our E2E tests.

--- a/pkg/controllers/dynakube/kubemon/connectioninfo/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/connectioninfo/reconciler_integration_test.go
@@ -3,7 +3,6 @@ package connectioninfo_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	kubemonapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
@@ -22,17 +21,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Integration tests for the connectioninfo reconciler against a real API server. Drives one DynaKube
-// through ordered, state-sharing phases; most phases assert with a single reconcile call and apiReader.
-// Branch and error logic is covered by the unit test.
+// Integration tests for the connectioninfo reconciler against a real API server (cached client). Each
+// phase ensures the cache reflects a setup write before reconciling; see test/integrationtests/cache.go.
+// This reconciler returns nil on success (no in-loop rollout read), so phases are a single reconcile
+// once preconditions are cache-visible. Branch and error logic is covered by the unit test.
 
 const (
-	integrationNamespace         = "dynatrace"
-	integrationTenantUUID        = "test-uuid"
-	integrationEndpoints         = "https://tenant.live.dynatrace.com/communication"
-	integrationTenantToken       = "test-token"
-	integrationEventuallyTimeout = 5 * time.Second
-	integrationEventuallyTick    = 50 * time.Millisecond
+	integrationNamespace   = "dynatrace"
+	integrationTenantUUID  = "test-uuid"
+	integrationEndpoints   = "https://tenant.live.dynatrace.com/communication"
+	integrationTenantToken = "test-token"
 )
 
 var anyContext = mock.MatchedBy(func(context.Context) bool { return true })
@@ -131,6 +129,16 @@ func runStabilizePhase(t *testing.T, deps lifecycleDeps) {
 	dtClient := agclientmock.NewClient(t)
 	dtClient.EXPECT().GetConnectionInfo(anyContext).Return(deps.rotatedConnectionInfo, nil)
 
+	// sync the cache to the rotated config map/secret so the reconciles below are true no-ops
+	cmKey := client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetConnectionInfoConfigMapName(), Namespace: deps.dk.Namespace}
+	secretKey := client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetTenantSecretName(), Namespace: deps.dk.Namespace}
+	integrationtests.WaitForCachedMatch(t, deps.clt, cmKey, &corev1.ConfigMap{}, func(cm *corev1.ConfigMap) bool {
+		return cm.Data[sharedconnectioninfo.CommunicationEndpointsKey] == deps.rotatedConnectionInfo.Endpoints
+	})
+	integrationtests.WaitForCachedMatch(t, deps.clt, secretKey, &corev1.Secret{}, func(secret *corev1.Secret) bool {
+		return string(secret.Data[sharedconnectioninfo.TenantTokenKey]) == deps.rotatedConnectionInfo.TenantToken
+	})
+
 	cmRV := getConfigMap(t, deps.apiReader, deps.dk).ResourceVersion
 	secretRV := getSecret(t, deps.apiReader, deps.dk).ResourceVersion
 
@@ -164,11 +172,10 @@ func runReEnablePhase(t *testing.T, deps lifecycleDeps) {
 	dtClient := agclientmock.NewClient(t)
 	dtClient.EXPECT().GetConnectionInfo(anyContext).Return(deps.baselineConnectionInfo, nil)
 
-	// The cache backing the reconciler may still hold the config map/secret deleted by the disable
-	// phase, so retry until the deletion has propagated and the reconcile re-creates them.
-	require.Eventually(t, func() bool {
-		return deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk) == nil
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
+	integrationtests.WaitForCachedGone(t, deps.clt, client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetConnectionInfoConfigMapName(), Namespace: deps.dk.Namespace}, &corev1.ConfigMap{})
+	integrationtests.WaitForCachedGone(t, deps.clt, client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetTenantSecretName(), Namespace: deps.dk.Namespace}, &corev1.Secret{})
+
+	require.NoError(t, deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk))
 	require.True(t, isConnectionInfoApplied(t.Context(), deps.apiReader, deps.dk, deps.baselineConnectionInfo))
 }
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
@@ -104,6 +104,8 @@ func runProvisionPhase(t *testing.T, deps *lifecycleDeps) {
 
 func runRolloutCompletePhase(t *testing.T, deps *lifecycleDeps) {
 	t.Helper()
+	// Sync cache to the StatefulSet created during the provision phase before reading it.
+	integrationtests.WaitForCachedMatch(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{}, func(*appsv1.StatefulSet) bool { return true })
 
 	markRolloutComplete(t, t.Context(), deps.clt, deps.dk)
 	integrationtests.WaitForCachedMatch(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{}, k8sstatefulset.IsRolloutComplete)

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
@@ -104,8 +104,6 @@ func runProvisionPhase(t *testing.T, deps *lifecycleDeps) {
 
 func runRolloutCompletePhase(t *testing.T, deps *lifecycleDeps) {
 	t.Helper()
-	// Sync cache to the StatefulSet created during the provision phase before reading it.
-	integrationtests.WaitForCachedMatch(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{}, func(*appsv1.StatefulSet) bool { return true })
 
 	markRolloutComplete(t, t.Context(), deps.clt, deps.dk)
 	integrationtests.WaitForCachedMatch(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{}, k8sstatefulset.IsRolloutComplete)

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	kubemonapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
@@ -21,15 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Integration tests for the statefulset reconciler against a real API server. Drives one DynaKube
-// through ordered, state-sharing phases; most phases assert with a single reconcile call and apiReader.
-// Branch and error logic is covered by the unit test.
+// Integration tests for the statefulset reconciler against a real API server (cached client). Each
+// phase ensures the cache reflects a setup write before reconciling; see test/integrationtests/cache.go.
+// Drives one DynaKube through ordered, state-sharing phases. Branch and error logic is covered by
+// the unit test.
 
-const (
-	integrationNamespace         = "dynatrace"
-	integrationEventuallyTimeout = 5 * time.Second
-	integrationEventuallyTick    = 50 * time.Millisecond
-)
+const integrationNamespace = "dynatrace"
 
 type lifecycleDeps struct {
 	clt                    client.Client
@@ -110,11 +106,9 @@ func runRolloutCompletePhase(t *testing.T, deps *lifecycleDeps) {
 	t.Helper()
 
 	markRolloutComplete(t, t.Context(), deps.clt, deps.dk)
+	integrationtests.WaitForCachedMatch(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{}, k8sstatefulset.IsRolloutComplete)
 
-	// Retry until the cache reflects the completed status and reconcile reports no error.
-	require.Eventually(t, func() bool {
-		return deps.reconciler.Reconcile(t.Context(), deps.dk) == nil
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
+	require.NoError(t, deps.reconciler.Reconcile(t.Context(), deps.dk))
 }
 
 func runRotatePhase(t *testing.T, deps *lifecycleDeps) {
@@ -122,25 +116,27 @@ func runRotatePhase(t *testing.T, deps *lifecycleDeps) {
 
 	deps.secret.Data[connectioninfo.TenantTokenKey] = []byte("rotated-tenant-token")
 	require.NoError(t, deps.clt.Update(t.Context(), deps.secret))
+	integrationtests.WaitForCachedMatch(t, deps.clt, client.ObjectKeyFromObject(deps.secret), &corev1.Secret{}, func(secret *corev1.Secret) bool {
+		return string(secret.Data[connectioninfo.TenantTokenKey]) == "rotated-tenant-token"
+	})
 
-	require.Eventually(t, func() bool {
-		if !errors.Is(deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress) {
-			return false
-		}
-		sts := &appsv1.StatefulSet{}
-		if err := deps.clt.Get(t.Context(), statefulSetKey(deps.dk), sts); err != nil {
-			return false
-		}
-		deps.rotatedTenantTokenHash = sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash]
+	// the reconcile reads its own StatefulSet update back from the lagging cache, so its return is
+	// racy (old=complete, new=in-progress); assert the outcome via apiReader
+	err := deps.reconciler.Reconcile(t.Context(), deps.dk)
+	require.True(t, err == nil || errors.Is(err, k8sstatefulset.ErrRolloutInProgress))
 
-		return deps.rotatedTenantTokenHash != deps.initialTenantTokenHash
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
-
+	sts := getStatefulSet(t, deps.apiReader, deps.dk)
+	deps.rotatedTenantTokenHash = sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash]
 	assert.NotEqual(t, deps.initialTenantTokenHash, deps.rotatedTenantTokenHash)
 }
 
 func runStabilizePhase(t *testing.T, deps *lifecycleDeps) {
 	t.Helper()
+
+	// sync the cache to the rotated StatefulSet so the reconciles below are true no-ops
+	integrationtests.WaitForCachedMatch(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{}, func(sts *appsv1.StatefulSet) bool {
+		return sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash] == deps.rotatedTenantTokenHash
+	})
 
 	stsRV := getStatefulSet(t, deps.apiReader, deps.dk).ResourceVersion
 
@@ -169,17 +165,11 @@ func runReEnablePhase(t *testing.T, deps *lifecycleDeps) {
 	deps.dk.Spec.KubernetesMonitoring = &kubemonapi.Spec{}
 	deps.dk.Spec.KubernetesMonitoring.Image = "registry.example.com/linux/activegate:1.2.3"
 
-	// The cache backing the reconciler may still hold the StatefulSet deleted by the disable phase,
-	// so retry until the deletion has propagated, reconcile recreates it, and apiReader observes it.
-	sts := &appsv1.StatefulSet{}
-	require.Eventually(t, func() bool {
-		if !errors.Is(deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress) {
-			return false
-		}
+	integrationtests.WaitForCachedGone(t, deps.clt, statefulSetKey(deps.dk), &appsv1.StatefulSet{})
 
-		return deps.apiReader.Get(t.Context(), statefulSetKey(deps.dk), sts) == nil
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
+	require.ErrorIs(t, deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress)
 
+	sts := getStatefulSet(t, deps.apiReader, deps.dk)
 	assertStatefulSetShape(t, sts, deps.dk)
 	assert.Equal(t, deps.rotatedTenantTokenHash, sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash])
 }

--- a/test/integrationtests/cache.go
+++ b/test/integrationtests/cache.go
@@ -1,0 +1,70 @@
+package integrationtests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Testing reconcilers that use a cached client.
+//
+// Reconcilers read through the manager's cached client, which keeps them simple and cuts apiserver
+// calls but is eventually consistent: a write reaches the apiserver at once, while the informer
+// cache that serves reads catches up a moment later. So a reconciler that writes an object and then
+// reads it back — a read-after-write — can act on a stale copy, a real class of bug.
+//
+// The test must run on that same cached client to exercise this path; a direct apiserver client is
+// read-after-write consistent, so it would never hit it and would hide those bugs.
+//
+// Approach: ensure the cache reflects a setup write before reconciling. This mirrors production,
+// where an informer event carries the change into the cache before it triggers a reconcile. Per
+// phase:
+//
+//   - Arrange: after a setup write, WaitForCachedMatch / WaitForCachedGone until the cache observes it.
+//   - Act: exactly one reconcile, never wrapped in require.Eventually.
+//   - Assert: through the direct apiReader.
+//
+// Rules:
+//
+//   - Check the result with apiReader, not the value Reconcile returns. A reconcile may write an
+//     object and then read it back from the cache to build its return value; because the cache lags,
+//     that read can catch the old or the new object, so the same call may return different things on
+//     different runs. The object in the apiserver is stable, so assert on that instead.
+//   - Before checking that a reconcile changes nothing (a no-op), first WaitForCached the previous
+//     write, so the reconcile reads an up-to-date cache and does not rewrite the object.
+//   - Keep exactly one reconcile per phase. Only wrap a reconcile in require.Eventually if it
+//     genuinely needs several passes on its own to settle (rare).
+//
+// Reference examples: pkg/controllers/dynakube/kubemon/statefulset and .../kubemon/connectioninfo.
+
+const (
+	cacheSyncTimeout = 5 * time.Second
+	cacheSyncTick    = 50 * time.Millisecond
+)
+
+// WaitForCachedMatch blocks until reader (a cached client) observes obj at key and match(obj)
+// holds, modeling the informer delivering a watch event into the cache before a reconcile.
+func WaitForCachedMatch[T client.Object](t *testing.T, reader client.Reader, key client.ObjectKey, obj T, match func(T) bool) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		if err := reader.Get(t.Context(), key, obj); err != nil {
+			return false
+		}
+
+		return match(obj)
+	}, cacheSyncTimeout, cacheSyncTick)
+}
+
+// WaitForCachedGone blocks until reader (a cached client) no longer observes obj at key, modeling
+// the informer delivering a delete watch event into the cache before a reconcile.
+func WaitForCachedGone(t *testing.T, reader client.Reader, key client.ObjectKey, obj client.Object) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return k8serrors.IsNotFound(reader.Get(t.Context(), key, obj))
+	}, cacheSyncTimeout, cacheSyncTick)
+}


### PR DESCRIPTION
## Goal

Simplify authoring integration tests that use a cached client (initially introduced in https://github.com/Dynatrace/dynatrace-operator/pull/6757).

## What
- New `test/integrationtests/cache.go` with `WaitForCachedMatch` / `WaitForCachedGone` helpers.
- Refactor the `kubemon/statefulset` and `kubemon/connectioninfo` integration tests to use them.
- New guide in `doc/coding-style-guide.md` for integration testing with a cached client.

## Why
Reconcilers run on the manager's cached client, which is eventually consistent — a reconcile can read a stale object right after a write. Tests that assumed one reconcile was enough [flaked](https://github.com/Dynatrace/dynatrace-operator/actions/runs/29504240911/job/87640800363?pr=6757) (e.g. re-enable after delete read a stale StatefulSet and skipped recreation), which shows this is easy to get wrong without a shared pattern. Each phase now waits for the cache to reflect its setup write before reconciling, then asserts via the direct `apiReader`.

## Testing
`make go/test`