### PR TITLE
fix: prevent file descriptor leak in CSI app volume publisher

### DIFF
--- a/pkg/controllers/csi/server/volumes/app/publisher.go
+++ b/pkg/controllers/csi/server/volumes/app/publisher.go
@@ -37,6 +37,8 @@ type Publisher struct {
 
 const (
 	retryLimitReachedMsg = "reached max mount attempts for pod, attaching dummy volume, monitoring disabled"
+
+	podInfoFilePerm = 0666
 )
 
 func (pub *Publisher) PublishVolume(ctx context.Context, volumeCfg *csivolumes.VolumeConfig) (*csi.NodePublishVolumeResponse, error) {
@@ -219,14 +221,8 @@ func (pub *Publisher) preparePodInfoUpperDir(volumeCfg *csivolumes.VolumeConfig)
 	content := pub.path.AppMountPodInfoDir(volumeCfg.DynakubeName, volumeCfg.PodNamespace, volumeCfg.PodName)
 	destPath := pub.path.OverlayVarPodInfo(volumeCfg.VolumeID)
 
-	destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
-	if err != nil {
-		return errors.WithMessagef(err, "failed to open destination pod-info file, path: %s", destPath)
-	}
-
-	_, err = destFile.WriteString(content)
-	if err != nil {
-		return errors.WithMessagef(err, "failed write into pod-info file, path: %s", destPath)
+	if err := os.WriteFile(destPath, []byte(content), podInfoFilePerm); err != nil {
+		return errors.WithMessagef(err, "failed to write pod-info file, path: %s", destPath)
 	}
 
 	return nil

--- a/pkg/controllers/csi/server/volumes/app/publisher_test.go
+++ b/pkg/controllers/csi/server/volumes/app/publisher_test.go
@@ -209,3 +209,40 @@ func getTestVolumeConfig(t *testing.T) csivolumes.VolumeConfig {
 		RetryTimeout: time.Minute,
 	}
 }
+
+func TestPreparePodInfoUpperDir(t *testing.T) {
+	path := metadata.PathResolver{RootDir: t.TempDir()}
+	volumeCfg := getTestVolumeConfig(t)
+	destPath := path.OverlayVarPodInfo(volumeCfg.VolumeID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(destPath), os.ModePerm))
+
+	pub := Publisher{path: path}
+
+	require.NoError(t, pub.preparePodInfoUpperDir(&volumeCfg))
+
+	// the pod-info file must not be left open between mounts
+	before := countOpenFiles(t)
+	for range 50 {
+		require.NoError(t, pub.preparePodInfoUpperDir(&volumeCfg))
+	}
+
+	assert.Equal(t, before, countOpenFiles(t), "open file descriptors leaked across mounts")
+
+	written, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, path.AppMountPodInfoDir(volumeCfg.DynakubeName, volumeCfg.PodNamespace, volumeCfg.PodName), string(written))
+}
+
+func countOpenFiles(t *testing.T) int {
+	t.Helper()
+
+	dir, err := os.Open("/dev/fd")
+	require.NoError(t, err)
+
+	defer func() { _ = dir.Close() }()
+
+	names, err := dir.Readdirnames(-1)
+	require.NoError(t, err)
+
+	return len(names)
+}


### PR DESCRIPTION
## Description

`preparePodInfoUpperDir` in the CSI app volume publisher opens the destination file with `os.OpenFile` and writes to it, but never closes the handle. every volume mount leaks one file descriptor on the node, so a workload that mounts and remounts (or crash-loops) slowly exhausts the CSI driver process fds until mounts start failing with "too many open files"

the fix replaces the manual open/write with `os.WriteFile`, which closes the handle on return

## How can this be tested?

hard to see directly at runtime without watching `/proc/<csi-driver-pid>/fd` count while pods mount app volumes repeatedly - it grows without bound on main and stays flat with this change

at the unit level the added `TestPreparePodInfoUpperDir` writes the pod info file and asserts the content, and the change is a straight swap to a self-closing write so no fd is left open