### PR TITLE
add support of new db extension component name for image fetching

### DIFF
--- a/pkg/clients/dynatrace/image/client.go
+++ b/pkg/clients/dynatrace/image/client.go
@@ -21,7 +21,10 @@ const (
 	ActiveGate  ComponentType = "activegate"
 	EEC         ComponentType = "eec"
 	LogModule   ComponentType = "logmodule"
-	DBExecutor  ComponentType = "dynatrace-sql-extension-executor"
+	DBExecutor  ComponentType = "sql-extension-executor"
+	// DBExecutorOldName is a fallback for the old name of the DBExecutor component type
+	// TODO: remove this fallback in a future release
+	DBExecutorOldName ComponentType = "dynatrace-sql-extension-executor"
 )
 
 type Info struct {

--- a/pkg/controllers/dynakube/extension/databases/reconciler.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler.go
@@ -125,7 +125,7 @@ func resolveImageURI(ctx context.Context, imageClient dtimage.Client, dk *dynaku
 
 	// fallback to old image name for backward compatibility if we can't resolve the image URI by new component name.
 	// TODO: remove this fallback in a future release
-	if apiErr := new(core.HTTPError); err != nil && !errors.As(err, &apiErr) { //nolint:revive // we want to check for a specific error type, not the whole error chain
+	if apiErr := new(core.HTTPError); err != nil && !errors.As(err, &apiErr) {
 		imageURI, err = registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutorOldName)
 		if err != nil {
 			return "", err

--- a/pkg/controllers/dynakube/extension/databases/reconciler.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler.go
@@ -5,8 +5,10 @@ package databases
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	dtimage "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -62,16 +64,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 	} else {
 		var err error
 
-		imageURI, err = registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutor)
+		imageURI, err = resolveImageURI(ctx, imageClient, dk)
 		if err != nil {
-			// fallback to old image name for backward compatibility
-			// TODO: remove this fallback in a future release
-			imageURI, err = registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutorOldName)
-			if err != nil {
-				return err
-			}
-
-			log.Debug("using old image name for backward compatibility", "imageURI", imageURI)
+			return err
 		}
 	}
 
@@ -122,4 +117,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 	k8sconditions.SetDeploymentsApplied(dk, conditionType, expectedDeploymentNames)
 
 	return nil
+}
+
+func resolveImageURI(ctx context.Context, imageClient dtimage.Client, dk *dynakube.DynaKube) (string, error) {
+	ctx, log := logd.NewFromContext(ctx, "resolveImageURI")
+	imageURI, err := registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutor)
+
+	// fallback to old image name for backward compatibility if we can't resolve the image URI by new component name.
+	// TODO: remove this fallback in a future release
+	if apiErr := new(core.HTTPError); err != nil && !errors.As(err, &apiErr) { //nolint:revive // we want to check for a specific error type, not the whole error chain
+		imageURI, err = registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutorOldName)
+		if err != nil {
+			return "", err
+		}
+
+		log.Debug("using old image name for backward compatibility", "imageURI", imageURI)
+	}
+
+	return imageURI, err
 }

--- a/pkg/controllers/dynakube/extension/databases/reconciler.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler.go
@@ -64,7 +64,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 
 		imageURI, err = registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutor)
 		if err != nil {
-			return err
+			// fallback to old image name for backward compatibility
+			// TODO: remove this fallback in a future release
+			imageURI, err = registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.DBExecutorOldName)
+			if err != nil {
+				return err
+			}
+
+			log.Debug("using old image name for backward compatibility", "imageURI", imageURI)
 		}
 	}
 

--- a/pkg/controllers/dynakube/extension/databases/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler_test.go
@@ -365,6 +365,33 @@ func TestPublicRegistryImage(t *testing.T) {
 		require.Equal(t, expectedImageURI, deployment.Spec.Template.Spec.Containers[0].Image)
 	})
 
