### PR TITLE
Fix create-marketplaces-forks: workflows push rejection, missing Dockerfile, and wrong spec.replaces

### DIFF
--- a/.github/workflows/create-marketplaces-forks.yaml
+++ b/.github/workflows/create-marketplaces-forks.yaml
@@ -177,10 +177,7 @@ jobs:
 
           csv_file="${operator_dir}/manifests/dynatrace-operator.clusterserviceversion.yaml"
 
-          # community-prod never sets spec.replaces; all others set it to the previous version when one exists
-          if [ "${MARKETPLACE}" = "community-prod" ]; then
-            yq e -i 'del(.spec.replaces)' "${csv_file}"
-          elif [ -n "${last_version}" ]; then
+          if [ -n "${last_version}" ]; then
             if [ "${MARKETPLACE}" = "redhat" ]; then
               yq -i ".spec.replaces = \"dynatrace-operator-rhmp.v${last_version}\"" "${csv_file}"
             else

--- a/.github/workflows/create-marketplaces-forks.yaml
+++ b/.github/workflows/create-marketplaces-forks.yaml
@@ -122,10 +122,6 @@ jobs:
           fi
           git checkout -B "${branch_name}" "upstream/main"
 
-          # Remove upstream workflow files so the push does not require the workflows permission.
-          git rm -rf --cached .github/workflows/ 2>/dev/null || true
-          rm -rf .github/workflows/
-
           echo "FORK_REPO_DIR=$(pwd)" >> "$GITHUB_ENV"
           echo "BRANCH_NAME=${branch_name}" >> "$GITHUB_ENV"
       - name: Prepare bundle files for ${{ env.MARKETPLACE }}
@@ -218,7 +214,11 @@ jobs:
         run: |
           cd "${FORK_REPO_DIR}"
 
-          git add -A
+          if [ "${MARKETPLACE}" = "redhat" ]; then
+            git add "operators/dynatrace-operator-rhmp/${VERSION}/"
+          else
+            git add "operators/dynatrace-operator/${VERSION}/"
+          fi
           if git diff-index --quiet HEAD; then
             echo "No changes to commit; nothing to push for ${MARKETPLACE}."
             exit 0

--- a/.github/workflows/create-marketplaces-forks.yaml
+++ b/.github/workflows/create-marketplaces-forks.yaml
@@ -122,6 +122,10 @@ jobs:
           fi
           git checkout -B "${branch_name}" "upstream/main"
 
+          # Remove upstream workflow files so the push does not require the workflows permission.
+          git rm -rf --cached .github/workflows/ 2>/dev/null || true
+          rm -rf .github/workflows/
+
           echo "FORK_REPO_DIR=$(pwd)" >> "$GITHUB_ENV"
           echo "BRANCH_NAME=${branch_name}" >> "$GITHUB_ENV"
       - name: Prepare bundle files for ${{ env.MARKETPLACE }}
@@ -145,17 +149,27 @@ jobs:
             operator_dir="operators/dynatrace-operator/${VERSION}"
           fi
 
+          # Detect previous version BEFORE creating the new directory so the current version is not included in the scan
+          if [ "${MARKETPLACE}" = "redhat" ]; then
+            operator_versions_dirs="$(ls -d operators/dynatrace-operator-rhmp/*/ 2>/dev/null || true)"
+          else
+            operator_versions_dirs="$(ls -d operators/dynatrace-operator/*/ 2>/dev/null || true)"
+          fi
+          # strip trailing slash and path prefix from each dir, filter out non-version strings, then pick the highest semver
+          last_version="$(echo "${operator_versions_dirs}" | sed 's|/$||' | sed 's|.*/||' | grep -E '^[vV]?[0-9]' | sort -V | tail -1)"
+
           mkdir -p "${operator_dir}"
 
           # Copy bundle files
           cp -rf "${GITHUB_WORKSPACE}/release-src/config/olm/${bundle_source}/${VERSION}/manifests" "${operator_dir}/"
           cp -rf "${GITHUB_WORKSPACE}/release-src/config/olm/${bundle_source}/${VERSION}/metadata" "${operator_dir}/"
 
-          # Create Dockerfile for community marketplaces
+          # Create Dockerfile for community marketplaces using the platform-appropriate source
           if [ "${MARKETPLACE}" = "community" ] || [ "${MARKETPLACE}" = "community-prod" ]; then
             echo "Creating Dockerfile for ${MARKETPLACE}"
-            origin_dockerfile="${GITHUB_WORKSPACE}/release-src/config/olm/kubernetes/${VERSION}/bundle.Dockerfile"
+            origin_dockerfile="${GITHUB_WORKSPACE}/release-src/config/olm/${bundle_source}/${VERSION}/bundle.Dockerfile"
             target_dockerfile="${operator_dir}/Dockerfile"
+            cp "${origin_dockerfile}" "${target_dockerfile}"
           fi
 
           # Update package annotation for redhat
@@ -165,18 +179,12 @@ jobs:
               "${operator_dir}/metadata/annotations.yaml"
           fi
 
-          # Determine last existing version and set spec.replaces
-          if [ "${MARKETPLACE}" = "redhat" ]; then
-            operator_versions_dirs="$(ls -d operators/dynatrace-operator-rhmp/*/ 2>/dev/null || true)"
-          else
-            operator_versions_dirs="$(ls -d operators/dynatrace-operator/*/ 2>/dev/null || true)"
-          fi
-          # strip trailing slash and path prefix from each dir, filter out non-version strings, then pick the highest semver
-          last_version="$(echo "${operator_versions_dirs}" | sed 's|/$||' | sed 's|.*/||' | grep -E '^[vV]?[0-9]' | sort -V | tail -1)"
-
           csv_file="${operator_dir}/manifests/dynatrace-operator.clusterserviceversion.yaml"
 
-          if [ -n "${last_version}" ]; then
+          # community-prod never sets spec.replaces; all others set it to the previous version when one exists
+          if [ "${MARKETPLACE}" = "community-prod" ]; then
+            yq e -i 'del(.spec.replaces)' "${csv_file}"
+          elif [ -n "${last_version}" ]; then
             if [ "${MARKETPLACE}" = "redhat" ]; then
               yq -i ".spec.replaces = \"dynatrace-operator-rhmp.v${last_version}\"" "${csv_file}"
             else


### PR DESCRIPTION


<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[ICP-7631](https://dt-rnd.atlassian.net/browse/ICP-7631)

Fixes three bugs in the `create-marketplaces-forks` workflow that required manual intervention on every release.


~~**Community push rejected (missing `workflows` permission)**~~

This is fixed by not touching workflow files at all, which is why I striked it out here

**Dockerfile never copied anmd community-prod used wrong source**

**`spec.replaces` pointed to current version**


## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Trigger the `Create forks for marketplaces` workflow via `workflow_dispatch` with a release branch and `fork_branch` override, then verify:
1. The community fork branch is pushed without a push rejection
2. A `Dockerfile` is present in the operator directory for both community and community-prod
3. `spec.replaces` in the community CSV points to the previous release version, not the current one

[ICP-7631]: https://dt-rnd.atlassian.net/browse/ICP-7631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