### PR TITLE
Make init user/group configurable

### DIFF
--- a/pkg/webhook/mutation/pod/handler/injection/handle.go
+++ b/pkg/webhook/mutation/pod/handler/injection/handle.go
@@ -125,7 +125,7 @@ func (h *Handler) isInjected(mutationRequest *dtwebhook.MutationRequest) bool {
 }
 
 func (h *Handler) handlePodMutation(mutationRequest *dtwebhook.MutationRequest) (bool, error) {
-	mutationRequest.InstallContainer = h.createInitContainerBase(mutationRequest.Pod, mutationRequest.DynaKube)
+	mutationRequest.InstallContainer = h.createInitContainerBase(mutationRequest.Context, mutationRequest.Pod, mutationRequest.DynaKube)
 
 	var mutated bool
 

--- a/pkg/webhook/mutation/pod/handler/injection/handle_test.go
+++ b/pkg/webhook/mutation/pod/handler/injection/handle_test.go
@@ -278,7 +278,7 @@ func getTestDynakubeWithAGCerts() *dynakube.DynaKube {
 func createTestMutationRequestWithInjectedPod(t *testing.T, dk *dynakube.DynaKube) *dtwebhook.MutationRequest {
 	t.Helper()
 
-	return dtwebhook.NewMutationRequest(context.Background(), *getTestNamespace(), nil, getInjectedPod(t), *dk)
+	return dtwebhook.NewMutationRequest(t.Context(), *getTestNamespace(), nil, getInjectedPod(t), *dk)
 }
 
 func getInjectedPod(t *testing.T) *corev1.Pod {
@@ -316,7 +316,7 @@ func getInjectedPod(t *testing.T) *corev1.Pod {
 
 	h := createTestHandler(webhookmock.NewMutator(t), webhookmock.NewMutator(t))
 
-	installContainer := h.createInitContainerBase(pod, *getTestDynakube())
+	installContainer := h.createInitContainerBase(t.Context(), pod, *getTestDynakube())
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *installContainer)
 
 	return pod

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -131,11 +131,11 @@ func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.Securit
 		baseSecurityCtx.RunAsGroup = containerSecurityCtx.RunAsGroup
 	}
 
-	if user := parseAnnotationAsUint32(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
+	if user := getValidatedID(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
 		baseSecurityCtx.RunAsUser = user
 	}
 
-	if group := parseAnnotationAsUint32(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
+	if group := getValidatedID(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
 		baseSecurityCtx.RunAsGroup = group
 	}
 
@@ -144,16 +144,16 @@ func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.Securit
 	return &baseSecurityCtx
 }
 
-// parseAnnotationAsUint32 will parse the provided annotation as a uint32,
-// but will return an int64 pointer for compatibility reasons with the corev1.SecurityContext type.
-// Will only log parsing errors, as we do not want to block due to incorrect user annotation.
-func parseAnnotationAsUint32(ctx context.Context, annotations map[string]string, key string) *int64 {
+// getValidatedID will parse the provided annotation as valid user/group ID between 0 and math.MaxInt32.
+// Returns *int64 for compatibility with corev1.SecurityContext
+func getValidatedID(ctx context.Context, annotations map[string]string, key string) *int64 {
 	val, ok := annotations[key]
 	if !ok {
 		return nil
 	}
 
-	parsed, err := strconv.ParseUint(val, 10, 32)
+	// uint31 == positive int32 range
+	parsed, err := strconv.ParseUint(val, 10, 31)
 	if err != nil {
 		logd.FromContext(ctx).Error(err, "failed to parse annotation value, must be a uint32", "key", key, "value", val)
 

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -131,11 +131,11 @@ func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.Securit
 		baseSecurityCtx.RunAsGroup = containerSecurityCtx.RunAsGroup
 	}
 
-	if user := getValidatedID(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
+	if user := getValidatedID(ctx, pod.Annotations[dtwebhook.AnnotationInitContainerRunAsUser]); user != nil {
 		baseSecurityCtx.RunAsUser = user
 	}
 
-	if group := getValidatedID(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
+	if group := getValidatedID(ctx, pod.Annotations[dtwebhook.AnnotationInitContainerRunAsGroup]); group != nil {
 		baseSecurityCtx.RunAsGroup = group
 	}
 
@@ -146,16 +146,15 @@ func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.Securit
 
 // getValidatedID will parse the provided annotation as valid user/group ID between 0 and math.MaxInt32.
 // Returns *int64 for compatibility with corev1.SecurityContext
-func getValidatedID(ctx context.Context, annotations map[string]string, key string) *int64 {
-	val, ok := annotations[key]
-	if !ok {
+func getValidatedID(ctx context.Context, value string) *int64 {
+	if value == "" {
 		return nil
 	}
 
 	// uint31 == positive int32 range
-	parsed, err := strconv.ParseUint(val, 10, 31)
+	parsed, err := strconv.ParseUint(value, 10, 31)
 	if err != nil {
-		logd.FromContext(ctx).Error(err, "failed to parse annotation value, must be a positive int32", "key", key, "value", val)
+		logd.FromContext(ctx).Error(err, "failed to parse annotation value, must be a positive int32", "value", value)
 
 		return nil
 	}

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -5,9 +5,7 @@ package injection
 
 import (
 	"context"
-	"errors"
 	"strconv"
-	"strings"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure"
@@ -22,7 +20,6 @@ import (
 	oacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/volumes"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func (h *Handler) createInitContainerBase(ctx context.Context, pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Container {
@@ -134,20 +131,12 @@ func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.Securit
 		baseSecurityCtx.RunAsGroup = containerSecurityCtx.RunAsGroup
 	}
 
-	if user := parseAnnotationAsInt64(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
-		if valErrs := validation.IsValidUserID(*user); valErrs != nil {
-			logd.FromContext(ctx).Error(errors.New(strings.Join(valErrs, ";")), "invalid user ID from annotation, ignoring")
-		} else {
-			baseSecurityCtx.RunAsUser = user
-		}
+	if user := parseAnnotationAsUint32(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
+		baseSecurityCtx.RunAsUser = user
 	}
 
-	if group := parseAnnotationAsInt64(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
-		if valErrs := validation.IsValidGroupID(*group); valErrs != nil {
-			logd.FromContext(ctx).Error(errors.New(strings.Join(valErrs, ";")), "invalid group ID from annotation, ignoring")
-		} else {
-			baseSecurityCtx.RunAsGroup = group
-		}
+	if group := parseAnnotationAsUint32(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
+		baseSecurityCtx.RunAsGroup = group
 	}
 
 	baseSecurityCtx.RunAsNonRoot = new(isNonRoot(&baseSecurityCtx))
@@ -155,20 +144,23 @@ func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.Securit
 	return &baseSecurityCtx
 }
 
-func parseAnnotationAsInt64(ctx context.Context, annotations map[string]string, key string) *int64 {
+// parseAnnotationAsUint32 will parse the provided annotation as a uint32,
+// but will return an int64 pointer for compatibility reasons with the corev1.SecurityContext type.
+// Will only log parsing errors, as we do not want to block due to incorrect user annotation.
+func parseAnnotationAsUint32(ctx context.Context, annotations map[string]string, key string) *int64 {
 	val, ok := annotations[key]
 	if !ok {
 		return nil
 	}
 
-	parsed, err := strconv.ParseInt(val, 10, 64)
+	parsed, err := strconv.ParseUint(val, 10, 32)
 	if err != nil {
-		logd.FromContext(ctx).Error(err, "failed to parse annotation value", "key", key, "value", val)
+		logd.FromContext(ctx).Error(err, "failed to parse annotation value, must be a uint32", "key", key, "value", val)
 
 		return nil
 	}
 
-	return &parsed
+	return new(int64(parsed))
 }
 
 func addSeccompProfile(ctx *corev1.SecurityContext, dk dynakube.DynaKube) {

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -5,12 +5,14 @@ package injection
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure"
 	"github.com/Dynatrace/dynatrace-operator/cmd/bootstrapper"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/namespace/bootstrapperconfig"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sresource"
 	maputils "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/arg"
@@ -129,9 +131,33 @@ func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.
 		baseSecurityCtx.RunAsGroup = containerSecurityCtx.RunAsGroup
 	}
 
+	if user := parseAnnotationAsInt64(pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
+		baseSecurityCtx.RunAsUser = user
+	}
+
+	if group := parseAnnotationAsInt64(pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
+		baseSecurityCtx.RunAsGroup = group
+	}
+
 	baseSecurityCtx.RunAsNonRoot = new(isNonRoot(&baseSecurityCtx))
 
 	return &baseSecurityCtx
+}
+
+func parseAnnotationAsInt64(annotations map[string]string, key string) *int64 {
+	val, ok := annotations[key]
+	if !ok {
+		return nil
+	}
+
+	parsed, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		logd.Get().Error(err, "failed to parse pod annotation as int64, ignoring", "annotation", key, "value", val)
+
+		return nil
+	}
+
+	return &parsed
 }
 
 func addSeccompProfile(ctx *corev1.SecurityContext, dk dynakube.DynaKube) {

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -155,7 +155,7 @@ func getValidatedID(ctx context.Context, annotations map[string]string, key stri
 	// uint31 == positive int32 range
 	parsed, err := strconv.ParseUint(val, 10, 31)
 	if err != nil {
-		logd.FromContext(ctx).Error(err, "failed to parse annotation value, must be a uint32", "key", key, "value", val)
+		logd.FromContext(ctx).Error(err, "failed to parse annotation value, must be a positive int32", "key", key, "value", val)
 
 		return nil
 	}

--- a/pkg/webhook/mutation/pod/handler/injection/init.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init.go
@@ -5,7 +5,9 @@ package injection
 
 import (
 	"context"
+	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure"
@@ -20,9 +22,10 @@ import (
 	oacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/volumes"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-func (h *Handler) createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Container {
+func (h *Handler) createInitContainerBase(ctx context.Context, pod *corev1.Pod, dk dynakube.DynaKube) *corev1.Container {
 	args := []arg.Arg{
 		{
 			Name:  configure.ConfigFolderFlag,
@@ -49,7 +52,7 @@ func (h *Handler) createInitContainerBase(pod *corev1.Pod, dk dynakube.DynaKube)
 		Name:            dtwebhook.InstallContainerName,
 		Image:           h.webhookPodImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		SecurityContext: securityContextForInitContainer(pod, dk, h.isOpenShift),
+		SecurityContext: securityContextForInitContainer(ctx, pod, dk, h.isOpenShift),
 		Resources:       defaultInitContainerResources(),
 		Args:            append([]string{bootstrapper.Use}, arg.ConvertArgsToStrings(args)...),
 	}
@@ -85,7 +88,7 @@ func defaultInitContainerResources() corev1.ResourceRequirements {
 	}
 }
 
-func securityContextForInitContainer(pod *corev1.Pod, dk dynakube.DynaKube, isOpenShift bool) *corev1.SecurityContext {
+func securityContextForInitContainer(ctx context.Context, pod *corev1.Pod, dk dynakube.DynaKube, isOpenShift bool) *corev1.SecurityContext {
 	initSecurityCtx := corev1.SecurityContext{
 		ReadOnlyRootFilesystem:   new(true),
 		AllowPrivilegeEscalation: new(false),
@@ -104,10 +107,10 @@ func securityContextForInitContainer(pod *corev1.Pod, dk dynakube.DynaKube, isOp
 
 	addSeccompProfile(&initSecurityCtx, dk)
 
-	return combineSecurityContexts(initSecurityCtx, *pod)
+	return combineSecurityContexts(ctx, initSecurityCtx, *pod)
 }
 
-func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.Pod) *corev1.SecurityContext {
+func combineSecurityContexts(ctx context.Context, baseSecurityCtx corev1.SecurityContext, pod corev1.Pod) *corev1.SecurityContext {
 	containerSecurityCtx := &corev1.SecurityContext{}
 	if len(pod.Spec.Containers) > 0 {
 		containerSecurityCtx = pod.Spec.Containers[0].SecurityContext
@@ -131,12 +134,20 @@ func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.
 		baseSecurityCtx.RunAsGroup = containerSecurityCtx.RunAsGroup
 	}
 
-	if user := parseAnnotationAsInt64(pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
-		baseSecurityCtx.RunAsUser = user
+	if user := parseAnnotationAsInt64(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsUser); user != nil {
+		if valErrs := validation.IsValidUserID(*user); valErrs != nil {
+			logd.FromContext(ctx).Error(errors.New(strings.Join(valErrs, ";")), "invalid user ID from annotation, ignoring")
+		} else {
+			baseSecurityCtx.RunAsUser = user
+		}
 	}
 
-	if group := parseAnnotationAsInt64(pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
-		baseSecurityCtx.RunAsGroup = group
+	if group := parseAnnotationAsInt64(ctx, pod.Annotations, dtwebhook.AnnotationInitContainerRunAsGroup); group != nil {
+		if valErrs := validation.IsValidGroupID(*group); valErrs != nil {
+			logd.FromContext(ctx).Error(errors.New(strings.Join(valErrs, ";")), "invalid group ID from annotation, ignoring")
+		} else {
+			baseSecurityCtx.RunAsGroup = group
+		}
 	}
 
 	baseSecurityCtx.RunAsNonRoot = new(isNonRoot(&baseSecurityCtx))
@@ -144,7 +155,7 @@ func combineSecurityContexts(baseSecurityCtx corev1.SecurityContext, pod corev1.
 	return &baseSecurityCtx
 }
 
-func parseAnnotationAsInt64(annotations map[string]string, key string) *int64 {
+func parseAnnotationAsInt64(ctx context.Context, annotations map[string]string, key string) *int64 {
 	val, ok := annotations[key]
 	if !ok {
 		return nil
@@ -152,7 +163,7 @@ func parseAnnotationAsInt64(annotations map[string]string, key string) *int64 {
 
 	parsed, err := strconv.ParseInt(val, 10, 64)
 	if err != nil {
-		logd.Get().Error(err, "failed to parse pod annotation as int64, ignoring", "annotation", key, "value", val)
+		logd.FromContext(ctx).Error(err, "failed to parse annotation value", "key", key, "value", val)
 
 		return nil
 	}

--- a/pkg/webhook/mutation/pod/handler/injection/init_test.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init_test.go
@@ -482,6 +482,19 @@ func Test_combineSecurityContexts_annotations(t *testing.T) {
 		assert.Equal(t, int64(42), *out.RunAsUser)
 		assert.Equal(t, int64(42), *out.RunAsGroup)
 	})
+
+	t.Run("math.MaxInt32 works", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: strconv.Itoa(math.MaxInt32), dtwebhook.AnnotationInitContainerRunAsGroup: strconv.Itoa(math.MaxInt32)}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(42)), RunAsGroup: new(int64(42))}
+
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsUser)
+		require.NotNil(t, out.RunAsGroup)
+		assert.Equal(t, int64(math.MaxInt32), *out.RunAsUser)
+		assert.Equal(t, int64(math.MaxInt32), *out.RunAsGroup)
+	})
 }
 
 func Test_securityContextForInitContainer(t *testing.T) {

--- a/pkg/webhook/mutation/pod/handler/injection/init_test.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init_test.go
@@ -391,6 +391,69 @@ func Test_combineSecurityContexts(t *testing.T) {
 	}
 }
 
+func Test_combineSecurityContexts_annotations(t *testing.T) {
+	t.Run("annotation overrides user", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "999"}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(10))}
+
+		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsUser)
+		assert.Equal(t, int64(999), *out.RunAsUser)
+	})
+
+	t.Run("annotation overrides group", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsGroup: "888"}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsGroup: new(int64(10))}
+
+		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsGroup)
+		assert.Equal(t, int64(888), *out.RunAsGroup)
+	})
+
+	t.Run("annotation overrides container security context", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{
+			dtwebhook.AnnotationInitContainerRunAsUser:  "777",
+			dtwebhook.AnnotationInitContainerRunAsGroup: "666",
+		}
+		pod.Spec.Containers = []corev1.Container{
+			{SecurityContext: &corev1.SecurityContext{RunAsUser: new(int64(0)), RunAsGroup: new(int64(0))}},
+		}
+
+		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsUser)
+		assert.Equal(t, int64(777), *out.RunAsUser)
+		require.NotNil(t, out.RunAsGroup)
+		assert.Equal(t, int64(666), *out.RunAsGroup)
+	})
+
+	t.Run("annotation root user sets RunAsNonRoot false", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "0"}
+
+		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsNonRoot)
+		assert.False(t, *out.RunAsNonRoot)
+	})
+
+	t.Run("invalid annotation value is ignored", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "not-a-number"}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(42))}
+
+		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsUser)
+		assert.Equal(t, int64(42), *out.RunAsUser)
+	})
+}
+
 func Test_securityContextForInitContainer(t *testing.T) {
 	type testCase struct {
 		title       string

--- a/pkg/webhook/mutation/pod/handler/injection/init_test.go
+++ b/pkg/webhook/mutation/pod/handler/injection/init_test.go
@@ -4,6 +4,8 @@
 package injection
 
 import (
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit"
@@ -44,7 +46,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = nil
 		pod.Spec.Containers[0].SecurityContext.RunAsGroup = nil
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		require.NotNil(t, initContainer)
 
@@ -81,7 +83,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = testUser
 		pod.Spec.Containers[0].SecurityContext.RunAsGroup = testUser
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
@@ -101,7 +103,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod.Spec.SecurityContext.RunAsUser = testUser
 		pod.Spec.SecurityContext.RunAsGroup = testUser
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		require.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.True(t, *initContainer.SecurityContext.RunAsNonRoot)
@@ -120,7 +122,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod.Spec.SecurityContext.RunAsUser = new(RootUser)
 		pod.Spec.SecurityContext.RunAsGroup = new(RootGroup)
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.NotNil(t, initContainer.SecurityContext.RunAsNonRoot)
 		assert.False(t, *initContainer.SecurityContext.RunAsNonRoot)
@@ -137,7 +139,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, initContainer.SecurityContext.SeccompProfile.Type)
 	})
