### PR TITLE
Fix webhook CrashLoopBackOff on gVisor nodes

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -111,7 +111,7 @@ spec:
               {{- toYaml (.Values.webhook).limits | nindent 14 }}
           volumeMounts:
             - name: certs-dir
-              mountPath: /tmp/k8s-webhook-server/serving-certs/
+              mountPath: /tmp/k8s-webhook-server/serving-certs
           securityContext:
           {{- include "webhook.securityContext" . | nindent 12 }}
       serviceAccountName: dynatrace-webhook

--- a/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/deployment-webhook_test.yaml
@@ -185,7 +185,7 @@ tests:
                     memory: 128Mi
                 volumeMounts:
                   - name: certs-dir
-                    mountPath: /tmp/k8s-webhook-server/serving-certs/
+                    mountPath: /tmp/k8s-webhook-server/serving-certs
                 securityContext:
                   seccompProfile:
                     type: RuntimeDefault
@@ -398,7 +398,7 @@ tests:
                     memory: 128Mi
                 volumeMounts:
                   - name: certs-dir
-                    mountPath: /tmp/k8s-webhook-server/serving-certs/
+                    mountPath: /tmp/k8s-webhook-server/serving-certs
                 securityContext:
                   seccompProfile:
                     type: RuntimeDefault
@@ -576,7 +576,7 @@ tests:
                     memory: 128Mi
                 volumeMounts:
                   - name: certs-dir
-                    mountPath: /tmp/k8s-webhook-server/serving-certs/
+                    mountPath: /tmp/k8s-webhook-server/serving-certs
                 securityContext:
                   seccompProfile:
                     type: RuntimeDefault

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -46,7 +46,7 @@ const (
 	clusterCaCertVolumeMountPath = "/mnt/dynatrace/certs"
 
 	activeGateCaCertVolumeName      = "active-gate-ca"
-	activeGateCaCertVolumeMountPath = "/mnt/dynatrace/certs/activegate/"
+	activeGateCaCertVolumeMountPath = "/mnt/dynatrace/certs/activegate"
 
 	csiStorageVolumeName  = "osagent-storage"
 	csiStorageVolumeMount = "/mnt/volume_storage_mount"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-7883](https://dt-rnd.atlassian.net/browse/ICP-7883)

The `webhook` pod crashes immediately when scheduled on a gVisor node
(`runtimeClassName: gvisor`). gVisor interprets a trailing slash on a
volumeMount `mountPath` as an instruction to create a new directory as a mountpoint.
When the target path already exists inside the container image, gVisor returns
`file exists` and fails container startup.

Removed the trailing slash from the `certs-dir` volumeMount `mountPath`.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

1. Create a gVisor node pool on your GKE cluster:

```
   gcloud container node-pools create gvisor-pool \
     --cluster=<cluster-name> \
     --region=<region> \
     --sandbox type=gvisor \
     --num-nodes=1 \
     --machine-type=e2-standard-4
```

2. Deploy the operator:

   make deploy

3. Patch the webhook Deployment to use the gVisor runtime class:

```
   kubectl patch deployment dynatrace-webhook -n dynatrace \
     --type=merge \
     -p '{"spec":{"template":{"spec":{"runtimeClassName":"gvisor"}}}}'
```

4. Verify the rollout completes without CrashLoopBackOff:

   kubectl rollout status deployment/dynatrace-webhook -n dynatrace

   Before the fix, pods would fail immediately with:
   "failed to create directory mountpoint ... serving-certs/: file exists"

   After the fix, the rollout should complete successfully.

[ICP-7883]: https://dt-rnd.atlassian.net/browse/ICP-7883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