### PR TITLE
ci: nightly chart and image for daily fips e2e runs

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -33,7 +33,8 @@ echo "Running make target: ${TARGET:-default}"
 if [[ $FLC_ENVIRONMENT =~ "olm" ]]; then
   make OLM=true "${TARGET:-test/e2e/no-csi/publish}"
 elif [[ $FLC_ENVIRONMENT =~ "fips" ]]; then
-  make BRANCH="$TARGET_BRANCH" FIPS=true "${TARGET:-test/e2e-publish}"
+  export FIPS=true
+  make BRANCH="$TARGET_BRANCH" "${TARGET:-test/e2e-publish}"
 else
   make BRANCH="$TARGET_BRANCH" "${TARGET:-test/e2e-publish}"
 fi

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -33,8 +33,7 @@ echo "Running make target: ${TARGET:-default}"
 if [[ $FLC_ENVIRONMENT =~ "olm" ]]; then
   make OLM=true "${TARGET:-test/e2e/no-csi/publish}"
 elif [[ $FLC_ENVIRONMENT =~ "fips" ]]; then
-  export FIPS=true
-  make BRANCH="$TARGET_BRANCH" "${TARGET:-test/e2e-publish}"
+  make BRANCH="$TARGET_BRANCH" FIPS=true "${TARGET:-test/e2e-publish}"
 else
   make BRANCH="$TARGET_BRANCH" "${TARGET:-test/e2e-publish}"
 fi

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -513,6 +513,7 @@ jobs:
         with:
           flc-namespace: dto
           flc-environment: dto-ocp-fips
+          helm-chart: ${{ github.event.inputs.helm-chart || 'oci://ghcr.io/dynatrace/dynatrace-operator:0.0.0-nightly-chart' }}
           target-branch: ${{ github.event.inputs.target }}
           tenant1-name: ${{ secrets.TENANT1_NAME }}
           tenant1-apitoken: ${{ secrets.TENANT1_APITOKEN }}

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -239,9 +239,10 @@ func getHelmOptions(releaseTag, platform string, withCSI bool) ([]helm.Option, e
 	if chartURI := os.Getenv("HELM_CHART"); strings.HasSuffix(chartURI, ":0.0.0-nightly-chart") {
 		opts = append(opts, helm.WithArgs(chartURI))
 		if isFIPS {
-			registry := strings.TrimPrefix(strings.TrimSuffix(chartURI, ":0.0.0-nightly-chart"), "oci://")
+			repository := strings.TrimPrefix(strings.TrimSuffix(chartURI, ":0.0.0-nightly-chart"), "oci://")
 			opts = append(opts,
-				helm.WithArgs("--set", "image="+registry+":nightly-fips"),
+				helm.WithArgs("--set", "imageRef.repository="+repository),
+				helm.WithArgs("--set", "imageRef.tag=nightly-fips"),
 				helm.WithArgs("--set", "imageRef.pullPolicy=Always"),
 			)
 		}

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -237,7 +237,16 @@ func getHelmOptions(releaseTag, platform string, withCSI bool) ([]helm.Option, e
 
 	// Install nightly
 	if chartURI := os.Getenv("HELM_CHART"); strings.HasSuffix(chartURI, ":0.0.0-nightly-chart") {
-		return append(opts, helm.WithArgs(chartURI)), nil
+		opts = append(opts, helm.WithArgs(chartURI))
+		if isFIPS {
+			registry := strings.TrimPrefix(strings.TrimSuffix(chartURI, ":0.0.0-nightly-chart"), "oci://")
+			opts = append(opts,
+				helm.WithArgs("--set", "image="+registry+":nightly-fips"),
+				helm.WithArgs("--set", "imageRef.pullPolicy=Always"),
+			)
+		}
+
+		return opts, nil
 	}
 
 	return append(opts,

--- a/test/e2e/helpers/components/operator/installation_test.go
+++ b/test/e2e/helpers/components/operator/installation_test.go
@@ -83,7 +83,8 @@ func TestGetHelmOptions(t *testing.T) {
 				"--set", "manifests=true",
 				"--set", "debugLogs=true",
 				"oci://registry:0.0.0-nightly-chart",
-				"--set", "image=registry:nightly-fips",
+				"--set", "imageRef.repository=registry",
+				"--set", "imageRef.tag=nightly-fips",
 				"--set", "imageRef.pullPolicy=Always",
 			},
 		}, opts)

--- a/test/e2e/helpers/components/operator/installation_test.go
+++ b/test/e2e/helpers/components/operator/installation_test.go
@@ -66,6 +66,29 @@ func TestGetHelmOptions(t *testing.T) {
 		}, opts)
 	})
 
+	t.Run("use nightly with fips", func(t *testing.T) {
+		t.Setenv("HELM_CHART", "oci://registry:0.0.0-nightly-chart")
+		t.Setenv("FIPS", "true")
+		opts, err := getHelmOptions("", "test", true)
+		require.NoError(t, err)
+		assertOptions(t, &helm.Opts{
+			Namespace:   "dynatrace",
+			ReleaseName: "dynatrace-operator",
+			Args: []string{
+				"--create-namespace",
+				"--install",
+				"--set", "platform=test",
+				"--set", "installCRD=true",
+				"--set", "csidriver.enabled=true",
+				"--set", "manifests=true",
+				"--set", "debugLogs=true",
+				"oci://registry:0.0.0-nightly-chart",
+				"--set", "image=registry:nightly-fips",
+				"--set", "imageRef.pullPolicy=Always",
+			},
+		}, opts)
+	})
+
 	t.Run("use filesystem", func(t *testing.T) {
 		tempDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "make"), []byte("#!/bin/sh\necho repo:tag"), os.ModePerm)) //nolint:gosec


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-7887

- instead of using local chart + image, fips now also uses the `nightly` chart and the `-fips` variant of the nightly image for daily e2e testruns

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->