### PR TITLE
Fix OA communication host handling

### DIFF
--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts.go
@@ -61,15 +61,15 @@ func NewCommunicationHost(endpoint string) (CommunicationHost, error) {
 	}, nil
 }
 
-// NewOACommunicationHosts creates CommunicationHost slice from `;` separated endpoints.
+// ParseOACommunicationHosts creates CommunicationHost slice from `;` separated endpoints.
 // It removes duplicates and sorts the result for deterministic output.
-func NewOACommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+func ParseOACommunicationHosts(endpoints string) ([]CommunicationHost, error) {
 	return newCommunicationHosts(endpoints, ";")
 }
 
-// NewAGCommunicationHosts creates CommunicationHost slice from `,` separated endpoints.
+// ParseAGCommunicationHosts creates CommunicationHost slice from `,` separated endpoints.
 // It removes duplicates and sorts the result for deterministic output.
-func NewAGCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+func ParseAGCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
 	return newCommunicationHosts(endpoints, ",")
 }
 

--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts.go
@@ -61,9 +61,19 @@ func NewCommunicationHost(endpoint string) (CommunicationHost, error) {
 	}, nil
 }
 
-// NewCommunicationHosts creates CommunicationHost slice from comma separated endpoints.
+// NewOACommunicationHosts creates CommunicationHost slice from `;` separated endpoints.
 // It removes duplicates and sorts the result for deterministic output.
-func NewCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+func NewOACommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+	return newCommunicationHosts(endpoints, ";")
+}
+
+// NewAGCommunicationHosts creates CommunicationHost slice from `,` separated endpoints.
+// It removes duplicates and sorts the result for deterministic output.
+func NewAGCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+	return newCommunicationHosts(endpoints, ",")
+}
+
+func newCommunicationHosts(endpoints string, sep string) ([]CommunicationHost, error) {
 	// we want to avoid duplicates, because they cause problems with the istio "integration", as you should not have duplicate hosts in the ServiceEntries
 	comHosts := map[string]CommunicationHost{}
 
@@ -71,7 +81,7 @@ func NewCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
 		return []CommunicationHost{}, nil
 	}
 
