### PR TITLE
Introduce a limit for the value of metadata.dynatrace.com annotation

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -81,6 +81,7 @@ spec:
             - name: EXPERIMENTAL_ENABLE_KUBEMON_OPERAND
               value: "true"
             {{- end }}
+            {{ include "dynatrace-webhook.metadata-size-limit-env" . | nindent 12 }}
             {{ include "dynatrace-operator.modules-json-env" . | nindent 12 }}
           readinessProbe:
             httpGet:

--- a/config/helm/chart/default/templates/_helpers.tpl
+++ b/config/helm/chart/default/templates/_helpers.tpl
@@ -208,3 +208,10 @@ topologySpreadConstraints:
   value: {{ . | quote }}
   {{- end }}
 {{- end -}}
+
+{{- define "dynatrace-webhook.metadata-size-limit-env" -}}
+  {{- with .Values.webhook.metadataSizeLimit }}
+- name: DT_METADATA_SIZE_LIMIT
+  value: {{ . | quote }}
+  {{- end }}
+{{- end -}}

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -129,6 +129,7 @@ webhook:
     certsDir:
       sizeLimit: 10Mi
   startupProbe: {} # configurable: periodSeconds, timeoutSeconds, failureThreshold
+  metadataSizeLimit: "" # size limit for the metadata annotation, defaults to 24576 bytes
 
 csidriver:
   enabled: true

