### PR TITLE
Switch kubemon integration tests to a direct API client

### DIFF
--- a/pkg/controllers/dynakube/kubemon/connectioninfo/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/connectioninfo/reconciler_integration_test.go
@@ -3,7 +3,6 @@ package connectioninfo_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	kubemonapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
@@ -23,23 +22,20 @@ import (
 )
 
 // Integration tests for the connectioninfo reconciler against a real API server. Drives one DynaKube
-// through ordered, state-sharing phases; most phases assert with a single reconcile call and apiReader.
-// Branch and error logic is covered by the unit test.
+// through ordered, state-sharing phases; each phase asserts with a single reconcile call against a
+// direct API client. Branch and error logic is covered by the unit test.
 
 const (
-	integrationNamespace         = "dynatrace"
-	integrationTenantUUID        = "test-uuid"
-	integrationEndpoints         = "https://tenant.live.dynatrace.com/communication"
-	integrationTenantToken       = "test-token"
-	integrationEventuallyTimeout = 5 * time.Second
-	integrationEventuallyTick    = 50 * time.Millisecond
+	integrationNamespace   = "dynatrace"
+	integrationTenantUUID  = "test-uuid"
+	integrationEndpoints   = "https://tenant.live.dynatrace.com/communication"
+	integrationTenantToken = "test-token"
 )
 
 var anyContext = mock.MatchedBy(func(context.Context) bool { return true })
 
 type lifecycleDeps struct {
 	clt                    client.Client
-	apiReader              client.Reader
 	reconciler             *connectioninfo.Reconciler
 	dk                     *dynakube.DynaKube
 	baselineConnectionInfo agclient.ConnectionInfo
@@ -48,7 +44,7 @@ type lifecycleDeps struct {
 
 // TestReconcileLifecycle walks the phases in order: provision → rotate → stabilize → disable → re-enable.
 func TestReconcileLifecycle(t *testing.T) {
-	clt, apiReader := integrationtests.SetupCachedTestEnvironment(t)
+	clt := integrationtests.SetupTestEnvironment(t)
 	ctx := t.Context()
 	reconciler := connectioninfo.NewReconciler(clt)
 
@@ -81,7 +77,6 @@ func TestReconcileLifecycle(t *testing.T) {
 	// The subtests below share dk and run in order: each builds on the state left by the previous one.
 	deps := lifecycleDeps{
 		clt:                    clt,
-		apiReader:              apiReader,
 		reconciler:             reconciler,
 		dk:                     dk,
 		baselineConnectionInfo: baselineConnectionInfo,
@@ -102,14 +97,14 @@ func runProvisionPhase(t *testing.T, deps lifecycleDeps) {
 	dtClient.EXPECT().GetConnectionInfo(anyContext).Return(deps.baselineConnectionInfo, nil)
 
 	require.NoError(t, deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk))
-	require.True(t, isConnectionInfoApplied(t.Context(), deps.apiReader, deps.dk, deps.baselineConnectionInfo))
+	require.True(t, isConnectionInfoApplied(t.Context(), deps.clt, deps.dk, deps.baselineConnectionInfo))
 
-	cm := getConfigMap(t, deps.apiReader, deps.dk)
+	cm := getConfigMap(t, deps.clt, deps.dk)
 	assert.Len(t, cm.Data, 2)
 	assertManagedLabels(t, cm.Labels, deps.dk)
 	assert.True(t, metav1.IsControlledBy(cm, deps.dk))
 
-	secret := getSecret(t, deps.apiReader, deps.dk)
+	secret := getSecret(t, deps.clt, deps.dk)
 	assert.Len(t, secret.Data, 1)
 	assertManagedLabels(t, secret.Labels, deps.dk)
 	assert.True(t, metav1.IsControlledBy(secret, deps.dk))
@@ -122,7 +117,7 @@ func runRotatePhase(t *testing.T, deps lifecycleDeps) {
 	dtClient.EXPECT().GetConnectionInfo(anyContext).Return(deps.rotatedConnectionInfo, nil)
 
 	require.NoError(t, deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk))
-	require.True(t, isConnectionInfoApplied(t.Context(), deps.apiReader, deps.dk, deps.rotatedConnectionInfo))
+	require.True(t, isConnectionInfoApplied(t.Context(), deps.clt, deps.dk, deps.rotatedConnectionInfo))
 }
 
 func runStabilizePhase(t *testing.T, deps lifecycleDeps) {
@@ -131,14 +126,14 @@ func runStabilizePhase(t *testing.T, deps lifecycleDeps) {
 	dtClient := agclientmock.NewClient(t)
 	dtClient.EXPECT().GetConnectionInfo(anyContext).Return(deps.rotatedConnectionInfo, nil)
 
-	cmRV := getConfigMap(t, deps.apiReader, deps.dk).ResourceVersion
-	secretRV := getSecret(t, deps.apiReader, deps.dk).ResourceVersion
+	cmRV := getConfigMap(t, deps.clt, deps.dk).ResourceVersion
+	secretRV := getSecret(t, deps.clt, deps.dk).ResourceVersion
 
 	// Repeated reconciles with identical input must not rewrite resources.
 	for range 3 {
 		require.NoError(t, deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk))
-		assert.Equal(t, cmRV, getConfigMap(t, deps.apiReader, deps.dk).ResourceVersion)
-		assert.Equal(t, secretRV, getSecret(t, deps.apiReader, deps.dk).ResourceVersion)
+		assert.Equal(t, cmRV, getConfigMap(t, deps.clt, deps.dk).ResourceVersion)
+		assert.Equal(t, secretRV, getSecret(t, deps.clt, deps.dk).ResourceVersion)
 	}
 }
 
@@ -149,8 +144,8 @@ func runDisablePhase(t *testing.T, deps lifecycleDeps) {
 
 	require.NoError(t, deps.reconciler.Reconcile(t.Context(), nil, deps.dk))
 
-	cmErr := deps.apiReader.Get(t.Context(), client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetConnectionInfoConfigMapName(), Namespace: deps.dk.Namespace}, &corev1.ConfigMap{})
-	secretErr := deps.apiReader.Get(t.Context(), client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetTenantSecretName(), Namespace: deps.dk.Namespace}, &corev1.Secret{})
+	cmErr := deps.clt.Get(t.Context(), client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetConnectionInfoConfigMapName(), Namespace: deps.dk.Namespace}, &corev1.ConfigMap{})
+	secretErr := deps.clt.Get(t.Context(), client.ObjectKey{Name: deps.dk.KubernetesMonitoring().GetTenantSecretName(), Namespace: deps.dk.Namespace}, &corev1.Secret{})
 	require.True(t, k8serrors.IsNotFound(cmErr))
 	require.True(t, k8serrors.IsNotFound(secretErr))
 	assert.Empty(t, deps.dk.Status.KubernetesMonitoring.ConnectionInfo.TenantUUID)
@@ -164,12 +159,8 @@ func runReEnablePhase(t *testing.T, deps lifecycleDeps) {
 	dtClient := agclientmock.NewClient(t)
 	dtClient.EXPECT().GetConnectionInfo(anyContext).Return(deps.baselineConnectionInfo, nil)
 
-	// The cache backing the reconciler may still hold the config map/secret deleted by the disable
-	// phase, so retry until the deletion has propagated and the reconcile re-creates them.
-	require.Eventually(t, func() bool {
-		return deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk) == nil
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
-	require.True(t, isConnectionInfoApplied(t.Context(), deps.apiReader, deps.dk, deps.baselineConnectionInfo))
+	require.NoError(t, deps.reconciler.Reconcile(t.Context(), dtClient, deps.dk))
+	require.True(t, isConnectionInfoApplied(t.Context(), deps.clt, deps.dk, deps.baselineConnectionInfo))
 }
 
 func getConfigMap(t *testing.T, reader client.Reader, dk *dynakube.DynaKube) *corev1.ConfigMap {

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
@@ -2,9 +2,7 @@ package statefulset_test
 
 import (
 	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	kubemonapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
@@ -22,18 +20,15 @@ import (
 )
 
 // Integration tests for the statefulset reconciler against a real API server. Drives one DynaKube
-// through ordered, state-sharing phases; most phases assert with a single reconcile call and apiReader.
-// Branch and error logic is covered by the unit test.
+// through ordered, state-sharing phases; each phase asserts with a single reconcile call against a
+// direct API client. Branch and error logic is covered by the unit test.
 
 const (
-	integrationNamespace         = "dynatrace"
-	integrationEventuallyTimeout = 5 * time.Second
-	integrationEventuallyTick    = 50 * time.Millisecond
+	integrationNamespace = "dynatrace"
 )
 
 type lifecycleDeps struct {
 	clt                    client.Client
-	apiReader              client.Reader
 	reconciler             *statefulset.Reconciler
 	dk                     *dynakube.DynaKube
 	secret                 *corev1.Secret
@@ -43,7 +38,7 @@ type lifecycleDeps struct {
 
 // TestReconcileLifecycle walks the phases in order: provision → rollout complete → rotate → disable → re-enable.
 func TestReconcileLifecycle(t *testing.T) {
-	clt, apiReader := integrationtests.SetupCachedTestEnvironment(t)
+	clt := integrationtests.SetupTestEnvironment(t)
 
 	integrationtests.CreateNamespace(t, t.Context(), clt, integrationNamespace)
 
@@ -79,7 +74,6 @@ func TestReconcileLifecycle(t *testing.T) {
 	// The subtests below share dk and run in order: each builds on the state left by the previous one.
 	deps := &lifecycleDeps{
 		clt:        clt,
-		apiReader:  apiReader,
 		reconciler: reconciler,
 		dk:         dk,
 		secret:     secret,
@@ -98,7 +92,7 @@ func runProvisionPhase(t *testing.T, deps *lifecycleDeps) {
 
 	require.ErrorIs(t, deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress)
 
-	sts := getStatefulSet(t, deps.apiReader, deps.dk)
+	sts := getStatefulSet(t, deps.clt, deps.dk)
 
 	assertStatefulSetShape(t, sts, deps.dk)
 
@@ -111,10 +105,7 @@ func runRolloutCompletePhase(t *testing.T, deps *lifecycleDeps) {
 
 	markRolloutComplete(t, t.Context(), deps.clt, deps.dk)
 
-	// Retry until the cache reflects the completed status and reconcile reports no error.
-	require.Eventually(t, func() bool {
-		return deps.reconciler.Reconcile(t.Context(), deps.dk) == nil
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
+	require.NoError(t, deps.reconciler.Reconcile(t.Context(), deps.dk))
 }
 
 func runRotatePhase(t *testing.T, deps *lifecycleDeps) {
@@ -123,31 +114,22 @@ func runRotatePhase(t *testing.T, deps *lifecycleDeps) {
 	deps.secret.Data[connectioninfo.TenantTokenKey] = []byte("rotated-tenant-token")
 	require.NoError(t, deps.clt.Update(t.Context(), deps.secret))
 
-	require.Eventually(t, func() bool {
-		if !errors.Is(deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress) {
-			return false
-		}
-		sts := &appsv1.StatefulSet{}
-		if err := deps.clt.Get(t.Context(), statefulSetKey(deps.dk), sts); err != nil {
-			return false
-		}
-		deps.rotatedTenantTokenHash = sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash]
+	require.ErrorIs(t, deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress)
 
-		return deps.rotatedTenantTokenHash != deps.initialTenantTokenHash
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
-
+	sts := getStatefulSet(t, deps.clt, deps.dk)
+	deps.rotatedTenantTokenHash = sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash]
 	assert.NotEqual(t, deps.initialTenantTokenHash, deps.rotatedTenantTokenHash)
 }
 
 func runStabilizePhase(t *testing.T, deps *lifecycleDeps) {
 	t.Helper()
 
-	stsRV := getStatefulSet(t, deps.apiReader, deps.dk).ResourceVersion
+	stsRV := getStatefulSet(t, deps.clt, deps.dk).ResourceVersion
 
 	// Repeated reconciles with identical input must not rewrite the StatefulSet.
 	for range 3 {
 		require.ErrorIs(t, deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress)
-		assert.Equal(t, stsRV, getStatefulSet(t, deps.apiReader, deps.dk).ResourceVersion)
+		assert.Equal(t, stsRV, getStatefulSet(t, deps.clt, deps.dk).ResourceVersion)
 	}
 }
 
@@ -159,7 +141,7 @@ func runDisablePhase(t *testing.T, deps *lifecycleDeps) {
 
 	require.NoError(t, deps.reconciler.Reconcile(t.Context(), deps.dk))
 
-	err := deps.apiReader.Get(t.Context(), client.ObjectKey{Name: name, Namespace: integrationNamespace}, &appsv1.StatefulSet{})
+	err := deps.clt.Get(t.Context(), client.ObjectKey{Name: name, Namespace: integrationNamespace}, &appsv1.StatefulSet{})
 	require.True(t, k8serrors.IsNotFound(err))
 }
 
@@ -169,17 +151,9 @@ func runReEnablePhase(t *testing.T, deps *lifecycleDeps) {
 	deps.dk.Spec.KubernetesMonitoring = &kubemonapi.Spec{}
 	deps.dk.Spec.KubernetesMonitoring.Image = "registry.example.com/linux/activegate:1.2.3"
 
-	// The cache backing the reconciler may still hold the StatefulSet deleted by the disable phase,
-	// so retry until the deletion has propagated, reconcile recreates it, and apiReader observes it.
-	sts := &appsv1.StatefulSet{}
-	require.Eventually(t, func() bool {
-		if !errors.Is(deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress) {
-			return false
-		}
+	require.ErrorIs(t, deps.reconciler.Reconcile(t.Context(), deps.dk), k8sstatefulset.ErrRolloutInProgress)
 
-		return deps.apiReader.Get(t.Context(), statefulSetKey(deps.dk), sts) == nil
-	}, integrationEventuallyTimeout, integrationEventuallyTick)
-
+	sts := getStatefulSet(t, deps.clt, deps.dk)
 	assertStatefulSetShape(t, sts, deps.dk)
 	assert.Equal(t, deps.rotatedTenantTokenHash, sts.Spec.Template.Annotations[statefulset.AnnotationTenantTokenHash])
 }

--- a/test/integrationtests/environment.go
+++ b/test/integrationtests/environment.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/projectpath"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -71,65 +70,6 @@ func SetupTestEnvironment(tb testing.TB, opts ...TestEnvOpt) client.Client {
 	return clt
 }
 
-// startManager creates a Manager from cfg, runs it in a background goroutine, and waits for cache
-// sync. tb.Cleanup cancels the manager when the test ends.
-func startManager(tb testing.TB, cfg *rest.Config, setup func(ctrl.Manager) error) ctrl.Manager {
-	tb.Helper()
-
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:         testEnv.Scheme,
-		LeaderElection: false,
-		Metrics:        metricsserver.Options{BindAddress: "0"},
-	})
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	if setup != nil {
-		if err := setup(mgr); err != nil {
-			tb.Fatal(err)
-		}
-	}
-
-	ctx := tb.Context()
-
-	go func() {
-		if err := mgr.Start(ctx); err != nil {
-			tb.Error(err, "run manager")
-		}
-	}()
-
-	if !mgr.GetCache().WaitForCacheSync(ctx) {
-		tb.Fatal("cache failed to sync")
-	}
-
-	return mgr
-}
-
-func SetupCachedTestEnvironment(tb testing.TB, opts ...TestEnvOpt) (client.Client, client.Reader) {
-	setupBaseTestEnv(tb)
-
-	for _, opt := range opts {
-		opt(testEnv)
-	}
-
-	cfg, err := testEnv.Start()
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	tb.Cleanup(func() {
-		if err := testEnv.Stop(); err != nil {
-			tb.Error(err, "stop env")
-		}
-	})
-
-	mgr := startManager(tb, cfg, nil)
-
-	return mgr.GetClient(), mgr.GetAPIReader()
-}
-
-// TODO: could be refactored to use startManager
 func SetupWebhookTestEnvironment(t *testing.T, webhookOptions envtest.WebhookInstallOptions, webhookSetup func(ctrl.Manager) error) client.Client {
 	setupBaseTestEnv(t)
 


### PR DESCRIPTION
The kubemon _statefulset_ and _connectioninfo_ integration tests ran against the manager's cached client and hand-gated each phase against simulated cache/watch timing to cover eventual consistency. After trying to get that right in #6972, I concluded it's too difficult to get right in envtest (no real controller manager) for too little value — it never caught a real bug, and a stale read just requeues and self-corrects.

This PR:
- Switches both tests to `SetupTestEnvironment` (single direct, read-after-write-consistent client); each phase is now one reconcile with no `Eventually`/cache-sync loops.
- Deletes the now-unused `SetupCachedTestEnvironment` / `startManager` helpers.

Eventual-consistency behavior belongs in e2e, not envtest.