### PR TITLE
Remove control characters from PMC properties

### DIFF
--- a/pkg/injection/namespace/bootstrapperconfig/pmc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pmc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,6 +82,8 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk *dynakube.DynaKube)
 
 	pmConfig.SortPropertiesByKey()
 
+	sanitizePMC(log, dk, pmConfig)
+
 	marshaled, err := json.Marshal(pmConfig)
 	if err != nil {
 		k8sconditions.SetSecretGenFailed(dk.Conditions(), ConfigConditionType, err)
@@ -91,6 +94,27 @@ func (s *SecretGenerator) preparePMC(ctx context.Context, dk *dynakube.DynaKube)
 	}
 
 	return marshaled, nil
+}
+
+// sanitizePMC removes control characters from PMC properties to prevent
+// injection of malicious INI sections/keys in ruxitagentproc.conf.
+func sanitizePMC(log logd.Logger, dk *dynakube.DynaKube, pmConfig *oneagentclient.ProcessModuleConfig) {
+	for i := range pmConfig.Properties {
+		property := &pmConfig.Properties[i]
+
+		sanitizedSection := sanitize.CommandLineArg(property.Section)
+		sanitizedKey := sanitize.CommandLineArg(property.Key)
+		sanitizedValue := sanitize.CommandLineArg(property.Value)
+
+		if sanitizedSection != property.Section || sanitizedKey != property.Key || sanitizedValue != property.Value {
+			log.Info("stripped control characters from process module config property",
+				"dynakube", dk.Name, "section", property.Section, "key", property.Key)
+		}
+
+		property.Section = sanitizedSection
+		property.Key = sanitizedKey
+		property.Value = sanitizedValue
+	}
 }
 
 func (s *SecretGenerator) getCachedPMC(ctx context.Context, dk *dynakube.DynaKube) (*oneagentclient.ProcessModuleConfig, error) {

--- a/pkg/injection/namespace/bootstrapperconfig/pmc_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pmc_test.go
@@ -15,6 +15,7 @@ import (
 	oneagentclient "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/connectioninfo"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	oneagentclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/oneagent"
 	"github.com/stretchr/testify/assert"
@@ -303,6 +304,89 @@ func TestPreparePMC(t *testing.T) {
 		var pmConfig oneagentclient.ProcessModuleConfig
 		err = json.Unmarshal(result, &pmConfig)
 		require.NoError(t, err)
+	})
+}
+
+func TestSanitizePMC(t *testing.T) {
+	dk := &dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "some-dynakube",
+		},
+	}
+
+	t.Run("control chars in value => stripped", func(t *testing.T) {
+		pmConfig := &oneagentclient.ProcessModuleConfig{
+			Properties: []oneagentclient.ProcessModuleProperty{
+				{
+					Section: "general",
+					Key:     "containerInjectionRules",
+					Value:   "x\n[SpecializedAgent]\nlibraryPath64 /tmp\n[general]\nx",
+				},
+			},
+		}
+
+		sanitizePMC(logd.Get(), dk, pmConfig)
+
+		assert.Equal(t, "x[SpecializedAgent]libraryPath64 /tmp[general]x", pmConfig.Properties[0].Value)
+		assert.NotContains(t, pmConfig.Properties[0].Value, "\n")
+	})
+
+	t.Run("clean value => untouched", func(t *testing.T) {
+		pmConfig := &oneagentclient.ProcessModuleConfig{
+			Properties: []oneagentclient.ProcessModuleProperty{
+				{
+					Section: "general",
+					Key:     "hostGroup",
+					Value:   "clean-value",
+				},
+			},
+		}
+
+		sanitizePMC(logd.Get(), dk, pmConfig)
+
+		assert.Equal(t, "clean-value", pmConfig.Properties[0].Value)
+	})
+
+	t.Run("control chars in section/key => stripped", func(t *testing.T) {
+		pmConfig := &oneagentclient.ProcessModuleConfig{
+			Properties: []oneagentclient.ProcessModuleProperty{
+				{
+					Section: "general\n[other]",
+					Key:     "key\t",
+					Value:   "value\r",
+				},
+			},
+		}
+
+		sanitizePMC(logd.Get(), dk, pmConfig)
+
+		assert.Equal(t, "general[other]", pmConfig.Properties[0].Section)
+		assert.Equal(t, "key", pmConfig.Properties[0].Key)
+		assert.Equal(t, "value", pmConfig.Properties[0].Value)
+	})
+
+	t.Run("injected newline + marshaling/unmarshaling => single-line value", func(t *testing.T) {
+		pmConfig := &oneagentclient.ProcessModuleConfig{
+			Properties: []oneagentclient.ProcessModuleProperty{
+				{
+					Section: "general",
+					Key:     "containerInjectionRules",
+					Value:   "x\n[SpecializedAgent]\nlibraryPath64 /tmp\n[general]\nx",
+				},
+			},
+		}
+
+		sanitizePMC(logd.Get(), dk, pmConfig)
+
+		marshaled, err := json.Marshal(pmConfig)
+		require.NoError(t, err)
+
+		var roundTripped oneagentclient.ProcessModuleConfig
+		require.NoError(t, json.Unmarshal(marshaled, &roundTripped))
+
+		require.Len(t, roundTripped.Properties, 1)
+		assert.NotContains(t, roundTripped.Properties[0].Value, "\n")
+		assert.Equal(t, "x[SpecializedAgent]libraryPath64 /tmp[general]x", roundTripped.Properties[0].Value)
 	})
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Under certain circumstances, tenant settings values accept newlines, which are passed to the bootstrapper config, then written to `ruxitagentproc.conf`.
This is problematic because control characters like newlines could let property values inject additional INI sections.

Relevant ticket: ICP-6290.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Unit tests