### PR TITLE
Log skipped rules during injection

### DIFF
--- a/pkg/webhook/mutation/pod/attributes/pod.go
+++ b/pkg/webhook/mutation/pod/attributes/pod.go
@@ -64,7 +64,7 @@ func NewPodAttributes(ctx context.Context, request mutator.BaseRequest, client c
 		return nil, err
 	}
 
-	attrs.readMetadataAnnotations(request)
+	attrs.readMetadataAnnotations(ctx, request)
 	attrs.readPodAttributes(request)
 
 	if attrs.useDeprecated {

--- a/pkg/webhook/mutation/pod/attributes/read.go
+++ b/pkg/webhook/mutation/pod/attributes/read.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/metadataenrichment"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/workload"
@@ -14,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (attrs *Pod) readMetadataAnnotations(request mutator.BaseRequest) {
-	attrs.applyEnrichmentRules(request.Namespace, request.DynaKube)
+func (attrs *Pod) readMetadataAnnotations(ctx context.Context, request mutator.BaseRequest) {
+	attrs.applyEnrichmentRules(ctx, request.Namespace, request.DynaKube)
 	attrs.readNamespaceAnnotationAttributes(request.Namespace)
 	attrs.readPodAnnotationAttributes(*request.Pod)
 }
@@ -39,7 +40,9 @@ func (attrs *Pod) readPodAnnotationAttributes(pod corev1.Pod) {
 	}
 }
 
-func (attrs *Pod) applyEnrichmentRules(namespace corev1.Namespace, dk dynakube.DynaKube) {
+func (attrs *Pod) applyEnrichmentRules(ctx context.Context, namespace corev1.Namespace, dk dynakube.DynaKube) {
+	var skippedRules []metadataenrichment.Rule
+
 	for _, rule := range dk.Status.MetadataEnrichment.Rules {
 		var (
 			valueFromNamespace string
@@ -65,8 +68,14 @@ func (attrs *Pod) applyEnrichmentRules(namespace corev1.Namespace, dk dynakube.D
 				// The first rule to resolve to a value wins, regardless of type.
 				// This only is valid if the order of the rules remains unchanged from the API response.
 				attrs.rules[rule.Target] = valueFromNamespace
+			} else {
+				skippedRules = append(skippedRules, rule)
 			}
 		}
+	}
+
+	if len(skippedRules) > 0 {
+		logd.FromContext(ctx).Info("ignoring metadata enrichment rules with lower precedence", "rules", skippedRules)
 	}
 }
 

--- a/pkg/webhook/mutation/pod/attributes/read.go
+++ b/pkg/webhook/mutation/pod/attributes/read.go
@@ -62,7 +62,7 @@ func (attrs *Pod) applyEnrichmentRules(ctx context.Context, namespace corev1.Nam
 		if exists {
 			if rule.Target == "" {
 				// The last rule without a target to resolve to a value wins. This inconsistency is intentional to not introduce a behavior change for users upgrading from <1.10.
-				// Target can only be empty for legacy schema rules.
+				// TODO: Verify if we can remove this branch. The API in dev does not allow an empty target for neither schema.
 				attrs.rules[metadataenrichment.GetEmptyTargetEnrichmentKey(string(rule.Type), rule.Source)] = valueFromNamespace
 			} else if _, ok := attrs.rules[rule.Target]; !ok {
 				// The first rule to resolve to a value wins, regardless of type.

--- a/pkg/webhook/mutation/pod/attributes/read_test.go
+++ b/pkg/webhook/mutation/pod/attributes/read_test.go
@@ -118,7 +118,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		expectedKey := metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.LabelRule), "env")
 		assert.Equal(t, "production", attrs.rules[expectedKey])
@@ -142,7 +142,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		assert.Equal(t, "staging", attrs.rules["custom.env"])
 		assert.Len(t, attrs.rules, 1)
@@ -165,7 +165,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		assert.Equal(t, "backend", attrs.rules["team.name"])
 	})
@@ -182,7 +182,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(corev1.Namespace{}, dk)
+		attrs.applyEnrichmentRules(t.Context(), corev1.Namespace{}, dk)
 
 		assert.Empty(t, attrs.rules)
 	})
@@ -208,7 +208,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		envKey := metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.LabelRule), "env")
 		assert.Equal(t, "prod", attrs.rules[envKey])
@@ -232,7 +232,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		assert.Equal(t, "production", attrs.rules["custom.env"])
 		assert.Len(t, attrs.rules, 1)
