### PR TITLE
Remove olm manifests make target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -269,9 +269,7 @@ jobs:
         run: |
           make manifests/crd/release CHART_VERSION="${VERSION_WITHOUT_PREFIX}"
 
-          make manifests/kubernetes/olm IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
           make manifests/kubernetes IMAGE="public.ecr.aws/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
-          make manifests/openshift/olm IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
           make manifests/openshift IMAGE="registry.connect.redhat.com/dynatrace/dynatrace-operator" TAG="${VERSION}" DIGEST="${DIGEST}"
       - name: Build helm packages
         uses: ./.github/actions/build-helm

--- a/hack/make/manifests/config.mk
+++ b/hack/make/manifests/config.mk
@@ -11,11 +11,9 @@ RELEASE_CRD_YAML=config/deploy/dynatrace-operator-crd.yaml
 
 KUBERNETES_CORE_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes.yaml
 KUBERNETES_CSIDRIVER_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-csi.yaml
-KUBERNETES_OLM_YAML=$(MANIFESTS_DIR)kubernetes/kubernetes-olm.yaml
 
 OPENSHIFT_CORE_YAML=$(MANIFESTS_DIR)openshift/openshift.yaml
 OPENSHIFT_CSIDRIVER_YAML=$(MANIFESTS_DIR)openshift/openshift-csi.yaml
-OPENSHIFT_OLM_YAML=$(MANIFESTS_DIR)openshift/openshift-olm.yaml
 
 ifeq ($(shell echo $CHART_VERSION),)
 	ifneq ($(shell git branch --show-current | grep "^release-"),)

--- a/hack/make/manifests/kubernetes.mk
+++ b/hack/make/manifests/kubernetes.mk
@@ -21,9 +21,5 @@ manifests/kubernetes/csi: manifests/crd/helm
 manifests/kubernetes/core: manifests/crd/helm
 	$(call generate_k8s_manifest,false,$(KUBERNETES_CORE_YAML))
 
-## Generates a Kubernetes manifest including CRD and CSI driver with OLM set to true
-manifests/kubernetes/olm: manifests/crd/helm
-	OLM=true $(call generate_k8s_manifest,true,$(KUBERNETES_OLM_YAML))
-
 ## Generates a manifest for Kubernetes including a CRD, a CSI driver deployment
 manifests/kubernetes: manifests/kubernetes/core manifests/kubernetes/csi

--- a/hack/make/manifests/openshift.mk
+++ b/hack/make/manifests/openshift.mk
@@ -21,9 +21,5 @@ manifests/openshift/csi: manifests/crd/helm
 manifests/openshift/core: manifests/crd/helm
 	$(call generate_openshift_manifest,false,$(OPENSHIFT_CORE_YAML))
 
-## Generates an Openshift manifest including CRD and CSI driver with OLM set to true
-manifests/openshift/olm: manifests/crd/helm
-	OLM=true $(call generate_openshift_manifest,true,$(OPENSHIFT_OLM_YAML))
-
 ## Generates a manifest for OpenShift including a CRD and a CSI driver deployment
 manifests/openshift: manifests/openshift/core manifests/openshift/csi


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-8326](https://dt-rnd.atlassian.net/browse/ICP-8326)

These make targets for the olm manifests for both k8s and ocp were never used in the first place. 

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

n/a

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-8326]: https://dt-rnd.atlassian.net/browse/ICP-8326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