### PR TITLE
Fix: Helm unit tests silently pass on null paths for conditional initcontainer blocks

### DIFF
--- a/config/helm/chart/default/tests/Common/crd/job-crd-storage-migration_test.yaml
+++ b/config/helm/chart/default/tests/Common/crd/job-crd-storage-migration_test.yaml
@@ -63,6 +63,8 @@ tests:
       platform: kubernetes
       crdStorageMigrationJob: true
     asserts:
+      - isNotNull:
+          path: spec.template.spec.initContainers[0]
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: webhook-cert-generator
@@ -82,7 +84,7 @@ tests:
       - isNotEmpty:
           path: spec.template.spec.initContainers[0].resources.limits
       - isNotEmpty:
-          path: spec.template.spec.initContainers[0].securityContex
+          path: spec.template.spec.initContainers[0].securityContext
 
   - it: should have apparmor annotation when enabled on Kubernetes < 1.31.0
     set:

--- a/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
+++ b/config/helm/chart/default/tests/Common/operator/deployment-operator_test.yaml
@@ -1155,6 +1155,8 @@ tests:
 
   - it: should not have cert env vars in init container when certs values are empty
     asserts:
+      - isNotNull:
+          path: spec.template.spec.initContainers[0]
       - notContains:
           path: spec.template.spec.initContainers[0].env
           content:
@@ -1183,6 +1185,8 @@ tests:
       webhook.certs.renewalThreshold: "12h"
       webhook.certs.requeueAfter: "3h"
     asserts:
+      - isNotNull:
+          path: spec.template.spec.initContainers[0]
       - contains:
           path: spec.template.spec.initContainers[0].env
           content:


### PR DESCRIPTION


<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

[ICP-8316](https://dt-rnd.atlassian.net/browse/ICP-8316)

Helm unit tests asserting on children of conditionally rendered blocks (e.g.
`initContainers`) can silently pass when the parent block is not rendered at
all. `notContains` and `isNotEmpty` evaluate to true against a null path,
meaning a broken template condition that accidentally removes the block would
go undetected.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Run the Helm unit tests

[ICP-8316]: https://dt-rnd.atlassian.net/browse/ICP-8316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