### PR TITLE
fix: restore OneAgent downgrade detection for public registry image source

### DIFF
--- a/pkg/controllers/dynakube/version/oneagent.go
+++ b/pkg/controllers/dynakube/version/oneagent.go
@@ -130,15 +130,8 @@ func (updater *oneAgentUpdater) CheckForDowngrade(ctx context.Context, latestVer
 	var err error
 
 	switch updater.Target().Source {
-	case status.TenantRegistryVersionSource:
+	case status.TenantRegistryVersionSource, status.PublicRegistryVersionSource:
 		previousVersion = updater.Target().Version //nolint:staticcheck
-	case status.PublicRegistryVersionSource:
-		previousVersion, err = getTagFromImageID(imageID)
-		if err != nil {
-			setVerificationFailedReasonCondition(updater.dk.Conditions(), oaConditionType)
-
-			return false, err
-		}
 	}
 
 	downgrade, err := isDowngrade(ctx, updater.Name(), previousVersion, latestVersion)

--- a/pkg/controllers/dynakube/version/oneagent.go
+++ b/pkg/controllers/dynakube/version/oneagent.go
@@ -129,8 +129,16 @@ func (updater *oneAgentUpdater) CheckForDowngrade(ctx context.Context, latestVer
 
 	var err error
 
-	if updater.Target().Source == status.TenantRegistryVersionSource {
+	switch updater.Target().Source {
+	case status.TenantRegistryVersionSource:
 		previousVersion = updater.Target().Version //nolint:staticcheck
+	case status.PublicRegistryVersionSource:
+		previousVersion, err = getTagFromImageID(imageID)
+		if err != nil {
+			setVerificationFailedReasonCondition(updater.dk.Conditions(), oaConditionType)
+
+			return false, err
+		}
 	}
 
 	downgrade, err := isDowngrade(ctx, updater.Name(), previousVersion, latestVersion)

--- a/pkg/controllers/dynakube/version/oneagent_test.go
+++ b/pkg/controllers/dynakube/version/oneagent_test.go
@@ -242,6 +242,24 @@ func TestCheckForDowngrade(t *testing.T) {
 			isDowngrade: false,
 		},
 		{
+			testName: "is downgrade, public registry",
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
+				ImageID: "some.registry.com:" + newerVersion,
+				Source:  status.PublicRegistryVersionSource,
+			}),
+			newVersion:  olderVersion,
+			isDowngrade: true,
+		},
+		{
+			testName: "is NOT downgrade, public registry",
+			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
+				ImageID: "some.registry.com:" + olderVersion,
+				Source:  status.PublicRegistryVersionSource,
+			}),
+			newVersion:  newerVersion,
+			isDowngrade: false,
+		},
+		{
 			testName: "is NOT downgrade, custom image - no logic",
 			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + newerVersion,

--- a/pkg/controllers/dynakube/version/oneagent_test.go
+++ b/pkg/controllers/dynakube/version/oneagent_test.go
@@ -245,6 +245,7 @@ func TestCheckForDowngrade(t *testing.T) {
 			testName: "is downgrade, public registry",
 			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + newerVersion,
+				Version: newerVersion,
 				Source:  status.PublicRegistryVersionSource,
 			}),
 			newVersion:  olderVersion,
@@ -254,6 +255,7 @@ func TestCheckForDowngrade(t *testing.T) {
 			testName: "is NOT downgrade, public registry",
 			dk: newDynakubeWithOneAgentStatus(status.VersionStatus{
 				ImageID: "some.registry.com:" + olderVersion,
+				Version: olderVersion,
 				Source:  status.PublicRegistryVersionSource,
 			}),
 			newVersion:  newerVersion,


### PR DESCRIPTION
## Description

`CheckForDowngrade` only fills `previousVersion` when the target source is `TenantRegistryVersionSource`. for public-registry setups (the `public-registry` feature flag) the source is `PublicRegistryVersionSource`, so `previousVersion` stays empty, `isDowngrade` always compares against an empty string and returns false - the downgrade guard is silently off

this is a regression from #6227 (commit c78fc15de), which dropped the `PublicRegistryVersionSource` branch that read the version tag from the image id. this restores it

impact: with a public-registry OneAgent image, lowering the version rolls the OLDER image across the whole DaemonSet instead of being blocked as a downgrade

## How can this be tested?

enable the public registry feature flag on a DynaKube so the OneAgent version source is `PublicRegistryVersionSource`, let it settle on an image at some version, then reconcile with a lower target version - on main the downgrade is accepted, with this change the downgrade condition is set and the rollback is blocked

the added `TestCheckForDowngrade` cases cover the public-registry downgrade and non-downgrade paths without needing a cluster