@@ -148,7 +150,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.NotContains(t, initContainer.Args, "--"+k8sinit.SuppressErrorsFlag)
 	})
@@ -159,7 +161,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{dtwebhook.AnnotationFailurePolicy: "fail"}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.NotContains(t, initContainer.Args, "--"+k8sinit.SuppressErrorsFlag)
 	})
@@ -170,7 +172,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.Contains(t, initContainer.Args, "--"+k8sinit.SuppressErrorsFlag)
 	})
@@ -181,7 +183,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.Contains(t, initContainer.Args, "--"+k8sinit.SuppressErrorsFlag)
 
@@ -190,7 +192,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod = getTestPod()
 		pod.Annotations = map[string]string{dtwebhook.AnnotationFailurePolicy: "asd"}
 
-		initContainer = wh.createInitContainerBase(pod, *dk)
+		initContainer = wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.Contains(t, initContainer.Args, "--"+k8sinit.SuppressErrorsFlag)
 	})
@@ -202,11 +204,11 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod.Annotations = map[string]string{}
 
 		dk := getTestDynakube()
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 		assert.Contains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 
 		dk.Spec.OneAgent = getApplicationMonitoringSpec()
-		initContainer = wh.createInitContainerBase(pod, *dk)
+		initContainer = wh.createInitContainerBase(t.Context(), pod, *dk)
 		assert.Contains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 	})
 
