### PR TITLE
Fix order of precedence for enrichment rules (main)

### DIFF
--- a/pkg/api/latest/dynakube/metadataenrichment/spec.go
+++ b/pkg/api/latest/dynakube/metadataenrichment/spec.go
@@ -16,8 +16,7 @@ const (
 
 	K8sNamespaceLabelRule      RuleType = "K8S_NAMESPACE_LABEL"
 	K8sNamespaceAnnotationRule RuleType = "K8S_NAMESPACE_ANNOTATION"
-	// TODO: implement support for this type.
-	CustomRule RuleType = "CUSTOM"
+	CustomRule                 RuleType = "CUSTOM"
 
 	Annotation         = "metadata.dynatrace.com"
 	Prefix             = Annotation + "/"

--- a/pkg/clients/dynatrace/settings/enchrichment.go
+++ b/pkg/clients/dynatrace/settings/enchrichment.go
@@ -217,7 +217,9 @@ func isNewSchemaRequested(resp getRulesResponse) bool {
 	return false
 }
 
+// Map rules from either schema to a list of [metadataenrichment.Rule].
 func getRulesFromResponse(ctx context.Context, resp getRulesResponse) []metadataenrichment.Rule {
+	// IMPORTANT: The order of the rules MUST NOT be changed. This is because we must guarantee that the first rule to match a key wins (ICP-7916).
 	var (
 		rules   []metadataenrichment.Rule
 		dropped []ingestEnrichmentConfig

--- a/pkg/clients/dynatrace/settings/enchrichment.go
+++ b/pkg/clients/dynatrace/settings/enchrichment.go
@@ -99,42 +99,56 @@ func (c *ClientImpl) GetLegacyEnrichmentRuleObjects(ctx context.Context, scope s
 	return c.getEnrichmentRuleObjectsForSchema(ctx, legacyMetadataEnrichmentSchemaID, scope)
 }
 
-func (c *ClientImpl) CreateEnrichmentRuleObject(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error) {
-	return c.createEnrichmentRule(ctx, metadataEnrichmentSchemaID, scope, rule)
+func (c *ClientImpl) CreateEnrichmentRuleObject(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error) {
+	return c.createEnrichmentRule(ctx, metadataEnrichmentSchemaID, scope, rules)
 }
 
-func (c *ClientImpl) CreateLegacyEnrichmentRuleObject(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error) {
-	return c.createEnrichmentRule(ctx, legacyMetadataEnrichmentSchemaID, scope, rule)
+func (c *ClientImpl) CreateLegacyEnrichmentRuleObject(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error) {
+	return c.createEnrichmentRule(ctx, legacyMetadataEnrichmentSchemaID, scope, rules)
 }
 
-func (c *ClientImpl) createEnrichmentRule(ctx context.Context, schemaID, scope string, rule metadataenrichment.Rule) (string, error) {
+func (c *ClientImpl) createEnrichmentRule(ctx context.Context, schemaID, scope string, rules []metadataenrichment.Rule) ([]string, error) {
 	if scope == "" {
-		return "", errors.New("no scope (MEID) was provided for creating the enrichment rule")
+		return nil, errors.New("no scope (MEID) was provided for creating the enrichment rule")
 	}
 
 	var response []postObjectsResponse
 
 	err := c.apiClient.POST(ctx, ObjectsPath).
 		WithQueryParams(map[string]string{validateOnlyQueryParam: "false"}).
-		WithJSONBody(buildEnrichmentBody(schemaID, scope, rule)).
+		WithJSONBody(buildEnrichmentBody(schemaID, scope, rules)).
 		Execute(&response)
 	if err != nil {
-		return "", fmt.Errorf("create enrichment rule (%s): %w", schemaID, err)
+		return nil, fmt.Errorf("create enrichment rule (%s): %w", schemaID, err)
 	}
 
-	return getObjectID(response)
+	objectIDs := make([]string, len(response))
+	for i, resp := range response {
+		objectIDs[i] = resp.ObjectID
+	}
+
+	return objectIDs, nil
 }
 
-func buildEnrichmentBody(schemaID, scope string, rule metadataenrichment.Rule) any {
+func buildEnrichmentBody(schemaID, scope string, rules []metadataenrichment.Rule) any {
 	if schemaID == metadataEnrichmentSchemaID {
-		return newPostObjectsBody(schemaID, "", scope, enrichmentRuleValue{
-			Type:        rule.Type,
-			ValueSource: rule.Source,
-			Target:      rule.Target,
-		})
+		values := make([]enrichmentRuleValue, len(rules))
+		for i, rule := range rules {
+			values[i] = convertRule(rule)
+		}
+
+		return newPostObjectsBody(schemaID, "", scope, values...)
 	}
 
-	return newPostObjectsBody(schemaID, "", scope, legacyEnrichmentValue{Rules: []metadataenrichment.Rule{rule}})
+	return newPostObjectsBody(schemaID, "", scope, legacyEnrichmentValue{Rules: rules})
+}
+
+func convertRule(rule metadataenrichment.Rule) enrichmentRuleValue {
+	return enrichmentRuleValue{
+		Type:        rule.Type,
+		ValueSource: rule.Source,
+		Target:      rule.Target,
+	}
 }
 
 // GetRules returns metadata enrichment rules.

--- a/pkg/clients/dynatrace/settings/enchrichment_test.go
+++ b/pkg/clients/dynatrace/settings/enchrichment_test.go
@@ -312,9 +312,7 @@ func TestCreateEnrichmentRuleObject(t *testing.T) {
 			len(body) == 1 &&
 			body[0].SchemaID == metadataEnrichmentSchemaID &&
 			body[0].Scope == scope &&
-			body[0].Value.Type == metadataenrichment.K8sNamespaceLabelRule &&
-			body[0].Value.ValueSource == "my-label" &&
-			body[0].Value.Target == "dt.cost.product"
+			body[0].Value == convertRule(rule)
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -328,9 +326,9 @@ func TestCreateEnrichmentRuleObject(t *testing.T) {
 		apiClient.EXPECT().POST(ctx, ObjectsPath).Return(request).Once()
 
 		client := NewClient(apiClient)
-		objectID, err := client.CreateEnrichmentRuleObject(ctx, scope, rule)
+		objectIDs, err := client.CreateEnrichmentRuleObject(ctx, scope, rule)
 		require.NoError(t, err)
-		assert.Equal(t, "obj-123", objectID)
+		assert.Equal(t, []string{"obj-123"}, objectIDs)
 	})
 
 	t.Run("error from API", func(t *testing.T) {
@@ -342,31 +340,49 @@ func TestCreateEnrichmentRuleObject(t *testing.T) {
 		apiClient.EXPECT().POST(ctx, ObjectsPath).Return(request).Once()
 
 		client := NewClient(apiClient)
-		objectID, err := client.CreateEnrichmentRuleObject(ctx, scope, rule)
+		objectIDs, err := client.CreateEnrichmentRuleObject(ctx, scope, rule)
 		require.Error(t, err)
-		assert.Empty(t, objectID)
-	})
-
-	t.Run("response not exactly one entry", func(t *testing.T) {
-		apiClient := coremock.NewClient(t)
-		request := coremock.NewRequest(t)
-		request.EXPECT().WithQueryParams(map[string]string{validateOnlyQueryParam: "false"}).Return(request).Once()
-		request.EXPECT().WithJSONBody(matchBody).Return(request).Once()
-		request.EXPECT().Execute(new([]postObjectsResponse)).Return(nil).Once()
-		apiClient.On("POST", ctx, ObjectsPath).Return(request)
-
-		client := NewClient(apiClient)
-		objectID, err := client.CreateEnrichmentRuleObject(ctx, scope, rule)
-		require.ErrorAs(t, err, new(notSingleEntryError))
-		assert.Empty(t, objectID)
+		assert.Empty(t, objectIDs)
 	})
 
 	t.Run("empty scope", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		client := NewClient(apiClient)
-		objectID, err := client.CreateEnrichmentRuleObject(t.Context(), "", rule)
+		objectIDs, err := client.CreateEnrichmentRuleObject(t.Context(), "", rule)
 		require.Error(t, err)
-		assert.Empty(t, objectID)
+		assert.Empty(t, objectIDs)
+	})
+
+	t.Run("multiple rules", func(t *testing.T) {
+		rule := metadataenrichment.Rule{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "my-label", Target: "dt.cost.product"}
+		rule2 := metadataenrichment.Rule{Type: metadataenrichment.K8sNamespaceAnnotationRule, Source: "my-label-2", Target: "dt.security_context"}
+		matchBody := mock.MatchedBy(func(arg any) bool {
+			body, ok := arg.([]postObjectsBody[enrichmentRuleValue])
+
+			return ok &&
+				len(body) == 2 &&
+				body[0].SchemaID == metadataEnrichmentSchemaID &&
+				body[0].Scope == scope &&
+				body[0].Value == convertRule(rule) &&
+				body[1].SchemaID == metadataEnrichmentSchemaID &&
+				body[1].Scope == scope &&
+				body[1].Value == convertRule(rule2)
+		})
+
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		request.EXPECT().WithQueryParams(map[string]string{validateOnlyQueryParam: "false"}).Return(request).Once()
+		request.EXPECT().WithJSONBody(matchBody).Return(request).Once()
+		request.EXPECT().Execute(new([]postObjectsResponse)).
+			Run(injectResponse([]postObjectsResponse{{ObjectID: "obj-1"}, {ObjectID: "obj-2"}})).
+			Return(nil).Once()
+		apiClient.EXPECT().POST(ctx, ObjectsPath).Return(request).Once()
+
+		client := NewClient(apiClient)
+
+		objectIDs, err := client.CreateEnrichmentRuleObject(ctx, scope, rule, rule2)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"obj-1", "obj-2"}, objectIDs)
 	})
 }
 
@@ -384,9 +400,7 @@ func TestCreateLegacyEnrichmentRuleObject(t *testing.T) {
 			body[0].SchemaID == legacyMetadataEnrichmentSchemaID &&
 			body[0].Scope == scope &&
 			len(body[0].Value.Rules) == 1 &&
-			body[0].Value.Rules[0].Type == metadataenrichment.LabelRule &&
-			body[0].Value.Rules[0].Source == "my-label" &&
-			body[0].Value.Rules[0].Target == "dt.cost.product"
+			body[0].Value.Rules[0] == rule
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -400,9 +414,9 @@ func TestCreateLegacyEnrichmentRuleObject(t *testing.T) {
 		apiClient.EXPECT().POST(ctx, ObjectsPath).Return(request).Once()
 
 		client := NewClient(apiClient)
-		objectID, err := client.CreateLegacyEnrichmentRuleObject(ctx, scope, rule)
+		objectIDs, err := client.CreateLegacyEnrichmentRuleObject(ctx, scope, rule)
 		require.NoError(t, err)
-		assert.Equal(t, "obj-456", objectID)
+		assert.Equal(t, []string{"obj-456"}, objectIDs)
 	})
 
 	t.Run("error from API", func(t *testing.T) {
@@ -414,31 +428,47 @@ func TestCreateLegacyEnrichmentRuleObject(t *testing.T) {
 		apiClient.EXPECT().POST(ctx, ObjectsPath).Return(request).Once()
 
 		client := NewClient(apiClient)
-		objectID, err := client.CreateLegacyEnrichmentRuleObject(ctx, scope, rule)
+		objectIDs, err := client.CreateLegacyEnrichmentRuleObject(ctx, scope, rule)
 		require.Error(t, err)
-		assert.Empty(t, objectID)
-	})
-
-	t.Run("response not exactly one entry", func(t *testing.T) {
-		apiClient := coremock.NewClient(t)
-		request := coremock.NewRequest(t)
-		request.EXPECT().WithQueryParams(map[string]string{validateOnlyQueryParam: "false"}).Return(request).Once()
-		request.EXPECT().WithJSONBody(matchBody).Return(request).Once()
-		request.EXPECT().Execute(new([]postObjectsResponse)).Return(nil).Once()
-		apiClient.On("POST", ctx, ObjectsPath).Return(request)
-
-		client := NewClient(apiClient)
-		objectID, err := client.CreateLegacyEnrichmentRuleObject(ctx, scope, rule)
-		require.ErrorAs(t, err, new(notSingleEntryError))
-		assert.Empty(t, objectID)
+		assert.Empty(t, objectIDs)
 	})
 
 	t.Run("empty scope", func(t *testing.T) {
 		apiClient := coremock.NewClient(t)
 		client := NewClient(apiClient)
-		objectID, err := client.CreateLegacyEnrichmentRuleObject(t.Context(), "", rule)
+		objectIDs, err := client.CreateLegacyEnrichmentRuleObject(t.Context(), "", rule)
 		require.Error(t, err)
-		assert.Empty(t, objectID)
+		assert.Empty(t, objectIDs)
+	})
+
+	t.Run("multiple rules", func(t *testing.T) {
+		rule := metadataenrichment.Rule{Type: metadataenrichment.LabelRule, Source: "my-label", Target: "dt.cost.product"}
+		rule2 := metadataenrichment.Rule{Type: metadataenrichment.AnnotationRule, Source: "my-label-2", Target: "dt.security_context"}
+		matchBody := mock.MatchedBy(func(arg any) bool {
+			body, ok := arg.([]postObjectsBody[legacyEnrichmentValue])
+
+			return ok &&
+				len(body) == 1 &&
+				body[0].SchemaID == legacyMetadataEnrichmentSchemaID &&
+				body[0].Scope == scope &&
+				len(body[0].Value.Rules) == 2 &&
+				body[0].Value.Rules[0] == rule &&
+				body[0].Value.Rules[1] == rule2
+		})
+
+		apiClient := coremock.NewClient(t)
+		request := coremock.NewRequest(t)
+		request.EXPECT().WithQueryParams(map[string]string{validateOnlyQueryParam: "false"}).Return(request).Once()
+		request.EXPECT().WithJSONBody(matchBody).Return(request).Once()
+		request.EXPECT().Execute(new([]postObjectsResponse)).
+			Run(injectResponse([]postObjectsResponse{{ObjectID: "obj-456"}})).
+			Return(nil).Once()
+		apiClient.EXPECT().POST(ctx, ObjectsPath).Return(request).Once()
+
+		client := NewClient(apiClient)
+		objectIDs, err := client.CreateLegacyEnrichmentRuleObject(ctx, scope, rule, rule2)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"obj-456"}, objectIDs)
 	})
 }
 

--- a/pkg/clients/dynatrace/settings/settings.go
+++ b/pkg/clients/dynatrace/settings/settings.go
@@ -71,9 +71,9 @@ type Client interface {
 	// Only intended for e2e tests, where the number of rules is small. Does not handle pagination.
 	GetLegacyEnrichmentRuleObjects(ctx context.Context, scope string) ([]EnrichmentRuleObject, error)
 	// CreateEnrichmentRuleObject creates a settings object for the builtin:ingest.enrichment.config schema.
-	CreateEnrichmentRuleObject(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error)
+	CreateEnrichmentRuleObject(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error)
 	// CreateLegacyEnrichmentRuleObject creates a settings object for the builtin:kubernetes.generic.metadata.enrichment schema.
-	CreateLegacyEnrichmentRuleObject(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error)
+	CreateLegacyEnrichmentRuleObject(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error)
 	// DeleteSettings deletes the settings for a monitored entity.
 	DeleteSettings(ctx context.Context, settingsID string) error
 }
@@ -121,16 +121,17 @@ type postObjectsBody[T any] struct {
 	Value         T      `json:"value"`
 }
 
-// As of 1.26 type deduction is not good enough to omit the type from struct initialization.
-func newPostObjectsBody[T any](schemaID, schemaVersion, scope string, value T) []postObjectsBody[T] {
-	return []postObjectsBody[T]{
-		{
-			SchemaID:      schemaID,
-			SchemaVersion: schemaVersion,
-			Scope:         scope,
-			Value:         value,
-		},
+func newPostObjectsBody[T any](schemaID, schemaVersion, scope string, values ...T) []postObjectsBody[T] {
+	body := make([]postObjectsBody[T], len(values))
+
+	for i, value := range values {
+		body[i].SchemaID = schemaID
+		body[i].SchemaVersion = schemaVersion
+		body[i].Scope = scope
+		body[i].Value = value
 	}
+
+	return body
 }
 
 // getObjectID gives back the ID of the first element of the post response.

--- a/pkg/webhook/mutation/pod/attributes/read.go
+++ b/pkg/webhook/mutation/pod/attributes/read.go
@@ -55,19 +55,19 @@ func (attrs *Pod) applyEnrichmentRules(namespace corev1.Namespace, dk dynakube.D
 		case metadataenrichment.AnnotationRule, metadataenrichment.K8sNamespaceAnnotationRule:
 			valueFromNamespace, exists = namespace.Annotations[rule.Source]
 		case metadataenrichment.CustomRule:
-			if len(rule.Target) == 0 {
-				continue
-			}
-
 			valueFromNamespace = rule.Source
 			exists = true
 		}
 
 		if exists {
-			if len(rule.Target) > 0 {
-				attrs.rules[rule.Target] = valueFromNamespace
-			} else {
+			if rule.Target == "" {
+				// The last rule without a target to resolve to a value wins. This inconsistency is intentional to not introduce a behavior change for users upgrading from <1.10.
+				// Target can only be empty for legacy schema rules.
 				attrs.rules[metadataenrichment.GetEmptyTargetEnrichmentKey(string(rule.Type), rule.Source)] = valueFromNamespace
+			} else if _, ok := attrs.rules[rule.Target]; !ok {
+				// The first rule to resolve to a value wins, regardless of type.
+				// This only is valid if the order of the rules remains unchanged from the API response.
+				attrs.rules[rule.Target] = valueFromNamespace
 			}
 		}
 	}
@@ -86,7 +86,8 @@ func (attrs *Pod) readWorkloadInfoAttributes(ctx context.Context, request mutato
 }
 
 func (attrs *Pod) readPodAttributes(request mutator.BaseRequest) {
-	attrs.podEnvVars = append(attrs.podEnvVars,
+	attrs.podEnvVars = append(
+		attrs.podEnvVars,
 		corev1.EnvVar{Name: K8sPodNameEnv, ValueFrom: k8senv.NewSourceForField("metadata.name")},
 		corev1.EnvVar{Name: K8sPodUIDEnv, ValueFrom: k8senv.NewSourceForField("metadata.uid")},
 		corev1.EnvVar{Name: K8sNodeNameEnv, ValueFrom: k8senv.NewSourceForField("spec.nodeName")},

--- a/pkg/webhook/mutation/pod/attributes/read_test.go
+++ b/pkg/webhook/mutation/pod/attributes/read_test.go
@@ -322,23 +322,90 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 		assert.Equal(t, "my-literal-value", attrs.rules["dt.custom"])
 		assert.Len(t, attrs.rules, 1)
 	})
+}
 
-	t.Run("CUSTOM without target is dropped", func(t *testing.T) {
-		attrs := newTestPodAttributes()
-		dk := dynakube.DynaKube{
-			Status: dynakube.DynaKubeStatus{
-				MetadataEnrichment: metadataenrichment.Status{
-					Rules: []metadataenrichment.Rule{
-						{Type: metadataenrichment.CustomRule, Source: "high prio!"},
-					},
-				},
+func TestGetFromEnrichmentRulesPrecedence(t *testing.T) {
+	tests := []struct {
+		name                 string
+		rules                []metadataenrichment.Rule
+		namespaceLabels      map[string]string
+		namespaceAnnotations map[string]string
+		expect               map[string]string
+	}{
+		{
+			name: "explicit-target rule: first rule to resolve a value wins over later rules",
+			rules: []metadataenrichment.Rule{
+				{Type: metadataenrichment.LabelRule, Source: "env", Target: "custom.env"},
+				{Type: metadataenrichment.K8sNamespaceAnnotationRule, Source: "env-annotation", Target: "custom.env"},
 			},
-		}
+			namespaceLabels:      map[string]string{"env": "first"},
+			namespaceAnnotations: map[string]string{"env-annotation": "second"},
+			expect:               map[string]string{"custom.env": "first"},
+		},
+		{
+			name: "explicit-target rule: later rule wins when the earlier rule's source is absent from namespace",
+			rules: []metadataenrichment.Rule{
+				{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "missing-label", Target: "custom.env"},
+				{Type: metadataenrichment.AnnotationRule, Source: "env-annotation", Target: "custom.env"},
+			},
+			namespaceAnnotations: map[string]string{"env-annotation": "second"},
+			expect:               map[string]string{"custom.env": "second"},
+		},
+		{
+			name: "explicit-target CUSTOM rule takes precedence when listed first, regardless of type",
+			rules: []metadataenrichment.Rule{
+				{Type: metadataenrichment.CustomRule, Source: "literal-value", Target: "custom.env"},
+				{Type: metadataenrichment.LabelRule, Source: "env", Target: "custom.env"},
+			},
+			namespaceLabels: map[string]string{"env": "from-label"},
+			expect:          map[string]string{"custom.env": "literal-value"},
+		},
+		{
+			name: "explicit-target rule: precedence applies independently per target key",
+			rules: []metadataenrichment.Rule{
+				{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "env", Target: "custom.env"},
+				{Type: metadataenrichment.K8sNamespaceLabelRule, Source: "team", Target: "custom.team"},
+				{Type: metadataenrichment.K8sNamespaceAnnotationRule, Source: "env-annotation", Target: "custom.env"},
+			},
+			namespaceLabels:      map[string]string{"env": "prod", "team": "platform"},
+			namespaceAnnotations: map[string]string{"env-annotation": "should-be-ignored"},
+			expect:               map[string]string{"custom.env": "prod", "custom.team": "platform"},
+		},
+		{
+			// Legacy (no-target) rules always overwrite, even a value already claimed by an
+			// earlier explicit-target rule for the same key. This is the intentional
+			// inconsistency preserving pre-1.10 behavior for legacy schema rules.
+			name: "legacy rule without a target overwrites a value already claimed by an earlier explicit-target rule for the same key",
+			rules: []metadataenrichment.Rule{
+				{Type: metadataenrichment.LabelRule, Source: "env", Target: metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.AnnotationRule), "note")},
+				{Type: metadataenrichment.AnnotationRule, Source: "note"},
+			},
+			namespaceLabels:      map[string]string{"env": "explicit-value"},
+			namespaceAnnotations: map[string]string{"note": "legacy-value"},
+			expect:               map[string]string{metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.AnnotationRule), "note"): "legacy-value"},
+		},
+		{
+			name: "explicit-target rule does not overwrite a value already claimed by an earlier legacy rule for the same key",
+			rules: []metadataenrichment.Rule{
+				{Type: metadataenrichment.AnnotationRule, Source: "note"},
+				{Type: metadataenrichment.LabelRule, Source: "env", Target: metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.AnnotationRule), "note")},
+			},
+			namespaceLabels:      map[string]string{"env": "explicit-value"},
+			namespaceAnnotations: map[string]string{"note": "legacy-value"},
+			expect:               map[string]string{metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.AnnotationRule), "note"): "legacy-value"},
+		},
+	}
 
