### PR TITLE
Fix update-csv-bundles: scoped git restore, missing deploy manifests, and CSV description updates

### DIFF
--- a/.github/actions/update-csv-bundles/action.yml
+++ b/.github/actions/update-csv-bundles/action.yml
@@ -125,7 +125,9 @@ runs:
         add-paths: |
           config/olm/**
           config/deploy/kubernetes/kustomization.yaml
+          config/deploy/kubernetes/kubernetes.yaml
           config/deploy/openshift/kustomization.yaml
+          config/deploy/openshift/openshift.yaml
           config/manifests/bases/**
           config/helm/**
         commit-message: "[Automatic] Update OLM bundles for v${{ inputs.version }}"
@@ -141,7 +143,9 @@ runs:
         path: |
           config/olm/
           config/deploy/kubernetes/kustomization.yaml
+          config/deploy/kubernetes/kubernetes.yaml
           config/deploy/openshift/kustomization.yaml
+          config/deploy/openshift/openshift.yaml
           config/manifests/bases/
           config/helm/
         if-no-files-found: error

--- a/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dynatrace-operator.clusterserviceversion.yaml
@@ -21,10 +21,11 @@ spec:
   description: |
     The Dynatrace Operator supports rollout and lifecycle management of various Dynatrace components in Kubernetes and OpenShift.
 
-    Currently the Dynatrace Operator supports the following capabilities:
+    The Dynatrace Operator supports the following capabilities:
 
     ### OneAgent
       * `classicFullStack` rolls out one OneAgent pod per node to monitor its pods and the node itself
+      * `cloudNativeFullStack` rolls out one OneAgent pod per node to monitor its pods and the node itself, and injects into application pods via a webhook
       * `applicationMonitoring` is a webhook based injection mechanism for automatic app-only injection
       * `hostMonitoring` monitors only the hosts, i.e., the nodes, in the cluster without app-only injection
     ### ActiveGate
@@ -37,18 +38,18 @@ spec:
     ### Installation
     Once you've installed the Dynatrace Operator, you can create a DynaKube custom resource.
 
-    First, please add a Secret within the Project you've deployed the Dynatrace Operator to, which would contain your API and PaaS tokens. Create tokens of type *Dynatrace API* (`API_TOKEN`) and *Platform as a Service* (`PAAS_TOKEN`) and use their values in the following commands respectively.
+    First, please add a Secret within the Project you've deployed the Dynatrace Operator to, which would contain your API token. Create a token of type *Dynatrace API* (`API_TOKEN`) and use its value in the following command.
 
     For assistance please refer to [Create user-generated access tokens](https://www.dynatrace.com/support/help/shortlink/token#create-user-generated-access-tokens).
 
-    ``` $ kubectl -n <project> create secret generic dynakube --from-literal="apiToken=API_TOKEN" --from-literal="paasToken=PAAS_TOKEN" ```
+    ``` $ kubectl -n <project> create secret generic dynakube --from-literal="apiToken=API_TOKEN" ```
 
-    You may update this Secret at any time to rotate the tokens.
+    You may update this Secret at any time to rotate the token.
 
     After creation of the secret add the DynaKube object in the project where the Dynatrace Operator has been deployed, configured to your needs.
 
     ### Required Parameters
-    * `apiUrl` - provide the URL to the API of your Dynatrace environment. In Dynatrace SaaS it will look like `https://<ENVIRONMENTID>.live.dynatrace.com/api` . In Dynatrace Managed like `https://<YourDynatraceServerURL>/e/<ENVIRONMENTID>/api` .
+    * `apiUrl` - provide the URL to the API of your Dynatrace environment. In Dynatrace SaaS it will look like `https://<ENVIRONMENTID>.live.dynatrace.com/api`.
 
     ### Advanced Options
     * **Disable Certificate Checking** - disable any certificate validation that may interact poorly with proxies with in your cluster

--- a/hack/make/bundle.mk
+++ b/hack/make/bundle.mk
@@ -45,7 +45,7 @@ bundle/show-image-ref:
 bundle: OLM=true # with the current state of the helm chart OLM must always be true when generating the bundle. it should not be set to false accidentally
 bundle: prerequisites/kustomize prerequisites/operator-sdk manifests/$(PLATFORM)/core
 	./hack/build/bundle.sh "$(PLATFORM)" "$(VERSION)" "$(BUNDLE_CHANNELS)" "$(BUNDLE_DEFAULT_CHANNEL)"
-	@git restore config/crd/ config/helm/chart/default/templates/
+	@git restore config/crd/ config/helm/chart/default/templates/ config/manifests/bases/
 
 .PHONY: bundle/build
 ## Build the bundle image

--- a/hack/make/bundle.mk
+++ b/hack/make/bundle.mk
@@ -45,7 +45,7 @@ bundle/show-image-ref:
 bundle: OLM=true # with the current state of the helm chart OLM must always be true when generating the bundle. it should not be set to false accidentally
 bundle: prerequisites/kustomize prerequisites/operator-sdk manifests/$(PLATFORM)/core
 	./hack/build/bundle.sh "$(PLATFORM)" "$(VERSION)" "$(BUNDLE_CHANNELS)" "$(BUNDLE_DEFAULT_CHANNEL)"
-	@git restore config/
+	@git restore config/crd/ config/helm/chart/default/templates/
 
 .PHONY: bundle/build
 ## Build the bundle image


### PR DESCRIPTION

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[ICP-7626](https://dt-rnd.atlassian.net/browse/ICP-7626)

Fixes three issues with the automated OLM bundle workflow, observed in the v1.10.0 bot PR (#6965) where Chart.yaml, schema.yaml, and the kubernetes deploy manifests had to be committed manually.

**Scoped `git restore` in `bundle.mk`**
`make bundle` called `git restore config/` after each run, which reset Chart.yaml and schema.yaml to their pre-release snapshot values. The kubernetes bundle runs after the first restore, so `helm template` baked `app.kubernetes.io/version: 0.0.0-snapshot` into every kubernetes OLM manifest. The restore is now scoped to only the intermediate files that actually need cleanup (`config/crd/` and `config/helm/chart/default/templates/`), leaving Chart.yaml, schema.yaml, and the generated deploy manifests intact.

**Missing deploy manifest paths in `add-paths`**
`config/deploy/kubernetes/kubernetes.yaml` and `config/deploy/openshift/openshift.yaml` were generated by `make bundle` but never listed in the `create-pull-request` add-paths block (or the dry-run artifact upload), so they were silently excluded from the bot PR.

**CSV description updates**
- Added `cloudNativeFullStack` to the OneAgent capability list
- Added `dynatrace-api` to the ActiveGate capability list
- Added missing top-level capability sections: Log Monitoring, Extensions, and KSPM
- Removed the deprecated `paasToken` secret field from the installation instructions
- Removed the Dynatrace Managed URL reference (EOL)
- Removed stale "Currently" wording

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Trigger the `Update CSV Bundles` workflow via `workflow_dispatch` with `dry-run: true` and verify the downloaded artifact contains correct versions in `kubernetes.yaml` / `openshift.yaml` and that both files are present alongside the OLM bundle content.

[ICP-7626]: https://dt-rnd.atlassian.net/browse/ICP-7626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