@@ -218,11 +220,11 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod.Annotations = map[string]string{}
 
 		dk.Spec.OneAgent = getHostMonitoringSpec()
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 
 		dk.Spec.OneAgent = getClassicFullStackSpec()
-		initContainer = wh.createInitContainerBase(pod, *dk)
+		initContainer = wh.createInitContainerBase(t.Context(), pod, *dk)
 		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 	})
 
@@ -232,7 +234,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 	})
@@ -244,7 +246,7 @@ func TestCreateInitContainerBase(t *testing.T) {
 		pod := getTestPod()
 		pod.Annotations = map[string]string{}
 
-		initContainer := wh.createInitContainerBase(pod, *dk)
+		initContainer := wh.createInitContainerBase(t.Context(), pod, *dk)
 
 		assert.NotContains(t, initContainer.Args, "--"+bootstrapper.BaseURL)
 	})
@@ -383,7 +385,7 @@ func Test_combineSecurityContexts(t *testing.T) {
 				},
 			}
 
-			out := combineSecurityContexts(c.initContainerSc, pod)
+			out := combineSecurityContexts(t.Context(), c.initContainerSc, pod)
 			require.NotNil(t, out)
 
 			assert.Equal(t, c.expectedOut, *out)
@@ -397,7 +399,7 @@ func Test_combineSecurityContexts_annotations(t *testing.T) {
 		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "999"}
 		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(10))}
 
