### PR TITLE
Remove duplicate user from namespace webhook logs

### DIFF
--- a/pkg/webhook/mutation/namespace/webhook.go
+++ b/pkg/webhook/mutation/namespace/webhook.go
@@ -44,16 +44,14 @@ type webhook struct {
 //  2. if the namespace was updated by the operator => don't do the mapping: we do this because the operator also does the mapping
 //     but from the DynaKube's side (during DynaKube reconcile) and we don't want to repeat ourselves
 func (wh *webhook) Handle(ctx context.Context, request admission.Request) admission.Response {
-	ctx, log := logd.NewFromContext(ctx, "namespace-mutation")
+	ctx, log := logd.NewFromContext(ctx, "namespace-mutation", "operation", request.Operation)
 
 	if wh.namespace == request.Namespace {
 		return admission.Allowed("")
 	}
 
-	logger := log.WithValues("namespace", request.Name, "operation", request.Operation)
-
 	if request.UserInfo.Username == wh.serviceAccount {
-		logger.Info("ignoring change from operator", "serviceAccount", wh.serviceAccount)
+		log.Info("ignoring change from operator")
 
 		return admission.Allowed("")
 	}


### PR DESCRIPTION
## Description

I saw this while testing another webhook change. The webhook logger from context already contains the user so we don't need to add it as an additional key.
The namespace name is also redundant.

```
{"level":"info","ts":"2026-07-29T09:17:47.553Z","logger":"admission.namespace-mutation","msg":"ignoring change from operator","object":{"name":"inject","namespace":"inject"},"namespace":"inject","name":"inject","resource":{"group":"","version":"v1","resource":"namespaces"},"user":"system:serviceaccount:dynatrace:dynatrace-operator","requestID":"0a3bdd8f-b0a0-4c97-902e-2b2dd5b12168","namespace":"inject","operation":"UPDATE","serviceAccount":"system:serviceaccount:dynatrace:dynatrace-operator"}
```

## How can this be tested?

* Deploy the operator with any kind of injection enabled and check the webhook logs