-		attrs.applyEnrichmentRules(corev1.Namespace{}, dk)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := newTestPodAttributes()
+			dk := dynakube.DynaKube{Status: dynakube.DynaKubeStatus{MetadataEnrichment: metadataenrichment.Status{Rules: tt.rules}}}
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Labels: tt.namespaceLabels, Annotations: tt.namespaceAnnotations}}
 
-		assert.Empty(t, attrs.rules)
-	})
+			attrs.applyEnrichmentRules(ns, dk)
+			assert.Equal(t, tt.expect, attrs.rules)
+		})
+	}
 }
 
 func TestGetMetadataAnnotations(t *testing.T) {
@@ -586,6 +653,7 @@ func createTestMutationRequest(t *testing.T, dk *dynakube.DynaKube, annotations 
 		*dk,
 	)
 }
+
 func getTestNamespace(dk *dynakube.DynaKube) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -596,6 +664,7 @@ func getTestNamespace(dk *dynakube.DynaKube) *corev1.Namespace {
 		},
 	}
 }
+
 func getTestPod(annotations map[string]string) *corev1.Pod {
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{

--- a/test/e2e/features/applicationmonitoring/enrichment_rules.go
+++ b/test/e2e/features/applicationmonitoring/enrichment_rules.go
@@ -33,10 +33,16 @@ func EnrichmentRules(t *testing.T) features.Feature {
 		Source: "e2e-test-label",
 		Target: "dt.cost.product",
 	}
+	ignoredRule := metadataenrichment.Rule{
+		Type:   metadataenrichment.LabelRule,
+		Source: "e2e-test-label-ignore",
+		Target: "dt.cost.product",
+	}
 
 	// on phase 3 only the new schema is supported, which uses the "K8S_NAMESPACE_LABEL" rule type
 	if tenant.UsePhase3Tenant() {
 		expectedRule.Type = metadataenrichment.K8sNamespaceLabelRule
+		ignoredRule.Type = metadataenrichment.K8sNamespaceLabelRule
 	}
 
 	// Setup: pre-create the Kubernetes Cluster MEID on the tenant so the rule can be
@@ -47,7 +53,7 @@ func EnrichmentRules(t *testing.T) features.Feature {
 
 	// Be aware that this requires additional permissions on the service user group if platform token is used
 	// Add a new policy to your service user group that allows write access to 'ingest.enrichment.config'
-	builder.Setup(enrichment.CreateEnrichmentRuleOnTenant(secretConfig, expectedRule))
+	builder.Setup(enrichment.CreateEnrichmentRuleOnTenant(secretConfig, expectedRule, ignoredRule))
 
 	testDynakube := dynakubeComponents.New(
 		dynakubeComponents.WithAPIURL(secretConfig.APIURL),
@@ -57,13 +63,15 @@ func EnrichmentRules(t *testing.T) features.Feature {
 	dynakubeComponents.Install(builder, &secretConfig, *testDynakube)
 
 	builder.Assess("enrichment rule is stored in DynaKube status",
-		enrichment.CheckEnrichmentRuleInDynaKubeStatus(testDynakube, expectedRule))
+		enrichment.CheckEnrichmentRuleInDynaKubeStatus(testDynakube, expectedRule, ignoredRule))
 
-	sampleApp := sample.NewApp(t, testDynakube,
+	sampleApp := sample.NewApp(
+		t, testDynakube,
 		sample.WithName("enrichment-rule-app"),
 		sample.WithNamespaceLabels(maputil.MergeMap(
 			testDynakube.MetadataEnrichment().GetNamespaceSelector().MatchLabels,
 			map[string]string{expectedRule.Source: enrichmentLabelValue},
+			map[string]string{ignoredRule.Source: "ignore-me"},
 		)),
 	)
 

--- a/test/e2e/helpers/components/metadataenrichment/enrichment.go
+++ b/test/e2e/helpers/components/metadataenrichment/enrichment.go
@@ -75,7 +75,7 @@ func EnsureKubernetesClusterMEID(secretConfig tenant.Secret) features.Func {
 
 // CreateEnrichmentRuleOnTenant creates a single enrichment rule scoped to the cluster MEID.
 // It tries the legacy schema first; if that schema is unavailable (404) it falls back to the new schema.
-func CreateEnrichmentRuleOnTenant(secretConfig tenant.Secret, rule metadataenrichment.Rule) features.Func {
+func CreateEnrichmentRuleOnTenant(secretConfig tenant.Secret, rules ...metadataenrichment.Rule) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		settingsClient, err := tenant.BuildSettingsClient(secretConfig)
 		require.NoError(t, err)
@@ -86,16 +86,16 @@ func CreateEnrichmentRuleOnTenant(secretConfig tenant.Secret, rule metadataenric
 		require.NoError(t, err, "Could not get K8s cluster MEID")
 		require.NotEmpty(t, k8sClusterME.ID, "Kubernetes Cluster MEID must exist before creating enrichment rules")
 
-		objectID, err := settingsClient.CreateLegacyEnrichmentRuleObject(ctx, k8sClusterME.ID, rule)
+		objectIDs, err := settingsClient.CreateLegacyEnrichmentRuleObject(ctx, k8sClusterME.ID, rules...)
 		if core.IsNotFound(err) {
 			t.Log("Legacy schema not available, falling back to new schema")
 
-			objectID, err = settingsClient.CreateEnrichmentRuleObject(ctx, k8sClusterME.ID, rule)
+			objectIDs, err = settingsClient.CreateEnrichmentRuleObject(ctx, k8sClusterME.ID, rules...)
 			require.NoError(t, err, "Could not create enrichment rule on tenant with new schema either. Please follow comment on ICP-1164 how to enable on tenant.")
 		}
 
 		require.NoError(t, err, "Could not create enrichment rule on tenant")
-		t.Logf("Created enrichment rule with objectId: %s (scope: %s)", objectID, k8sClusterME.ID)
+		t.Logf("Created enrichment rule with objectId: %v (scope: %s)", objectIDs, k8sClusterME.ID)
 
 		return ctx
 	}
@@ -151,15 +151,17 @@ func DeleteEnrichmentRulesFromTenant(secretConfig tenant.Secret) features.Func {
 }
 
 // CheckEnrichmentRuleInDynaKubeStatus asserts that the DynaKube status contains an enrichment rule matching the expected type, source, and target.
-func CheckEnrichmentRuleInDynaKubeStatus(dk *dynakube.DynaKube, expected metadataenrichment.Rule) features.Func {
+func CheckEnrichmentRuleInDynaKubeStatus(dk *dynakube.DynaKube, expected ...metadataenrichment.Rule) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		require.NoError(t, envConfig.Client().Resources().Get(ctx, dk.Name, dk.Namespace, dk))
 
 		rules := dk.Status.MetadataEnrichment.Rules
 		assert.NotEmpty(t, rules, "expected enrichment rules in DynaKube status, got none")
 
-		if !slices.Contains(rules, expected) {
-			t.Errorf("enrichment rule not found in DynaKube status: want %+v, got %+v", expected, rules)
+		for _, expect := range expected {
+			if !slices.Contains(rules, expect) {
+				t.Errorf("enrichment rule not found in DynaKube status: want %+v, got %+v", expected, rules)
+			}
 		}
 
 		return ctx

--- a/test/mocks/pkg/clients/dynatrace/settings/client.go
+++ b/test/mocks/pkg/clients/dynatrace/settings/client.go
@@ -44,25 +44,33 @@ func (_m *Client) EXPECT() *Client_Expecter {
 }
 
 // CreateEnrichmentRuleObject provides a mock function for the type Client
-func (_mock *Client) CreateEnrichmentRuleObject(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error) {
-	ret := _mock.Called(ctx, scope, rule)
+func (_mock *Client) CreateEnrichmentRuleObject(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error) {
+	var tmpRet mock.Arguments
+	if len(rules) > 0 {
+		tmpRet = _mock.Called(ctx, scope, rules)
+	} else {
+		tmpRet = _mock.Called(ctx, scope)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateEnrichmentRuleObject")
 	}
 
-	var r0 string
+	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, metadataenrichment.Rule) (string, error)); ok {
-		return returnFunc(ctx, scope, rule)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...metadataenrichment.Rule) ([]string, error)); ok {
+		return returnFunc(ctx, scope, rules...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, metadataenrichment.Rule) string); ok {
-		r0 = returnFunc(ctx, scope, rule)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...metadataenrichment.Rule) []string); ok {
+		r0 = returnFunc(ctx, scope, rules...)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, metadataenrichment.Rule) error); ok {
-		r1 = returnFunc(ctx, scope, rule)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...metadataenrichment.Rule) error); ok {
+		r1 = returnFunc(ctx, scope, rules...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -77,12 +85,13 @@ type Client_CreateEnrichmentRuleObject_Call struct {
 // CreateEnrichmentRuleObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scope string
-//   - rule metadataenrichment.Rule
-func (_e *Client_Expecter) CreateEnrichmentRuleObject(ctx any, scope any, rule any) *Client_CreateEnrichmentRuleObject_Call {
-	return &Client_CreateEnrichmentRuleObject_Call{Call: _e.mock.On("CreateEnrichmentRuleObject", ctx, scope, rule)}
+//   - rules ...metadataenrichment.Rule
+func (_e *Client_Expecter) CreateEnrichmentRuleObject(ctx any, scope any, rules ...any) *Client_CreateEnrichmentRuleObject_Call {
+	return &Client_CreateEnrichmentRuleObject_Call{Call: _e.mock.On("CreateEnrichmentRuleObject",
+		append([]any{ctx, scope}, rules...)...)}
 }
 
-func (_c *Client_CreateEnrichmentRuleObject_Call) Run(run func(ctx context.Context, scope string, rule metadataenrichment.Rule)) *Client_CreateEnrichmentRuleObject_Call {
+func (_c *Client_CreateEnrichmentRuleObject_Call) Run(run func(ctx context.Context, scope string, rules ...metadataenrichment.Rule)) *Client_CreateEnrichmentRuleObject_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -92,25 +101,27 @@ func (_c *Client_CreateEnrichmentRuleObject_Call) Run(run func(ctx context.Conte
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 metadataenrichment.Rule
-		if args[2] != nil {
-			arg2 = args[2].(metadataenrichment.Rule)
+		var arg2 []metadataenrichment.Rule
+		var variadicArgs []metadataenrichment.Rule
+		if len(args) > 2 {
+			variadicArgs = args[2].([]metadataenrichment.Rule)
 		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
-			arg2,
+			arg2...,
 		)
 	})
 	return _c
 }
 
-func (_c *Client_CreateEnrichmentRuleObject_Call) Return(s string, err error) *Client_CreateEnrichmentRuleObject_Call {
-	_c.Call.Return(s, err)
+func (_c *Client_CreateEnrichmentRuleObject_Call) Return(strings []string, err error) *Client_CreateEnrichmentRuleObject_Call {
+	_c.Call.Return(strings, err)
 	return _c
 }
 
-func (_c *Client_CreateEnrichmentRuleObject_Call) RunAndReturn(run func(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error)) *Client_CreateEnrichmentRuleObject_Call {
+func (_c *Client_CreateEnrichmentRuleObject_Call) RunAndReturn(run func(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error)) *Client_CreateEnrichmentRuleObject_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -188,25 +199,33 @@ func (_c *Client_CreateKSPMSetting_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // CreateLegacyEnrichmentRuleObject provides a mock function for the type Client
-func (_mock *Client) CreateLegacyEnrichmentRuleObject(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error) {
-	ret := _mock.Called(ctx, scope, rule)
+func (_mock *Client) CreateLegacyEnrichmentRuleObject(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error) {
+	var tmpRet mock.Arguments
+	if len(rules) > 0 {
+		tmpRet = _mock.Called(ctx, scope, rules)
+	} else {
+		tmpRet = _mock.Called(ctx, scope)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateLegacyEnrichmentRuleObject")
 	}
 
-	var r0 string
+	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, metadataenrichment.Rule) (string, error)); ok {
-		return returnFunc(ctx, scope, rule)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...metadataenrichment.Rule) ([]string, error)); ok {
+		return returnFunc(ctx, scope, rules...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, metadataenrichment.Rule) string); ok {
-		r0 = returnFunc(ctx, scope, rule)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...metadataenrichment.Rule) []string); ok {
+		r0 = returnFunc(ctx, scope, rules...)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, metadataenrichment.Rule) error); ok {
-		r1 = returnFunc(ctx, scope, rule)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...metadataenrichment.Rule) error); ok {
+		r1 = returnFunc(ctx, scope, rules...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -221,12 +240,13 @@ type Client_CreateLegacyEnrichmentRuleObject_Call struct {
 // CreateLegacyEnrichmentRuleObject is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scope string
-//   - rule metadataenrichment.Rule
-func (_e *Client_Expecter) CreateLegacyEnrichmentRuleObject(ctx any, scope any, rule any) *Client_CreateLegacyEnrichmentRuleObject_Call {
-	return &Client_CreateLegacyEnrichmentRuleObject_Call{Call: _e.mock.On("CreateLegacyEnrichmentRuleObject", ctx, scope, rule)}
+//   - rules ...metadataenrichment.Rule
+func (_e *Client_Expecter) CreateLegacyEnrichmentRuleObject(ctx any, scope any, rules ...any) *Client_CreateLegacyEnrichmentRuleObject_Call {
+	return &Client_CreateLegacyEnrichmentRuleObject_Call{Call: _e.mock.On("CreateLegacyEnrichmentRuleObject",
+		append([]any{ctx, scope}, rules...)...)}
 }
 
-func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) Run(run func(ctx context.Context, scope string, rule metadataenrichment.Rule)) *Client_CreateLegacyEnrichmentRuleObject_Call {
+func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) Run(run func(ctx context.Context, scope string, rules ...metadataenrichment.Rule)) *Client_CreateLegacyEnrichmentRuleObject_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -236,25 +256,27 @@ func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) Run(run func(ctx context
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 metadataenrichment.Rule
-		if args[2] != nil {
-			arg2 = args[2].(metadataenrichment.Rule)
+		var arg2 []metadataenrichment.Rule
+		var variadicArgs []metadataenrichment.Rule
+		if len(args) > 2 {
+			variadicArgs = args[2].([]metadataenrichment.Rule)
 		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
-			arg2,
+			arg2...,
 		)
 	})
 	return _c
 }
 
-func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) Return(s string, err error) *Client_CreateLegacyEnrichmentRuleObject_Call {
-	_c.Call.Return(s, err)
+func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) Return(strings []string, err error) *Client_CreateLegacyEnrichmentRuleObject_Call {
+	_c.Call.Return(strings, err)
 	return _c
 }
 
-func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) RunAndReturn(run func(ctx context.Context, scope string, rule metadataenrichment.Rule) (string, error)) *Client_CreateLegacyEnrichmentRuleObject_Call {
+func (_c *Client_CreateLegacyEnrichmentRuleObject_Call) RunAndReturn(run func(ctx context.Context, scope string, rules ...metadataenrichment.Rule) ([]string, error)) *Client_CreateLegacyEnrichmentRuleObject_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Cherry-pick of #7025

Update the e2e tests to cover the precedence. I purposefully left some things out, like renaming the function to suit the new arguments better. The PR is focused on making things work first and foremost.
The main change to make it work was changing the signature of the create rule client methods. They now accept a list of rules and return a list of objects. For the legacy schema the returned list of objects will always have length 1, but for the new schema the length will equal the input rules.

Be aware that the e2e test overwrites your rules on the tenant. This will be fixed in ICP-8084