-		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
 		require.NotNil(t, out)
 		require.NotNil(t, out.RunAsUser)
 		assert.Equal(t, int64(999), *out.RunAsUser)
@@ -408,7 +410,7 @@ func Test_combineSecurityContexts_annotations(t *testing.T) {
 		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsGroup: "888"}
 		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsGroup: new(int64(10))}
 
-		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
 		require.NotNil(t, out)
 		require.NotNil(t, out.RunAsGroup)
 		assert.Equal(t, int64(888), *out.RunAsGroup)
@@ -424,7 +426,7 @@ func Test_combineSecurityContexts_annotations(t *testing.T) {
 			{SecurityContext: &corev1.SecurityContext{RunAsUser: new(int64(0)), RunAsGroup: new(int64(0))}},
 		}
 
-		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
 		require.NotNil(t, out)
 		require.NotNil(t, out.RunAsUser)
 		assert.Equal(t, int64(777), *out.RunAsUser)
@@ -436,21 +438,49 @@ func Test_combineSecurityContexts_annotations(t *testing.T) {
 		pod := corev1.Pod{}
 		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "0"}
 
-		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
 		require.NotNil(t, out)
 		require.NotNil(t, out.RunAsNonRoot)
 		assert.False(t, *out.RunAsNonRoot)
 	})
 