-	for endpoint := range strings.SplitSeq(endpoints, ",") {
+	for endpoint := range strings.SplitSeq(endpoints, sep) {
 		ch, err := NewCommunicationHost(endpoint)
 		if err != nil {
 			return nil, err

--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
@@ -150,7 +150,7 @@ func TestNewOACommunicationHosts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			hosts, err := NewOACommunicationHosts(tc.input)
+			hosts, err := ParseOACommunicationHosts(tc.input)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -242,7 +242,7 @@ func TestNewAGCommunicationHosts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			hosts, err := NewAGCommunicationHosts(tc.input)
+			hosts, err := ParseAGCommunicationHosts(tc.input)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
@@ -91,7 +91,7 @@ func TestNewCommunicationHost(t *testing.T) {
 	}
 }
 
-func TestNewOACommunicationHosts(t *testing.T) {
+func TestParseOACommunicationHosts(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       string
@@ -162,7 +162,7 @@ func TestNewOACommunicationHosts(t *testing.T) {
 	}
 }
 
-func TestNewAGCommunicationHosts(t *testing.T) {
+func TestParseAGCommunicationHosts(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       string

--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
@@ -91,7 +91,7 @@ func TestNewCommunicationHost(t *testing.T) {
 	}
 }
 
-func TestNewCommunicationHosts(t *testing.T) {
+func TestNewOACommunicationHosts(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       string
@@ -115,7 +115,78 @@ func TestNewCommunicationHosts(t *testing.T) {
 			},
 		},
 		{
-			name:  "multiple endpoints",
+			name:  "multiple endpoints separated by semicolons",
+			input: "https://example.live.dynatrace.com/communication;https://managedhost.com:9999/here/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+				{
+					Protocol: "https",
+					Host:     "managedhost.com",
+					Port:     9999,
+				},
+			},
+		},
+		{
+			name:  "duplicate endpoints are deduplicated",
+			input: "https://example.live.dynatrace.com/communication;https://example.live.dynatrace.com/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+			},
+		},
+		{
+			name:        "invalid endpoint in list",
+			input:       "https://valid.com/communication;invalidendpoint",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hosts, err := NewOACommunicationHosts(tc.input)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, hosts)
+			}
+		})
+	}
+}
+
+func TestNewAGCommunicationHosts(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    []CommunicationHost
+		expectError bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []CommunicationHost{},
+		},
+		{
+			name:  "single endpoint",
+			input: "https://example.live.dynatrace.com/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+			},
+		},
+		{
+			name:  "multiple endpoints separated by commas",
 			input: "https://example.live.dynatrace.com/communication,https://managedhost.com:9999/here/communication",
 			expected: []CommunicationHost{
 				{
@@ -171,7 +242,7 @@ func TestNewCommunicationHosts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			hosts, err := NewCommunicationHosts(tc.input)
+			hosts, err := NewAGCommunicationHosts(tc.input)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone.go
@@ -37,7 +37,7 @@ func hasStaleNetworkZoneEndpoints(dk *dynakube.DynaKube, endpoints string) bool 
 		return false
 	}
 
-	hosts, err := connectioninfo.NewOACommunicationHosts(endpoints)
+	hosts, err := connectioninfo.ParseOACommunicationHosts(endpoints)
 	if err != nil {
 		return false
 	}

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone.go
@@ -37,7 +37,7 @@ func hasStaleNetworkZoneEndpoints(dk *dynakube.DynaKube, endpoints string) bool 
 		return false
 	}
 
-	hosts, err := connectioninfo.NewCommunicationHosts(endpoints)
+	hosts, err := connectioninfo.NewOACommunicationHosts(endpoints)
 	if err != nil {
 		return false
 	}

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone_test.go
@@ -47,7 +47,7 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 			},
 		}
 
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
@@ -57,13 +57,13 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 
 		// Stale IP that would normally trigger; gate must suppress it because no
 		// network zone is configured.
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("no AG ServiceIPs → not stale (best effort skip)", func(t *testing.T) {
 		dk := newDynaKubeWithAG(nil)
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
@@ -74,52 +74,52 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 
 	t.Run("ServiceIP present alongside local AG DNS endpoint → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("ServiceIP present alongside unrelated endpoints → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		endpoints := "https://1.2.3.4:443/communication,https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://1.2.3.4:443/communication;https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("IPv6 ServiceIP present (bracketed in endpoint URL) → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"2001:db8::1"})
-		endpoints := "https://[2001:db8::1]:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://[2001:db8::1]:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("ServiceIP missing from endpoints → stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.2"})
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.True(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("endpoints contain no IP-based entries at all → stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		endpoints := "https://other-activegate.dynatrace:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://other-activegate.dynatrace:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.True(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("dual-stack: all ServiceIPs present → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1", "2001:db8::1"})
-		endpoints := "https://10.0.0.1:443/communication,https://[2001:db8::1]:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://[2001:db8::1]:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("dual-stack: one ServiceIP missing → stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1", "2001:db8::1"})
 		// Cluster still advertises the previous IPv6 address.
-		endpoints := "https://10.0.0.1:443/communication,https://[2001:db8::2]:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://[2001:db8::2]:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.True(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("unparseable endpoint string → not stale (best effort skip)", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		// "garbage" makes NewCommunicationHosts return an error; the function defers
+		// "garbage" makes NewOACommunicationHosts return an error; the function defers
 		// rather than blocking deployment on an input shape it cannot reason about.
-		endpoints := "garbage,https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "garbage;https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 }

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone_test.go
@@ -117,7 +117,7 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 
 	t.Run("unparseable endpoint string → not stale (best effort skip)", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		// "garbage" makes NewOACommunicationHosts return an error; the function defers
+		// "garbage" makes ParseOACommunicationHosts return an error; the function defers
 		// rather than blocking deployment on an input shape it cannot reason about.
 		endpoints := "garbage;https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -109,7 +109,7 @@ func (r *Reconciler) ReconcileCodeModules(ctx context.Context, dk *dynakube.Dyna
 		return nil
 	}
 
-	oaCommunicationHosts, err := connectioninfo.NewCommunicationHosts(dk.Status.OneAgent.ConnectionInfo.Endpoints)
+	oaCommunicationHosts, err := connectioninfo.NewOACommunicationHosts(dk.Status.OneAgent.ConnectionInfo.Endpoints)
 	if err != nil {
 		setServiceEntryFailedConditionForComponent(dk.Conditions(), codeModuleConditionName)
 
@@ -159,7 +159,7 @@ func (r *Reconciler) ReconcileActiveGate(ctx context.Context, dk *dynakube.DynaK
 		return nil
 	}
 
-	agCommunicationHosts, err := connectioninfo.NewCommunicationHosts(dk.Status.ActiveGate.ConnectionInfo.Endpoints)
+	agCommunicationHosts, err := connectioninfo.NewAGCommunicationHosts(dk.Status.ActiveGate.ConnectionInfo.Endpoints)
 	if err != nil {
 		setServiceEntryFailedConditionForComponent(dk.Conditions(), activeGateConditionName)
 

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -109,7 +109,7 @@ func (r *Reconciler) ReconcileCodeModules(ctx context.Context, dk *dynakube.Dyna
 		return nil
 	}
 
-	oaCommunicationHosts, err := connectioninfo.NewOACommunicationHosts(dk.Status.OneAgent.ConnectionInfo.Endpoints)
+	oaCommunicationHosts, err := connectioninfo.ParseOACommunicationHosts(dk.Status.OneAgent.ConnectionInfo.Endpoints)
 	if err != nil {
 		setServiceEntryFailedConditionForComponent(dk.Conditions(), codeModuleConditionName)
 
@@ -159,7 +159,7 @@ func (r *Reconciler) ReconcileActiveGate(ctx context.Context, dk *dynakube.DynaK
 		return nil
 	}
 
-	agCommunicationHosts, err := connectioninfo.NewAGCommunicationHosts(dk.Status.ActiveGate.ConnectionInfo.Endpoints)
+	agCommunicationHosts, err := connectioninfo.ParseAGCommunicationHosts(dk.Status.ActiveGate.ConnectionInfo.Endpoints)
 	if err != nil {
 		setServiceEntryFailedConditionForComponent(dk.Conditions(), activeGateConditionName)
 

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -528,7 +528,7 @@ func createTestDynaKube() *dynakube.DynaKube {
 		Status: dynakube.DynaKubeStatus{
 			OneAgent: oneagent.Status{
 				ConnectionInfo: communication.ConnectionInfo{
-					Endpoints: fqdnHost.String() + "," + ipHost.String(),
+					Endpoints: fqdnHost.String() + ";" + ipHost.String(),
 				},
 			},
 			ActiveGate: activegate.Status{


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/ICP-7623

The `NewCommunicationHosts` expected the endpoints to be separated via `,`, which is true for the AG endpoints, but not for the OA, which can cause issues with the networkZone check + `enableIstio`.

## How can this be tested?

The most visible way is to use `enableIstio: true` with a OneAgent, and check that the `ServiceEntries` have all endpoints properly listed.