@@ -255,7 +255,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		expectedKey := metadataenrichment.GetEmptyTargetEnrichmentKey(string(metadataenrichment.K8sNamespaceLabelRule), "env")
 		assert.Equal(t, "production", attrs.rules[expectedKey])
@@ -279,7 +279,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(ns, dk)
+		attrs.applyEnrichmentRules(t.Context(), ns, dk)
 
 		assert.Equal(t, "backend", attrs.rules["team.name"])
 		assert.Len(t, attrs.rules, 1)
@@ -297,7 +297,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(corev1.Namespace{}, dk)
+		attrs.applyEnrichmentRules(t.Context(), corev1.Namespace{}, dk)
 
 		assert.Empty(t, attrs.rules)
 	})
@@ -314,7 +314,7 @@ func TestGetFromEnrichmentRules(t *testing.T) {
 			},
 		}
 
-		attrs.applyEnrichmentRules(corev1.Namespace{}, dk)
+		attrs.applyEnrichmentRules(t.Context(), corev1.Namespace{}, dk)
 
 		assert.Equal(t, "my-literal-value", attrs.rules["dt.custom"])
 		assert.Len(t, attrs.rules, 1)
@@ -399,7 +399,7 @@ func TestGetFromEnrichmentRulesPrecedence(t *testing.T) {
 			dk := dynakube.DynaKube{Status: dynakube.DynaKubeStatus{MetadataEnrichment: metadataenrichment.Status{Rules: tt.rules}}}
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Labels: tt.namespaceLabels, Annotations: tt.namespaceAnnotations}}
 
-			attrs.applyEnrichmentRules(ns, dk)
+			attrs.applyEnrichmentRules(t.Context(), ns, dk)
 			assert.Equal(t, tt.expect, attrs.rules)
 		})
 	}
@@ -429,7 +429,7 @@ func TestGetMetadataAnnotations(t *testing.T) {
 			},
 		}
 
-		attrs.readMetadataAnnotations(dtwebhook.BaseRequest{Pod: &pod, Namespace: ns, DynaKube: dk})
+		attrs.readMetadataAnnotations(t.Context(), dtwebhook.BaseRequest{Pod: &pod, Namespace: ns, DynaKube: dk})
 
 		assert.Equal(t, "ns-val", attrs.namespaceAnnotations["ns-key"])
 		assert.Equal(t, "pod-val", attrs.podAnnotations["pod-key"])


### PR DESCRIPTION
## Description

We should be logging all rules that are skipped. #7026 just added the logs to the client that filters by type/condition, but I forgot to add the log in #7025.

The logs are duplicated if you use both OTLP auto config and metadata enrichment, but there's no easy way around this since they use shared code.

```
{"level":"info","ts":"2026-07-29T09:04:16.685Z","logger":"admission.pod-mutation.injection.otlp.resource-attributes","msg":"ignoring metadata enrichment rules with lower precedence","object":{"name":"","namespace":"inject"},"namespace":"inject","name":"","resource":{"group":"","version":"v1","resource":"pods"},"user":"system:serviceaccount:kube-system:replicaset-controller","requestID":"af2b1781-a66a-41c3-8755-72afdbff6017","podName":"nginx-56c45fd5ff-","namespace":"inject","rules":[{"type":"K8S_NAMESPACE_LABEL","source":"e2e-test-label","target":"dt.cost.product"}]}
{"level":"info","ts":"2026-07-29T09:04:57.186Z","logger":"admission.pod-mutation.injection","msg":"ignoring metadata enrichment rules with lower precedence","object":{"name":"","namespace":"inject"},"namespace":"inject","name":"","resource":{"group":"","version":"v1","resource":"pods"},"user":"system:serviceaccount:kube-system:replicaset-controller","requestID":"b915f9d8-d049-4c55-b0af-4d4ce4195e12","rules":[{"type":"K8S_NAMESPACE_LABEL","source":"e2e-test-label","target":"dt.cost.product"}]}
```

ICP-7797

## How can this be tested?

* Create two rules on the tenant that have the same target
* Label or annotate a namespace to ensure that one rule wins over the other
* Deploy a DynaKube with metadata enrichment or OTLP auto config (or both) enabled 
* Check that the rules appear in the correct order in the status
* Inject a workload in that namespace
* Check that the metadata annotation contains the expected  value
* Check the webhook logs to see if they mention the ignored rules