+	t.Run("imageURI from public registry fallback to old name", func(t *testing.T) {
+		expectedImageURI := "my-public-registry:5000/my-test-repo:my-test-tag"
+		getReconciledDeployment := func(t *testing.T) *appsv1.Deployment {
+			t.Helper()
+
+			dk := getTestDynakube()
+			dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+			dk.Spec.Templates = dynakube.TemplatesSpec{}
+			clt := fakeClient()
+
+			imageClient := imageclientmock.NewClient(t)
+			boom := errors.New("component not found")
+			imageClient.EXPECT().GetComponentLatestInfo(mock.MatchedBy(func(context.Context) bool { return true }), dtimage.DBExecutor, "").Return(nil, boom)
+			imageClient.EXPECT().GetComponentLatestInfo(mock.MatchedBy(func(context.Context) bool { return true }), dtimage.DBExecutorOldName, "").Return(&dtimage.Info{URI: expectedImageURI}, nil)
+
+			require.NoError(t, NewReconciler(clt, clt).Reconcile(t.Context(), imageClient, dk))
+			deployments := &appsv1.DeploymentList{}
+			require.NoError(t, clt.List(t.Context(), deployments))
+			require.Len(t, deployments.Items, 1)
+
+			return &deployments.Items[0]
+		}
+
+		deployment := getReconciledDeployment(t)
+		require.Equal(t, expectedImageURI, deployment.Spec.Template.Spec.Containers[0].Image)
+	})
+
 	t.Run("no call to api when extensions are not used", func(t *testing.T) {
 		dk := getTestDynakube()
 		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}

--- a/pkg/controllers/dynakube/extension/databases/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/databases/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/extensions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	dtimage "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
@@ -390,6 +391,19 @@ func TestPublicRegistryImage(t *testing.T) {
 
 		deployment := getReconciledDeployment(t)
 		require.Equal(t, expectedImageURI, deployment.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("imageURI from public registry http error", func(t *testing.T) {
+		dk := getTestDynakube()
+		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+		dk.Spec.Templates = dynakube.TemplatesSpec{}
+		clt := fakeClient()
+
+		imageClient := imageclientmock.NewClient(t)
+		boom := new(core.HTTPError)
+		imageClient.EXPECT().GetComponentLatestInfo(mock.MatchedBy(func(context.Context) bool { return true }), dtimage.DBExecutor, "").Return(nil, boom).Once()
+
+		require.Error(t, NewReconciler(clt, clt).Reconcile(t.Context(), imageClient, dk))
 	})
 
 	t.Run("no call to api when extensions are not used", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Resolves [ICP-7908](https://dt-rnd.atlassian.net/browse/ICP-7908)

An inconsistency in naming was identified for `dynatrace-sql-extension-executor` component so this PR resolves this problem by introducing correct name, but keep old name for backward compatibility

> [!NOTE]
> New name takes presedense: `sql-extension-executor` and the we fallback to old name

## How can this be tested?

unit-tests or manual test if you tenant supports both:

1. Apply DK
```
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: dynakube
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/use-public-registry: "true"
spec:
  customPullSecret: devregistry
  apiUrl: https://*.dev.dynatracelabs.com/api
  activeGate:
    capabilities:
      - kubernetes-monitoring
  extensions:
    databases:
      - id: testtest
```

2. Make sure db ext pods are up and running
```
k get pods
NAME                                              READY   STATUS    RESTARTS   AGE
dynakube-activegate-0                             1/1     Running   0          32m
dynakube-extension-controller-0                   1/1     Running   0          32m
dynakube-sql-ext-exec-testtest-5d57d5b6c4-lk644   1/1     Running   0          32m
dynatrace-operator-64f65dbbbf-v8htk               1/1     Running   0          60m
dynatrace-webhook-7cc5ffdccf-n6b74                1/1     Running   0          60m
dynatrace-webhook-7cc5ffdccf-x2467                1/1     Running   0          60m
```


> [!NOTE]
> My tenant supports both, so no fallabck. 
> it's not visiable anywhere only for component query, because the imageURI is the same:
```
    {
      "type": "sql-extension-executor",
      "imageUri": "****.dkr.ecr.us-east-1.amazonaws.com/dynatrace/dynatrace-sql-extension-executor:1.345.0.20260721-174746@sha256:155921e677efdc7512f9243ac7d6c0a7eeb00c3e8e6f059ba9c462b7d5008121"
    },
    {
      "type": "dynatrace-sql-extension-executor",
      "imageUri": "****.dkr.ecr.us-east-1.amazonaws.com/dynatrace/dynatrace-sql-extension-executor:1.345.0.20260721-174746@sha256:155921e677efdc7512f9243ac7d6c0a7eeb00c3e8e6f059ba9c462b7d5008121"
    },
``` 

[ICP-7908]: https://dt-rnd.atlassian.net/browse/ICP-7908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