--- a/pkg/util/kubernetes/fields/k8senv/env.go
+++ b/pkg/util/kubernetes/fields/k8senv/env.go
@@ -64,6 +64,9 @@ const (
 	defaultWebhookCertsRootDuration = 365 * 24 * time.Hour
 	minWebhookCertsRootDuration     = 7 * 24 * time.Hour
 	maxWebhookCertsRootDuration     = 10 * 365 * 24 * time.Hour
+
+	WebhookMetadataSizeLimitEnvVar       = "DT_METADATA_SIZE_LIMIT"
+	defaultWebhookMetadataSizeLimitValue = 24 * 1024
 )
 
 func Find(envVars []corev1.EnvVar, name string) *corev1.EnvVar {
@@ -238,52 +241,33 @@ func getSafeDurationFromEnv(ctx context.Context, envVar string, defaultValue, mi
 	return duration
 }
 
-func GetMetadaSizeLimit() BoundedInt {
-	return BoundedInt{
-		EnvName:      "DT_METADATA_SIZE_LIMIT",
-		DefaultValue: 24 * 1024,
-	}
-}
-
-type BoundedInt struct {
-	EnvName       string
-	DefaultValue  int
-	ResolvedValue int
-}
-
-func (d BoundedInt) Resolve(ctx context.Context) BoundedInt {
+func GetMetadaSizeLimit(ctx context.Context) int {
 	var log logd.Logger
 	if ctx != nil {
 		_, log = logd.NewFromContext(ctx, "k8senv")
 	}
 
-	rawValue := os.Getenv(d.EnvName)
+	rawValue := os.Getenv(WebhookMetadataSizeLimitEnvVar)
 	if rawValue == "" {
 		if ctx != nil {
-			log.Debug("no custom env set, using default", "env", d.EnvName, "default", d.DefaultValue)
+			log.Debug("no custom env set, using default", "env", WebhookMetadataSizeLimitEnvVar, "default", defaultWebhookMetadataSizeLimitValue)
 		}
 
-		d.ResolvedValue = d.DefaultValue
-
-		return d
+		return defaultWebhookMetadataSizeLimitValue
 	}
 
 	value, err := strconv.Atoi(rawValue)
 	if err != nil || value < 0 {
 		if ctx != nil {
-			log.Error(err, "invalid int value, using default", "env", d.EnvName, "value", rawValue, "default", d.DefaultValue)
+			log.Error(err, "invalid int value, using default", "env", WebhookMetadataSizeLimitEnvVar, "value", rawValue, "default", defaultWebhookMetadataSizeLimitValue)
 		}
 
-		d.ResolvedValue = d.DefaultValue
-
-		return d
+		return defaultWebhookMetadataSizeLimitValue
 	}
 
 	if ctx != nil {
-		log.Info("using custom int value", "env", d.EnvName, "value", value)
+		log.Info("using custom int value", "env", WebhookMetadataSizeLimitEnvVar, "value", value)
 	}
 
-	d.ResolvedValue = value
-
-	return d
+	return value
 }

--- a/pkg/util/kubernetes/fields/k8senv/env.go
+++ b/pkg/util/kubernetes/fields/k8senv/env.go
@@ -237,3 +237,60 @@ func getSafeDurationFromEnv(ctx context.Context, envVar string, defaultValue, mi
 
 	return duration
 }
+
+func GetMetadaSizeLimit() BoundedInt {
+	return BoundedInt{
+		EnvName:      "DT_METADATA_SIZE_LIMIT",
+		DefaultValue: 24 * 1024,
+	}
+}
+
+type BoundedInt struct {
+	EnvName       string
+	DefaultValue  int
+	ResolvedValue int
+	ctx           context.Context
+}
+
+func (d BoundedInt) WithLog(ctx context.Context) BoundedInt {
+	d.ctx = ctx
+
+	return d
+}
+
+func (d BoundedInt) Resolve() BoundedInt {
+	var log logd.Logger
+	if d.ctx != nil {
+		_, log = logd.NewFromContext(d.ctx, "k8senv")
+	}
+
+	rawValue := os.Getenv(d.EnvName)
+	if rawValue == "" {
+		if d.ctx != nil {
+			log.Debug("no custom env set, using default", "env", d.EnvName, "default", d.DefaultValue)
+		}
+
+		d.ResolvedValue = d.DefaultValue
+
+		return d
+	}
+
+	value, err := strconv.Atoi(rawValue)
+	if err != nil || value < 0 {
+		if d.ctx != nil {
+			log.Error(err, "invalid int value, using default", "env", d.EnvName, "value", rawValue, "default", d.DefaultValue)
+		}
+
+		d.ResolvedValue = d.DefaultValue
+
+		return d
+	}
+
+	if d.ctx != nil {
+		log.Info("using custom int value", "env", d.EnvName, "value", value)
+	}
+
+	d.ResolvedValue = value
+
+	return d
+}

--- a/pkg/util/kubernetes/fields/k8senv/env.go
+++ b/pkg/util/kubernetes/fields/k8senv/env.go
@@ -249,24 +249,17 @@ type BoundedInt struct {
 	EnvName       string
 	DefaultValue  int
 	ResolvedValue int
-	ctx           context.Context
 }
 
-func (d BoundedInt) WithLog(ctx context.Context) BoundedInt {
-	d.ctx = ctx
-
-	return d
-}
-
-func (d BoundedInt) Resolve() BoundedInt {
+func (d BoundedInt) Resolve(ctx context.Context) BoundedInt {
 	var log logd.Logger
-	if d.ctx != nil {
-		_, log = logd.NewFromContext(d.ctx, "k8senv")
+	if ctx != nil {
+		_, log = logd.NewFromContext(ctx, "k8senv")
 	}
 
 	rawValue := os.Getenv(d.EnvName)
 	if rawValue == "" {
-		if d.ctx != nil {
+		if ctx != nil {
 			log.Debug("no custom env set, using default", "env", d.EnvName, "default", d.DefaultValue)
 		}
 
@@ -277,7 +270,7 @@ func (d BoundedInt) Resolve() BoundedInt {
 
 	value, err := strconv.Atoi(rawValue)
 	if err != nil || value < 0 {
-		if d.ctx != nil {
+		if ctx != nil {
 			log.Error(err, "invalid int value, using default", "env", d.EnvName, "value", rawValue, "default", d.DefaultValue)
 		}
 
@@ -286,7 +279,7 @@ func (d BoundedInt) Resolve() BoundedInt {
 		return d
 	}
 
-	if d.ctx != nil {
+	if ctx != nil {
 		log.Info("using custom int value", "env", d.EnvName, "value", value)
 	}
 

--- a/pkg/webhook/mutation/pod/attributes/combine.go
+++ b/pkg/webhook/mutation/pod/attributes/combine.go
@@ -5,10 +5,13 @@ package attributes
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/metadataenrichment"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8spod"
+	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -38,15 +41,40 @@ const (
 		withRules | withPodAnnotations | withWorkloadInfo
 )
 
+const (
+	InvalidMetadataAnnotationSize = "Value of the metadata enrichment annotation exceeds the maximum allowed size of %d, actual size: %d"
+)
+
 func (attrs *Pod) ApplyJSONAnnotationToPod(pod *corev1.Pod) error {
 	json, err := attrs.combineForJSONAnnotation()
 	if err != nil {
 		return err
 	}
 
+	metadataSizeLimit := k8senv.GetMetadaSizeLimit().Resolve().ResolvedValue
+	if len(json) > metadataSizeLimit {
+		errMsg := fmt.Sprintf(InvalidMetadataAnnotationSize, metadataSizeLimit, len(json))
+
+		return dtwebhook.MutatorError{
+			Err:      errors.New(errMsg),
+			Annotate: setNotInjectedAnnotationFunc(errMsg),
+		}
+	}
+
 	k8spod.SetAnnotationIfNotExists(pod, metadataenrichment.Annotation, json)
 
 	return nil
+}
+
+func setNotInjectedAnnotationFunc(reason string) func(*corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+
+		pod.Annotations[dtwebhook.AnnotationDynatraceInjected] = "false"
+		pod.Annotations[dtwebhook.AnnotationDynatraceReason] = reason
+	}
 }
 
 // combine copies maps into a single result in fixed precedence order (low → high).

--- a/pkg/webhook/mutation/pod/attributes/combine.go
+++ b/pkg/webhook/mutation/pod/attributes/combine.go
@@ -51,7 +51,7 @@ func (attrs *Pod) ApplyJSONAnnotationToPod(pod *corev1.Pod) error {
 		return err
 	}
 
-	metadataSizeLimit := k8senv.GetMetadaSizeLimit().Resolve(nil).ResolvedValue //nolint:staticcheck
+	metadataSizeLimit := k8senv.GetMetadaSizeLimit(nil) //nolint:staticcheck
 	if len(json) > metadataSizeLimit {
 		errMsg := fmt.Sprintf(InvalidMetadataAnnotationSize, metadataSizeLimit, len(json))
 

--- a/pkg/webhook/mutation/pod/attributes/combine.go
+++ b/pkg/webhook/mutation/pod/attributes/combine.go
@@ -51,7 +51,7 @@ func (attrs *Pod) ApplyJSONAnnotationToPod(pod *corev1.Pod) error {
 		return err
 	}
 
-	metadataSizeLimit := k8senv.GetMetadaSizeLimit().Resolve().ResolvedValue
+	metadataSizeLimit := k8senv.GetMetadaSizeLimit().Resolve(nil).ResolvedValue //nolint:staticcheck
 	if len(json) > metadataSizeLimit {
 		errMsg := fmt.Sprintf(InvalidMetadataAnnotationSize, metadataSizeLimit, len(json))
 

--- a/pkg/webhook/mutation/pod/attributes/combine_test.go
+++ b/pkg/webhook/mutation/pod/attributes/combine_test.go
@@ -5,6 +5,7 @@ package attributes
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -517,4 +518,75 @@ func TestCombine_ViaConstructors_AnnotationsOverrideAutoCollected(t *testing.T) 
 		assert.Equal(t, "pod", result[K8sWorkloadKindAttr])
 		assert.Equal(t, podName, result[K8sWorkloadNameAttr])
 	})
+}
+
+func TestMetadataValueSizeLimit(t *testing.T) {
+	testCases := []struct {
+		envValue string
+		attrSize int
+		injected bool
+	}{
+		{
+			envValue: "", // resolvedLimit: k8senv.GetMetadaSizeLimit().DefaultValue = 24 * 1024 = 24576
+			attrSize: 24000,
+			injected: true,
+		},
+		{
+			envValue: "", // resolvedLimit: k8senv.GetMetadaSizeLimit().DefaultValue
+			attrSize: 24576,
+			injected: false,
+		},
+		{
+			envValue: "-1", // resolvedLimit: k8senv.GetMetadaSizeLimit().DefaultValue
+			attrSize: 24000,
+			injected: true,
+		},
+		{
+			envValue: "-1", // resolvedLimit: k8senv.GetMetadaSizeLimit().DefaultValue
+			attrSize: 24576,
+			injected: false,
+		},
+		{
+			envValue: "10", // resolvedLimit: 10
+			attrSize: 1,
+			injected: false,
+		},
+		{
+			envValue: "11", // resolvedLimit: 11
+			attrSize: 1,
+			injected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("returns MutatorError when JSON annotation exceeds size limit", func(t *testing.T) {
+			if testCase.envValue != "" {
+				t.Setenv("DT_METADATA_SIZE_LIMIT", testCase.envValue)
+			}
+
+			attrs := newTestPodAttributes()
+			attrs.dynakube["key"] = strings.Repeat("x", testCase.attrSize)
+			pod := &corev1.Pod{}
+
+			err := attrs.ApplyJSONAnnotationToPod(pod)
+
+			if testCase.injected {
+				require.NoError(t, err, testCase)
+
+				_, ok := pod.Annotations[metadataenrichment.Annotation]
+				assert.True(t, ok, testCase)
+			} else {
+				require.Error(t, err, testCase)
+				var mutErr dtwebhook.MutatorError
+				require.ErrorAs(t, err, &mutErr, testCase)
+
+				mutErr.SetAnnotations(pod)
+
+				_, ok := pod.Annotations[metadataenrichment.Annotation]
+				assert.False(t, ok, testCase)
+				assert.Equal(t, "false", pod.Annotations[dtwebhook.AnnotationDynatraceInjected])
+				assert.Contains(t, pod.Annotations[dtwebhook.AnnotationDynatraceReason], "exceeds the maximum allowed size")
+			}
+		})
+	}
 }

--- a/pkg/webhook/mutation/pod/register.go
+++ b/pkg/webhook/mutation/pod/register.go
@@ -77,7 +77,7 @@ func newWebhook( //nolint:revive
 
 	log.Info("got webhook's image from env", "image", webhookImage)
 
-	_ = k8senv.GetMetadaSizeLimit().Resolve(ctx) // log settings for the metadata size limit
+	_ = k8senv.GetMetadaSizeLimit(ctx) // log settings for the metadata size limit
 
 	return &webhook{
 		injectionHandler: injection.New(

--- a/pkg/webhook/mutation/pod/register.go
+++ b/pkg/webhook/mutation/pod/register.go
@@ -77,7 +77,7 @@ func newWebhook( //nolint:revive
 
 	log.Info("got webhook's image from env", "image", webhookImage)
 
-	_ = k8senv.GetMetadaSizeLimit().Resolve(ctx)
+	_ = k8senv.GetMetadaSizeLimit().Resolve(ctx) // log settings for the metadata size limit
 
 	return &webhook{
 		injectionHandler: injection.New(

--- a/pkg/webhook/mutation/pod/register.go
+++ b/pkg/webhook/mutation/pod/register.go
@@ -77,6 +77,8 @@ func newWebhook( //nolint:revive
 
 	log.Info("got webhook's image from env", "image", webhookImage)
 
+	_ = k8senv.GetMetadaSizeLimit().WithLog(ctx).Resolve()
+
 	return &webhook{
 		injectionHandler: injection.New(
 			kubeClient,

--- a/pkg/webhook/mutation/pod/register.go
+++ b/pkg/webhook/mutation/pod/register.go
@@ -77,7 +77,7 @@ func newWebhook( //nolint:revive
 
 	log.Info("got webhook's image from env", "image", webhookImage)
 
-	_ = k8senv.GetMetadaSizeLimit().WithLog(ctx).Resolve()
+	_ = k8senv.GetMetadaSizeLimit().Resolve(ctx)
 
 	return &webhook{
 		injectionHandler: injection.New(

--- a/pkg/webhook/mutation/pod/webhook.go
+++ b/pkg/webhook/mutation/pod/webhook.go
@@ -94,6 +94,15 @@ func (wh *webhook) Handle(ctx context.Context, request admission.Request) admiss
 	} else if mutationRequest.AnnotationWriter != nil {
 		if err := mutationRequest.AnnotationWriter.ApplyJSONAnnotationToPod(mutationRequest.Pod); err != nil {
 			log.Error(err, "failed to write pod annotations", "podName", podName)
+
+			mutErr := new(dtwebhook.MutatorError)
+			if !errors.As(err, mutErr) {
+				// the only error here is the one returned by json.Marshal
+				return silentErrorResponse(mutationRequest.Pod, err, log)
+			}
+
+			mutationRequest.Pod = originalPod // prevent partial modifications
+			mutErr.SetAnnotations(mutationRequest.Pod)
 		}
 	}
 


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-7924)

## Description

Adds webhook.metadatSizeLimit value.

Pod is not injected if size of combined value of the metadata annotation is greater than the limit. 
Then the Pod is annotated with the reason:
```
     dynakube.dynatrace.com/injected: "false"
     dynakube.dynatrace.com/reason: 'Value of the metadata enrichment annotation exceeds
       the maximum allowed size of 10, actual size: 87'
```

The limit has [no range](https://dt-rnd.atlassian.net/browse/ICP-7924?focusedCommentId=4762692).

## How can this be tested?

unittests

deploy operator with small limit (like < 20) , CNFS, install an app, check if the app is injected