### PR TITLE
fix: prevent panic on malformed ActiveGate auth token

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler.go
@@ -25,12 +25,15 @@ import (
 
 const (
 	activeGateAuthTokenSecretConditionType string = "ActiveGateAuthTokenSecret"
+	malformedAuthTokenReason               string = "MalformedAuthToken"
 
 	ActiveGateAuthTokenName = "auth-token"
 
 	// Buffer to avoid warnings in the UI
 	AuthTokenBuffer           = time.Hour * 24
 	AuthTokenRotationInterval = time.Hour*24*30 - AuthTokenBuffer
+
+	authTokenPublicParts = 2
 )
 
 type Reconciler struct {
@@ -95,9 +98,7 @@ func (r *Reconciler) reconcileAuthTokenSecret(ctx context.Context, dk *dynakube.
 		return r.ensureAuthTokenSecret(ctx, dk, agClient)
 	}
 
-	r.conditionSetSecretCreated(dk, secret) // update message once a day
-
-	return nil
+	return r.conditionSetSecretCreated(dk, secret) // update message once a day
 }
 
 func (r *Reconciler) ensureAuthTokenSecret(ctx context.Context, dk *dynakube.DynaKube, agClient agclient.Client) error {
@@ -144,9 +145,7 @@ func (r *Reconciler) createSecret(ctx context.Context, dk *dynakube.DynaKube, se
 		return errors.Errorf("failed to create secret '%s': %v", secretName, err)
 	}
 
-	r.conditionSetSecretCreated(dk, secret)
-
-	return nil
+	return r.conditionSetSecretCreated(dk, secret)
 }
 
 func (r *Reconciler) deleteSecret(ctx context.Context, dk *dynakube.DynaKube, secret *corev1.Secret) error {
@@ -163,13 +162,32 @@ func isSecretOutdated(secret *corev1.Secret) bool {
 	return secret.CreationTimestamp.Add(AuthTokenRotationInterval).Before(time.Now())
 }
 
-func (r *Reconciler) conditionSetSecretCreated(dk *dynakube.DynaKube, secret *corev1.Secret) {
+func (r *Reconciler) conditionSetSecretCreated(dk *dynakube.DynaKube, secret *corev1.Secret) error {
+	tokenAllParts := strings.Split(string(secret.Data[ActiveGateAuthTokenName]), ".")
+	if len(tokenAllParts) < authTokenPublicParts {
+		err := errors.Errorf("malformed ActiveGate auth token in secret '%s': expected at least %d dot-separated segments, got %d", secret.Name, authTokenPublicParts, len(tokenAllParts))
+		setAuthSecretMalformed(dk.Conditions(), activeGateAuthTokenSecretConditionType, err)
+
+		return err
+	}
+
 	lifespan := time.Since(secret.CreationTimestamp.Time)
 	days := strconv.Itoa(int(lifespan.Hours() / 24))
-	tokenAllParts := strings.Split(string(secret.Data[ActiveGateAuthTokenName]), ".")
-	tokenPublicPart := strings.Join(tokenAllParts[:2], ".")
+	tokenPublicPart := strings.Join(tokenAllParts[:authTokenPublicParts], ".")
 
 	setAuthSecretCreated(dk.Conditions(), activeGateAuthTokenSecretConditionType, "secret created "+days+" day(s) ago, token:"+tokenPublicPart)
+
+	return nil
+}
+
+func setAuthSecretMalformed(conditions *[]metav1.Condition, conditionType string, err error) {
+	condition := metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  malformedAuthTokenReason,
+		Message: err.Error(),
+	}
+	_ = meta.SetStatusCondition(conditions, condition)
 }
 
 func setAuthSecretCreated(conditions *[]metav1.Condition, conditionType string, msg string) {

--- a/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/authtoken/reconciler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -198,4 +199,43 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, firstCreationTimestamp, secondCreationTimestamp)
 		assert.Equal(t, secondTransition, firstTransition)
 	})
+}
+
+func TestConditionSetSecretCreatedMalformedToken(t *testing.T) {
+	r := &Reconciler{}
+
+	tests := []struct {
+		name         string
+		token        string
+		expectErr    bool
+		expectStatus metav1.ConditionStatus
+		expectReason string
+	}{
+		{name: "empty token", token: "", expectErr: true, expectStatus: metav1.ConditionFalse, expectReason: malformedAuthTokenReason},
+		{name: "single-part token", token: "single", expectErr: true, expectStatus: metav1.ConditionFalse, expectReason: malformedAuthTokenReason},
+		{name: "valid token", token: testToken, expectErr: false, expectStatus: metav1.ConditionTrue, expectReason: k8sconditions.SecretCreatedReason},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dk := newDynaKube()
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+				Data:       map[string][]byte{ActiveGateAuthTokenName: []byte(tt.token)},
+			}
+
+			err := r.conditionSetSecretCreated(dk, secret)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			condition := meta.FindStatusCondition(*dk.Conditions(), activeGateAuthTokenSecretConditionType)
+			require.NotNil(t, condition)
+			assert.Equal(t, tt.expectStatus, condition.Status)
+			assert.Equal(t, tt.expectReason, condition.Reason)
+		})
+	}
 }


### PR DESCRIPTION
## problem

`conditionSetSecretCreated` splits the ActiveGate `auth-token` secret value on `.` and takes `tokenAllParts[:2]` with no length check

`strings.Split("", ".")` returns a one-element slice, so an empty or single-segment token value panics with `slice bounds out of range [:2]`. it runs on every reconcile (the condition message is refreshed for each present, not-outdated secret), so a malformed or tampered secret wedges that DynaKube's reconcile in a panic/backoff loop

## fix

guard the length before slicing, so a token with fewer than two segments yields an empty public part instead of panicking

## how tested

added a table test calling `conditionSetSecretCreated` with empty, single-segment and valid tokens and asserting it does not panic; it panics on the old code and passes on the new
