### PR TITLE
Fix operator deadlock on OpenShift manifest-based install

### DIFF
--- a/config/helm/chart/default/templates/Common/crd/job-crd-storage-migration.yaml
+++ b/config/helm/chart/default/templates/Common/crd/job-crd-storage-migration.yaml
@@ -53,7 +53,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $needsCertgen := not (include "dynatrace-operator.openshiftOrOlm" .) }}
+      {{- $needsCertgen := not .Values.olm }}
       {{- if $needsCertgen }}
       initContainers:
         - name: webhook-cert-generator

--- a/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/config/helm/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -52,7 +52,7 @@ spec:
         {{- toYaml .Values.operator.labels | nindent 8 }}
         {{- end }}
     spec:
-      {{- $needsCertgen := not (include "dynatrace-operator.openshiftOrOlm" .) }}
+      {{- $needsCertgen := not .Values.olm }}
       {{- $needsMigrator := and .Release.IsUpgrade .Values.operator.crdStorageMigrationInitManager }}
       {{- if or $needsCertgen $needsMigrator }}
       initContainers:

--- a/config/helm/chart/default/templates/_platform.tpl
+++ b/config/helm/chart/default/templates/_platform.tpl
@@ -70,7 +70,7 @@ Set install source how the Operator was installed
 Exclude Kubernetes manifest not running on OLM
 */}}
 {{- define "dynatrace-operator.openshiftOrOlm" -}}
-{{- if and (or (eq (include "dynatrace-operator.platform" .) "openshift") (.Values.olm)) -}}
+{{- if or (eq (include "dynatrace-operator.platform" .) "openshift") (.Values.olm) -}}
     {{ default "true" }}
 {{- end -}}
 {{- end -}}

--- a/config/helm/chart/default/tests/Common/crd/job-crd-storage-migration_test.yaml
+++ b/config/helm/chart/default/tests/Common/crd/job-crd-storage-migration_test.yaml
@@ -200,6 +200,24 @@ tests:
       - isNotEmpty:
           path: spec.template.spec.affinity
 
+  - it: should have certgen init container on openshift
+    set:
+      platform: openshift
+      crdStorageMigrationJob: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: webhook-cert-generator
+
+  - it: should not have certgen init container when olm is true
+    set:
+      platform: kubernetes
+      olm: true
+      crdStorageMigrationJob: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+
   - it: should not render when crdStorageMigrationJob is false
     set:
       platform: kubernetes

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -297,23 +297,29 @@ tests:
             name: DT_HOST_AVAILABILITY_DETECTION
             value: "false"
 
-  - it: should not have init container on install
+  - it: should have certgen but not migrator on openshift install
     set:
       platform: openshift
       operator.crdStorageMigrationInitManager: true
     asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: webhook-cert-generator
       - isNull:
-          path: spec.template.spec.containers[0].initContainers
+          path: spec.template.spec.initContainers[1]
 
-  - it: should not have init container when they are disabled
+  - it: should have certgen but not migrator when migrator is disabled on openshift
     set:
       platform: openshift
       operator.crdStorageMigrationInitManager: false
     release:
       upgrade: true
     asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: webhook-cert-generator
       - isNull:
-          path: spec.template.spec.containers[0].initContainers
+          path: spec.template.spec.initContainers[1]
 
   - it: should not have imagePullSecrets defined in spec
     set:
@@ -357,6 +363,35 @@ tests:
           path: spec.template.spec
           value:
             initContainers:
+              - name: webhook-cert-generator
+                image: image-name
+                args:
+                  - certgen
+                env:
+                  - name: POD_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 100m
+                    memory: 128Mi
+                securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
+                  privileged: false
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  runAsUser: 1001
+                  runAsGroup: 1001
+                  capabilities:
+                    drop:
+                      - ALL
               - name: crd-storage-migrator
                 image: image-name
                 args:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[ICP-7989](https://dt-rnd.atlassian.net/browse/ICP-7989)

On OpenShift, installing the operator via manifest (`oc apply`) after a
previous uninstall causes the operator pod to get stuck in `Init` indefinitely.
The webhook pods start but never become healthy, leaving the installation in a
deadlock with no self-recovery.

The root cause is a regression in the init container setup: the webhook TLS
certificate was not being generated on OpenShift during a fresh manifest-based
install.

Helm-based installs were not affected.

Fixed by ensuring the certificate generation step runs on OpenShift, restoring
the behaviour that existed before the regression was introduced.


## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

1. Install the operator on OpenShift using the previous manifest:
oc apply -f openshift-csi.yaml


2. Uninstall:
oc delete -f openshift-csi.yaml


3. Re-apply the fixed manifest:
oc apply -f openshift-csi.yaml


4. Verify all pods reach `Running` without getting stuck in `Init`.

Before the fix, the operator pod would stay at `Init:0/1` indefinitely.
After the fix, operator and webhook pods come up within ~30 seconds.

[ICP-7989]: https://dt-rnd.atlassian.net/browse/ICP-7989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