### PR TITLE
Small fixes related to dtpullsecret

### DIFF
--- a/pkg/controllers/dynakube/dtpullsecret/generate.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate.go
@@ -6,7 +6,6 @@ package dtpullsecret
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -61,13 +60,13 @@ func generateData(dk *dynakube.DynaKube, tokens token.Tokens) (map[string][]byte
 	dockerCfg := newDockerConfigWithAuth(tenantUUID,
 		registryToken,
 		registry,
-		buildAuthString(tenantUUID, registryToken))
+		basicAuth(tenantUUID, registryToken))
 
 	return pullSecretDataFromDockerConfig(dockerCfg)
 }
 
-func buildAuthString(tenantUUID string, registryToken string) string {
-	auth := fmt.Sprintf("%s:%s", tenantUUID, registryToken)
+func basicAuth(username string, password string) string {
+	auth := username + ":" + password
 
 	return b64.StdEncoding.EncodeToString([]byte(auth))
 }

--- a/pkg/controllers/dynakube/dtpullsecret/generate.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate.go
@@ -7,7 +7,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/url"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
@@ -40,13 +39,10 @@ func newDockerConfigWithAuth(username string, password string, registry string, 
 	}
 }
 
-func (r *Reconciler) generateData(dk *dynakube.DynaKube, tokens token.Tokens) (map[string][]byte, error) {
+func generateData(dk *dynakube.DynaKube, tokens token.Tokens) (map[string][]byte, error) {
 	var registryToken string
 
-	registry, err := getImageRegistryFromAPIURL(dk.APIURL())
-	if err != nil {
-		return nil, err
-	}
+	registry := dk.APIURLHost()
 
 	switch {
 	case tokens.PaasToken().Value != "":
@@ -65,24 +61,15 @@ func (r *Reconciler) generateData(dk *dynakube.DynaKube, tokens token.Tokens) (m
 	dockerCfg := newDockerConfigWithAuth(tenantUUID,
 		registryToken,
 		registry,
-		r.buildAuthString(tenantUUID, registryToken))
+		buildAuthString(tenantUUID, registryToken))
 
 	return pullSecretDataFromDockerConfig(dockerCfg)
 }
 
-func (r *Reconciler) buildAuthString(tenantUUID string, registryToken string) string {
+func buildAuthString(tenantUUID string, registryToken string) string {
 	auth := fmt.Sprintf("%s:%s", tenantUUID, registryToken)
 
 	return b64.StdEncoding.EncodeToString([]byte(auth))
-}
-
-func getImageRegistryFromAPIURL(apiURL string) (string, error) {
-	u, err := url.Parse(apiURL)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	return u.Host, nil
 }
 
 func pullSecretDataFromDockerConfig(dockerConf *dockerConfig) (map[string][]byte, error) {

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -4,7 +4,7 @@
 package dtpullsecret
 
 import (
-	b64 "encoding/base64"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -23,19 +23,6 @@ const (
 	testAPIURL     = "https://" + testAPIURLHost + "/e/" + testTenant + "/api"
 )
 
-func TestGetImageRegistryFromAPIURL(t *testing.T) {
-	for _, url := range []string{
-		"https://host.com/api",
-		"https://host.com/e/abc1234/api",
-		"http://host.com/api",
-		"http://host.com/e/abc1234/api",
-	} {
-		host, err := getImageRegistryFromAPIURL(url)
-		require.NoError(t, err)
-		assert.Equal(t, "host.com", host)
-	}
-}
-
 func TestReconciler_GenerateData(t *testing.T) {
 	dk := &dynakube.DynaKube{
 		Spec: dynakube.DynaKubeSpec{
@@ -49,7 +36,6 @@ func TestReconciler_GenerateData(t *testing.T) {
 			},
 		},
 	}
-	r := &Reconciler{}
 
 	tests := []struct {
 		name        string
@@ -57,35 +43,35 @@ func TestReconciler_GenerateData(t *testing.T) {
 		expectToken string
 	}{
 		{
-			"use paas token",
-			token.Tokens{
+			name: "use paas token",
+			tokens: token.Tokens{
 				token.PaaSKey: &token.Token{Value: testPaasToken},
 			},
-			testPaasToken,
+			expectToken: testPaasToken,
 		},
 		{
-			"use api token",
-			token.Tokens{
+			name: "use api token",
+			tokens: token.Tokens{
 				token.APIKey: &token.Token{Value: testAPIToken},
 			},
-			testAPIToken,
+			expectToken: testAPIToken,
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			data, err := r.generateData(dk, test.tokens)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := generateData(dk, tt.tokens)
 
 			require.NoError(t, err)
 			assert.NotEmpty(t, data)
 
-			auth := fmt.Sprintf("%s:%s", testTenant, test.expectToken)
+			auth := fmt.Sprintf("%s:%s", testTenant, tt.expectToken)
 			expected := dockerConfig{
 				Auths: map[string]dockerAuthentication{
 					testAPIURLHost: {
 						Username: testTenant,
-						Password: test.expectToken,
-						Auth:     b64.StdEncoding.EncodeToString([]byte(auth)),
+						Password: tt.expectToken,
+						Auth:     base64.StdEncoding.EncodeToString([]byte(auth)),
 					},
 				},
 			}

--- a/pkg/controllers/dynakube/dtpullsecret/generate_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/generate_test.go
@@ -6,7 +6,6 @@ package dtpullsecret
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -23,7 +22,7 @@ const (
 	testAPIURL     = "https://" + testAPIURLHost + "/e/" + testTenant + "/api"
 )
 
-func TestReconciler_GenerateData(t *testing.T) {
+func TestGenerateData(t *testing.T) {
 	dk := &dynakube.DynaKube{
 		Spec: dynakube.DynaKubeSpec{
 			APIURL: testAPIURL,
@@ -42,20 +41,8 @@ func TestReconciler_GenerateData(t *testing.T) {
 		tokens      token.Tokens
 		expectToken string
 	}{
-		{
-			name: "use paas token",
-			tokens: token.Tokens{
-				token.PaaSKey: &token.Token{Value: testPaasToken},
-			},
-			expectToken: testPaasToken,
-		},
-		{
-			name: "use api token",
-			tokens: token.Tokens{
-				token.APIKey: &token.Token{Value: testAPIToken},
-			},
-			expectToken: testAPIToken,
-		},
+		{"use paas token", token.Tokens{token.PaaSKey: &token.Token{Value: testPaasToken}}, testPaasToken},
+		{"use api token", token.Tokens{token.APIKey: &token.Token{Value: testAPIToken}}, testAPIToken},
 	}
 
 	for _, tt := range tests {
@@ -65,7 +52,7 @@ func TestReconciler_GenerateData(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, data)
 
-			auth := fmt.Sprintf("%s:%s", testTenant, tt.expectToken)
+			auth := testTenant + ":" + tt.expectToken
 			expected := dockerConfig{
 				Auths: map[string]dockerAuthentication{
 					testAPIURLHost: {

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -37,9 +37,11 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	ctx, log := logd.NewFromContext(ctx, "pullsecret")
 
-	isKubemonOperandEnabled := k8senv.IsKubemonOperandEnabled() && dk.KubernetesMonitoring().IsEnabled()
+	anyRelevantOprandEnabled := dk.OneAgent().IsDaemonsetRequired() ||
+		dk.ActiveGate().IsEnabled() ||
+		(k8senv.IsKubemonOperandEnabled() && dk.KubernetesMonitoring().IsEnabled())
 
-	if dk.FF().IsPublicRegistry() || (!dk.OneAgent().IsDaemonsetRequired() && !dk.ActiveGate().IsEnabled() && !isKubemonOperandEnabled) {
+	if dk.FF().IsPublicRegistry() || !anyRelevantOprandEnabled {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}
@@ -80,7 +82,7 @@ func (r *Reconciler) deleteSecret(ctx context.Context, dk *dynakube.DynaKube, se
 func (r *Reconciler) reconcilePullSecret(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	log := logd.FromContext(ctx)
 
-	pullSecretData, err := r.generateData(dk, tokens)
+	pullSecretData, err := generateData(dk, tokens)
 	if err != nil {
 		return errors.WithMessage(err, "could not generate pull secret data")
 	}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler.go
@@ -37,11 +37,11 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube, tokens token.Tokens) error {
 	ctx, log := logd.NewFromContext(ctx, "pullsecret")
 
-	anyRelevantOprandEnabled := dk.OneAgent().IsDaemonsetRequired() ||
+	anyRelevantOperandEnabled := dk.OneAgent().IsDaemonsetRequired() ||
 		dk.ActiveGate().IsEnabled() ||
 		(k8senv.IsKubemonOperandEnabled() && dk.KubernetesMonitoring().IsEnabled())
 
-	if dk.FF().IsPublicRegistry() || !anyRelevantOprandEnabled {
+	if dk.FF().IsPublicRegistry() || !anyRelevantOperandEnabled {
 		if meta.FindStatusCondition(*dk.Conditions(), PullSecretConditionType) == nil {
 			return nil // no condition == nothing is there to clean up
 		}

--- a/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
+++ b/pkg/controllers/dynakube/dtpullsecret/reconciler_test.go
@@ -367,7 +367,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 	t.Run("Don't create when operand env is set but kubemon is not configured", func(t *testing.T) {
 		t.Setenv(k8senv.ExperimentalEnableKubemonOperand, "true")
-		dk := addFakeTennantUUID(&dynakube.DynaKube{
+		dk := addFakeTenantUUID(&dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testNamespace,
 				Name:      testName,
@@ -425,7 +425,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 }
 
 func createTestDynakube() *dynakube.DynaKube {
-	return addFakeTennantUUID(&dynakube.DynaKube{
+	return addFakeTenantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,
@@ -437,14 +437,14 @@ func createTestDynakube() *dynakube.DynaKube {
 	})
 }
 
-func addFakeTennantUUID(dk *dynakube.DynaKube) *dynakube.DynaKube {
+func addFakeTenantUUID(dk *dynakube.DynaKube) *dynakube.DynaKube {
 	dk.Status.OneAgent.ConnectionInfo.TenantUUID = testTenant
 
 	return dk
 }
 
 func createTestKubemonDynakube() *dynakube.DynaKube {
-	return addFakeTennantUUID(&dynakube.DynaKube{
+	return addFakeTenantUUID(&dynakube.DynaKube{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testName,

--- a/pkg/controllers/dynakube/kubemon/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/reconciler_test.go
@@ -18,7 +18,6 @@ import (
 	agclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/activegate"
 	imageclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
 	versionclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/version"
-	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -108,7 +107,7 @@ func TestReconcileConditionMapping(t *testing.T) {
 		},
 		{
 			name:           "stack-wrapped error -> error without stack trace in message",
-			statefulSetErr: pkgerrors.WithStack(errors.New("sentinel error")),
+			statefulSetErr: errors.New("sentinel error"),
 			wantStatus:     metav1.ConditionFalse,
 			wantReason:     reasonError,
 			wantMessage:    "sentinel error",

--- a/pkg/controllers/dynakube/kubemon/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/reconciler_test.go
@@ -105,13 +105,6 @@ func TestReconcileConditionMapping(t *testing.T) {
 			wantReason:     reasonError,
 			wantMessage:    "boom",
 		},
-		{
-			name:           "stack-wrapped error -> error without stack trace in message",
-			statefulSetErr: errors.New("sentinel error"),
-			wantStatus:     metav1.ConditionFalse,
-			wantReason:     reasonError,
-			wantMessage:    "sentinel error",
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

tiny follow up of https://github.com/Dynatrace/dynatrace-operator/pull/7074

Mainly non functional changes, fixing typos, converting "methods" into func, naming in tests.

1 functional change (kinda, but not really):
- Removed `getImageRegistryFromAPIURL`, which is basically the same as `dk.APIURLHost()` but can fail. (this fail scenario is not possible in reality as we need a tenantUUID for this whole thing to work, which means we need to be able to use the APIURL to make a call 🤷 )
- Which also caused me to stop using the `dk.APIURL()`, which is correct, because no gen3 tenants will have a tenant-registry to use this pull-secret for, so converting such URLs doesn't really help anyone.

> [!NOTE]
> I went down a rabbit hole of trying to make the tests pretty. Which I mostly discarded, as this logic is hopefully not going to be here for that much longer, so didn't want to change it for the sake of it. 


## How can this be tested?

No change in behavior