### PR TITLE
Delete replicated secrets on namespace deselection

### DIFF
--- a/pkg/injection/namespace/mapper/dynakubes.go
+++ b/pkg/injection/namespace/mapper/dynakubes.go
@@ -31,6 +31,8 @@ type DynakubeMapper struct {
 	matchedOANamespaces   []string
 	matchedMENamespaces   []string
 	matchedOTLPNamespaces []string
+
+	deselectedNamespaces []string
 }
 
 func NewDynakubeMapper(ctx context.Context, clt client.Client, apiReader client.Reader, operatorNs string, dk *dynakube.DynaKube) DynakubeMapper {
@@ -46,6 +48,7 @@ func NewDynakubeMapper(ctx context.Context, clt client.Client, apiReader client.
 		matchedOANamespaces:   []string{},
 		matchedMENamespaces:   []string{},
 		matchedOTLPNamespaces: []string{},
+		deselectedNamespaces:  []string{},
 	}
 }
 
@@ -60,6 +63,12 @@ func (dm *DynakubeMapper) MapFromDynakube() error {
 
 	for _, ns := range modifiedNs {
 		if err := dm.client.Update(dm.ctx, ns); err != nil {
+			return err
+		}
+	}
+
+	for _, nsName := range dm.deselectedNamespaces {
+		if err := dm.deleteReplicatedSecrets(nsName); err != nil {
 			return err
 		}
 	}
@@ -181,9 +190,7 @@ func (dm *DynakubeMapper) mapNamespace(namespace *corev1.Namespace, dkList *dyna
 	}
 
 	if previouslyInjected && !result.IsAny() {
-		if err := dm.deleteReplicatedSecrets(namespace.Name); err != nil {
-			return false, err
-		}
+		dm.deselectedNamespaces = append(dm.deselectedNamespaces, namespace.Name)
 	}
 
 	return updated, nil

--- a/pkg/injection/namespace/mapper/dynakubes.go
+++ b/pkg/injection/namespace/mapper/dynakubes.go
@@ -96,12 +96,7 @@ func (dm *DynakubeMapper) UnmapFromDynaKube(namespaces []corev1.Namespace) error
 			return errors.WithMessagef(err, "failed to remove label %s from namespace %s", dtwebhook.InjectionInstanceLabel, ns.Name)
 		}
 
-		if err := goerrors.Join(
-			dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitSecretName, ns.Name),
-			dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitCertsSecretName, ns.Name),
-			dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterSecretName, ns.Name),
-			dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterCertsSecretName, ns.Name),
-		); err != nil {
+		if err := dm.deleteReplicatedSecrets(ns.Name); err != nil {
 			return err
 		}
 	}
@@ -111,6 +106,15 @@ func (dm *DynakubeMapper) UnmapFromDynaKube(namespaces []corev1.Namespace) error
 	_ = meta.RemoveStatusCondition(dm.dk.Conditions(), otlpExporterNamespacesMonitoredConditionType.String())
 
 	return nil
