### PR TITLE
Fix OA DaemonSet secret mount permissions.

### DIFF
--- a/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/volumes.go
@@ -11,6 +11,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	// This should result in file permissions of -r--r--r--
+	// This is necessary because the OneAgent (in classicFullstack) may replicate these files into instrumented user pods
+	// where all processes need to be able to read these.
+	globalReadFilePerm = 0o444
+)
+
 func prepareVolumeMounts(dk *dynakube.DynaKube, processGroupConfigHash string) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{getOneAgentSecretVolumeMount(), getNodeMetadataVolumeMount()}
 
@@ -213,7 +220,7 @@ func getActiveGateCaCertVolume(dk *dynakube.DynaKube) corev1.Volume {
 						Path: "custom.pem",
 					},
 				},
-				DefaultMode: new(int32(0o640)),
+				DefaultMode: new(int32(globalReadFilePerm)), // secrets are always mounted readonly, so OA doesn't need write access
 			},
 		},
 	}
@@ -225,7 +232,7 @@ func buildHTTPProxyVolume(dk *dynakube.DynaKube) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  proxy.BuildSecretName(dk.Name),
-				DefaultMode: new(int32(0o640)),
+				DefaultMode: new(int32(globalReadFilePerm)), // secrets are always mounted readonly, so OA doesn't need write access
 			},
 		},
 	}
@@ -237,7 +244,7 @@ func getOneAgentSecretVolume(dk *dynakube.DynaKube) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  dk.OneAgent().GetTenantSecret(),
-				DefaultMode: new(int32(0o640)),
+				DefaultMode: new(int32(globalReadFilePerm)), // secrets are always mounted readonly, so OA doesn't need write access
 			},
 		},
 	}


### PR DESCRIPTION

## Description

https://dt-rnd.atlassian.net/browse/ICP-7532

The big issue we are solving: ClassicFullstack will replicate the the certs to into the instrumented app containers, so any process needs to be able to read it.

I modified all secret volumes for the OA, as I do not want to hunt down if anything else is broken due to the other secrets.

## How can this be tested?

1. Deploy an OA + AG (preferable classic)
2. Check that the certs we mount have `-r--r--r--` (both in the OA and injected containers)