### PR TITLE
add rbac and crd for dtprometheus to helm chart

### DIFF
--- a/config/helm/chart/default/templates/Common/prometheus/clusterrole-dtprometheus-operator.yaml
+++ b/config/helm/chart/default/templates/Common/prometheus/clusterrole-dtprometheus-operator.yaml
@@ -1,0 +1,35 @@
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dynatrace-dtprometheus-operator
+  labels:
+    {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+      - customresourcedefinitions/status
+    resourceNames:
+      - dtprometheuses.dynatrace.com
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-dtprometheus-operator
+  labels:
+    {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: dynatrace-dtprometheus-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/config/helm/chart/default/templates/Common/prometheus/role-dtprometheus-operator.yaml
+++ b/config/helm/chart/default/templates/Common/prometheus/role-dtprometheus-operator.yaml
@@ -1,0 +1,42 @@
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dynatrace-dtprometheus-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - dynatrace.com
+    resources:
+      - dtprometheuses
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - dynatrace.com
+    resources:
+      - dtprometheuses/finalizers
+      - dtprometheuses/status
+    verbs:
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dynatrace-dtprometheus-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dynatrace-operator.operatorLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-operator
+roleRef:
+  kind: Role
+  name: dynatrace-dtprometheus-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/config/helm/chart/default/tests/Common/crd/dynatrace-operator-crd_test.yaml
+++ b/config/helm/chart/default/tests/Common/crd/dynatrace-operator-crd_test.yaml
@@ -1,0 +1,33 @@
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test DtPrometheus CRD deployment
+templates:
+  - Common/crd/dynatrace-operator-crd.yaml
+tests:
+  - it: DtPrometheus CRD should render when installCRD is true
+    set:
+      installCRD: true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: CustomResourceDefinition
+      - equal:
+          path: metadata.name
+          value: dtprometheuses.dynatrace.com
+
+  - it: CRDs should be absent when installCRD is false
+    set:
+      installCRD: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: DtPrometheus CRD should render with default values
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: CustomResourceDefinition
+      - equal:
+          path: metadata.name
+          value: dtprometheuses.dynatrace.com

--- a/config/helm/chart/default/tests/Common/prometheus/clusterrole-dtprometheus-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/prometheus/clusterrole-dtprometheus-operator_test.yaml
@@ -1,0 +1,53 @@
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test ClusterRole and ClusterRoleBinding for DtPrometheus operator
+templates:
+  - Common/prometheus/clusterrole-dtprometheus-operator.yaml
+tests:
+  - it: ClusterRole should exist with correct verbs and resourceNames
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: dynatrace-dtprometheus-operator
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+                - customresourcedefinitions/status
+              resourceNames:
+                - dtprometheuses.dynatrace.com
+              verbs:
+                - get
+                - update
+
+  - it: ClusterRoleBinding should exist with correct subjects and roleRef
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-dtprometheus-operator
+      - isNotEmpty:
+          path: metadata.labels
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: dynatrace-operator
+            namespace: NAMESPACE
+      - equal:
+          path: roleRef
+          value:
+            kind: ClusterRole
+            name: dynatrace-dtprometheus-operator
+            apiGroup: rbac.authorization.k8s.io

--- a/config/helm/chart/default/tests/Common/prometheus/role-dtprometheus-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/prometheus/role-dtprometheus-operator_test.yaml
@@ -1,0 +1,64 @@
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test Role and RoleBinding for DtPrometheus operator
+templates:
+  - Common/prometheus/role-dtprometheus-operator.yaml
+tests:
+  - it: Role should exist with correct verbs and resources
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: dynatrace-dtprometheus-operator
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - dynatrace.com
+              resources:
+                - dtprometheuses
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+            - apiGroups:
+                - dynatrace.com
+              resources:
+                - dtprometheuses/finalizers
+                - dtprometheuses/status
+              verbs:
+                - update
+
+  - it: RoleBinding should exist with correct subjects and roleRef
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-dtprometheus-operator
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - isNotEmpty:
+          path: metadata.labels
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: dynatrace-operator
+      - equal:
+          path: roleRef
+          value:
+            kind: Role
+            name: dynatrace-dtprometheus-operator
+            apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

▎ Note: Reviewable but may be subject to change while https://github.com/Dynatrace/dynatrace-operator/pull/7107 is still open.

https://dt-rnd.atlassian.net/browse/ICP-7434

- Updates helm chart for DtPrometheus with RBAC templates and unit tests for CRD deployment gate and RBAC objects.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

`make test/helm/unit`

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->