-	t.Run("invalid annotation value is ignored", func(t *testing.T) {
+	t.Run("invalid annotation value is ignored - not a number", func(t *testing.T) {
 		pod := corev1.Pod{}
-		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "not-a-number"}
-		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(42))}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "not-a-number", dtwebhook.AnnotationInitContainerRunAsGroup: "not-a-number"}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(42)), RunAsGroup: new(int64(42))}
 
-		out := combineSecurityContexts(corev1.SecurityContext{}, pod)
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
 		require.NotNil(t, out)
 		require.NotNil(t, out.RunAsUser)
+		require.NotNil(t, out.RunAsGroup)
 		assert.Equal(t, int64(42), *out.RunAsUser)
+		assert.Equal(t, int64(42), *out.RunAsGroup)
+	})
+
+	t.Run("invalid annotation value is ignored - negative number", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: "-1", dtwebhook.AnnotationInitContainerRunAsGroup: "-1"}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(42)), RunAsGroup: new(int64(42))}
+
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsUser)
+		require.NotNil(t, out.RunAsGroup)
+		assert.Equal(t, int64(42), *out.RunAsUser)
+		assert.Equal(t, int64(42), *out.RunAsGroup)
+	})
+
+	t.Run("invalid annotation value is ignored - too big number", func(t *testing.T) {
+		pod := corev1.Pod{}
+		pod.Annotations = map[string]string{dtwebhook.AnnotationInitContainerRunAsUser: strconv.Itoa(math.MaxInt64), dtwebhook.AnnotationInitContainerRunAsGroup: strconv.Itoa(math.MaxInt64)}
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsUser: new(int64(42)), RunAsGroup: new(int64(42))}
+
+		out := combineSecurityContexts(t.Context(), corev1.SecurityContext{}, pod)
+		require.NotNil(t, out)
+		require.NotNil(t, out.RunAsUser)
+		require.NotNil(t, out.RunAsGroup)
+		assert.Equal(t, int64(42), *out.RunAsUser)
+		assert.Equal(t, int64(42), *out.RunAsGroup)
 	})
 }
 
