### PR TITLE
Set the Dynatrace Client connection timeout to 15 min

### DIFF
--- a/pkg/clients/dynatrace/client.go
+++ b/pkg/clients/dynatrace/client.go
@@ -296,7 +296,7 @@ func getClientAndConfig(options ...Option) (*http.Client, *Config, error) {
 
 	return &http.Client{
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		Timeout:   15 * time.Minute,
 	}, &config, nil
 }
 

--- a/pkg/clients/dynatrace/client_test.go
+++ b/pkg/clients/dynatrace/client_test.go
@@ -197,7 +197,7 @@ func TestGetClientAndConfig(t *testing.T) {
 		httpClient, config, err := getClientAndConfig()
 		require.NoError(t, err)
 		require.NotNil(t, config)
-		assert.Equal(t, 30*time.Second, httpClient.Timeout)
+		assert.Equal(t, 15*time.Minute, httpClient.Timeout)
 		assert.Equal(t, operatorversion.UserAgent(), config.UserAgent)
 	})
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-7877)

## Description

The default connection timeout is set to 15m.

## How can this be tested?