+}
+
+func (dm *DynakubeMapper) deleteReplicatedSecrets(namespaceName string) error {
+	return goerrors.Join(
+		dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitSecretName, namespaceName),
+		dm.secrets.DeleteForNamespace(dm.ctx, consts.BootstrapperInitCertsSecretName, namespaceName),
+		dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterSecretName, namespaceName),
+		dm.secrets.DeleteForNamespace(dm.ctx, consts.OTLPExporterCertsSecretName, namespaceName),
+	)
 }
 
 func (dm *DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *dynakube.DynaKubeList) ([]*corev1.Namespace, error) {
@@ -134,24 +138,7 @@ func (dm *DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *
 	for i := range nsList.Items {
 		namespace := &nsList.Items[i]
 
-		result, err := match(dm.dk, namespace)
-		if err != nil {
-			return nil, err
-		}
-
-		if result.IsOA {
-			dm.matchedOANamespaces = append(dm.matchedOANamespaces, namespace.Name)
-		}
-
-		if result.IsME {
-			dm.matchedMENamespaces = append(dm.matchedMENamespaces, namespace.Name)
-		}
-
-		if result.IsOTLP {
-			dm.matchedOTLPNamespaces = append(dm.matchedOTLPNamespaces, namespace.Name)
-		}
-
-		updated, err := updateNamespace(dm.ctx, namespace, dkList)
+		updated, err := dm.mapNamespace(namespace, dkList)
 		if err != nil {
 			return nil, err
 		}
@@ -166,4 +153,38 @@ func (dm *DynakubeMapper) mapFromDynakube(nsList *corev1.NamespaceList, dkList *
 	slices.Sort(dm.matchedOTLPNamespaces)
 
 	return modifiedNs, nil
+}
+
+func (dm *DynakubeMapper) mapNamespace(namespace *corev1.Namespace, dkList *dynakube.DynaKubeList) (bool, error) {
+	previouslyInjected := namespace.Labels[dtwebhook.InjectionInstanceLabel] == dm.dk.Name
+
+	result, err := match(dm.dk, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	if result.IsOA {
+		dm.matchedOANamespaces = append(dm.matchedOANamespaces, namespace.Name)
+	}
+
+	if result.IsME {
+		dm.matchedMENamespaces = append(dm.matchedMENamespaces, namespace.Name)
+	}
+
+	if result.IsOTLP {
+		dm.matchedOTLPNamespaces = append(dm.matchedOTLPNamespaces, namespace.Name)
+	}
+
+	updated, err := updateNamespace(dm.ctx, namespace, dkList)
+	if err != nil {
+		return false, err
+	}
+
+	if previouslyInjected && !result.IsAny() {
+		if err := dm.deleteReplicatedSecrets(namespace.Name); err != nil {
+			return false, err
+		}
+	}
+
+	return updated, nil
 }

--- a/pkg/injection/namespace/mapper/dynakubes_test.go
+++ b/pkg/injection/namespace/mapper/dynakubes_test.go
@@ -137,6 +137,46 @@ func TestMapFromDynakube(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, ns.Labels, 1)
 	})
+
+	t.Run("namespace no longer matches selector => secrets deleted", func(t *testing.T) {
+		matchingLabels := map[string]string{"foo": "bar"}
+		dk := createDynakubeWithAppInject("dk-test", convertToLabelSelector(matchingLabels))
+
+		namespace := createNamespace(
+			"definitely-not-selected",
+			map[string]string{
+				dtwebhook.InjectionInstanceLabel: dk.Name,
+			},
+		)
+
+		clt := fake.NewClient(dk, namespace)
+		ctx := t.Context()
+
+		secretNames := []string{
+			consts.BootstrapperInitSecretName,
+			consts.BootstrapperInitCertsSecretName,
+			consts.OTLPExporterSecretName,
+			consts.OTLPExporterCertsSecretName,
+		}
+		for _, secretName := range secretNames {
+			createSecret(t, clt, secretName, namespace.Name)
+		}
+
+		dm := NewDynakubeMapper(ctx, clt, clt, "dynatrace", dk)
+		err := dm.MapFromDynakube()
+		require.NoError(t, err)
+
+		var ns corev1.Namespace
+		err = clt.Get(ctx, types.NamespacedName{Name: namespace.Name}, &ns)
+		require.NoError(t, err)
+		assert.Empty(t, ns.Labels)
+
+		for _, secretName := range secretNames {
+			var secret corev1.Secret
+			err = clt.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace.Name}, &secret)
+			assert.Truef(t, k8serrors.IsNotFound(err), "expected secret %s to be deleted from deselected namespace", secretName)
+		}
+	})
 }
 
 func TestUnmapFromDynaKube(t *testing.T) {
@@ -146,11 +186,6 @@ func TestUnmapFromDynaKube(t *testing.T) {
 	}
 	namespace := createNamespace("ns1", labels)
 	namespace2 := createNamespace("ns2", labels)
-
-	createSecret := func(t *testing.T, c client.Client, name, namespace string) {
-		t.Helper()
-		c.Create(t.Context(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}})
-	}
 
 	t.Run("Remove from no ns => no error", func(t *testing.T) {
 		clt := fake.NewClient()
@@ -261,4 +296,9 @@ func TestUnmapFromDynaKube(t *testing.T) {
 		assert.NotEqual(t, consts.BootstrapperInitSecretName, deletedSecretNS2.Name)
 		assert.True(t, k8serrors.IsNotFound(err))
 	})
+}
+
+func createSecret(t *testing.T, c client.Client, name, namespace string) {
+	t.Helper()
+	c.Create(t.Context(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}})
 }

--- a/pkg/injection/namespace/mapper/dynakubes_test.go
+++ b/pkg/injection/namespace/mapper/dynakubes_test.go
@@ -179,6 +179,47 @@ func TestMapFromDynakube(t *testing.T) {
 	})
 }
 
+func TestMatchingNamespaces(t *testing.T) {
+	t.Run("validating webhook run on deselected ns => replicated secrets not deleted", func(t *testing.T) {
+		matchingLabels := map[string]string{"foo": "bar"}
+		dk := createDynakubeWithAppInject("dk-test", convertToLabelSelector(matchingLabels))
+
+		namespace := createNamespace(
+			"definitely-not-selected",
+			map[string]string{
+				dtwebhook.InjectionInstanceLabel: dk.Name,
+			},
+		)
+
+		clt := fake.NewClient(dk, namespace)
+		ctx := t.Context()
+
+		secretNames := []string{
+			consts.BootstrapperInitSecretName,
+			consts.BootstrapperInitCertsSecretName,
+			consts.OTLPExporterSecretName,
+			consts.OTLPExporterCertsSecretName,
+		}
+		for _, secretName := range secretNames {
+			createSecret(t, clt, secretName, namespace.Name)
+		}
+
+		// pass nil write client, just like validating webhooks
+		dm := NewDynakubeMapper(ctx, nil, clt, "dynatrace", dk)
+
+		require.NotPanics(t, func() {
+			_, err := dm.MatchingNamespaces()
+			require.NoError(t, err)
+		})
+
+		for _, secretName := range secretNames {
+			var secret corev1.Secret
+			err := clt.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace.Name}, &secret)
+			require.NoErrorf(t, err, "secret %s must not be deleted when validating webhooks are run", secretName)
+		}
+	})
+}
+
 func TestUnmapFromDynaKube(t *testing.T) {
 	dk := createDynakubeWithAppInject("dk", metav1.LabelSelector{})
 	labels := map[string]string{


### PR DESCRIPTION
## Description
Currently, replicated secrets (like `dynatrace-bootstrapper-config` or `dynatrace-otlp-exporter-config`, for example) aren't always deleted when a namespace is removed from a DynaKube's namespace selector. Fix this by reusing clean up logic from `UnmapFromDynaKube`.

Addresses ICP-7549.

## How can this be tested?
Unit tests