@@ -661,7 +691,7 @@ func Test_securityContextForInitContainer(t *testing.T) {
 			pod := corev1.Pod{}
 			pod.Spec.SecurityContext = &c.podSc
 
-			out := securityContextForInitContainer(&pod, c.dk, c.isOpenShift)
+			out := securityContextForInitContainer(t.Context(), &pod, c.dk, c.isOpenShift)
 			require.NotNil(t, out)
 
 			assert.Equal(t, c.expectedOut, *out)

--- a/pkg/webhook/mutation/pod/mutator/config.go
+++ b/pkg/webhook/mutation/pod/mutator/config.go
@@ -33,6 +33,11 @@ const (
 	// InstallContainerName is the name used for the install container
 	InstallContainerName = "dynatrace-operator"
 
+	// AnnotationInitContainerRunAsUser can be set on a Pod to override the RunAsUser in the init container's security context.
+	AnnotationInitContainerRunAsUser = "init-container.dynatrace.com/run-as-user"
+	// AnnotationInitContainerRunAsGroup can be set on a Pod to override the RunAsGroup in the init container's security context.
+	AnnotationInitContainerRunAsGroup = "init-container.dynatrace.com/run-as-group"
+
 	// AnnotationInjectionSplitMounts can be set on a Pod to indicate that the `/var/lib/dynatrace` volume mount on the user container should be split into multiple mounts.
 	// The following mounts are created:
 	// - In case OneAgent injection is enabled:

--- a/pkg/webhook/mutation/pod/mutator/config.go
+++ b/pkg/webhook/mutation/pod/mutator/config.go
@@ -33,10 +33,11 @@ const (
 	// InstallContainerName is the name used for the install container
 	InstallContainerName = "dynatrace-operator"
 
+	AnnotationInitContainerPrefix = "init-container.dynatrace.com/"
 	// AnnotationInitContainerRunAsUser can be set on a Pod to override the RunAsUser in the init container's security context.
-	AnnotationInitContainerRunAsUser = "init-container.dynatrace.com/run-as-user"
+	AnnotationInitContainerRunAsUser = AnnotationInitContainerPrefix + "securityContext.runAsUser"
 	// AnnotationInitContainerRunAsGroup can be set on a Pod to override the RunAsGroup in the init container's security context.
-	AnnotationInitContainerRunAsGroup = "init-container.dynatrace.com/run-as-group"
+	AnnotationInitContainerRunAsGroup = AnnotationInitContainerPrefix + "securityContext.runAsGroup"
 
 	// AnnotationInjectionSplitMounts can be set on a Pod to indicate that the `/var/lib/dynatrace` volume mount on the user container should be split into multiple mounts.
 	// The following mounts are created:


### PR DESCRIPTION
## Description
https://dt-rnd.atlassian.net/browse/ICP-7892

Adds 2 new pod level annotation, that can overrule the current "auto setting" of the init-container's `runAs*`.

```
init-container.dynatrace.com/securityContext.runAsUser: "1002"
init-container.dynatrace.com/securityContext.runAsGroup: "1002"
```

Introducing this config option for the rare usecase where the auto-setting does not comply with the user's setup.

Other option that was considered: "Never let the init-container to be root, even if the injected containers are root"
- Could be breaking change, why we decided to not do it.

## How can this be tested?

Set the mentioned annotations on a sample pod, and verify that it is respected.