### PR TITLE
Use `corev1.PullPolicy` + marker instead of custom type in kubemon

### DIFF
--- a/pkg/api/latest/dynakube/kubemon/props.go
+++ b/pkg/api/latest/dynakube/kubemon/props.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -61,14 +60,6 @@ func (km *KubeMon) GetTenantSecretName() string {
 
 func (km *KubeMon) GetAuthTokenSecretName() string {
 	return km.name + NameSuffix + "-authtoken-secret"
-}
-
-func (km *Spec) GetPullPolicy() corev1.PullPolicy {
-	if km == nil {
-		return ""
-	}
-
-	return corev1.PullPolicy(km.ImagePullPolicy)
 }
 
 // GetCustomImage returns the user-provided image override, or "" if unset.

--- a/pkg/api/latest/dynakube/kubemon/spec.go
+++ b/pkg/api/latest/dynakube/kubemon/spec.go
@@ -4,7 +4,6 @@
 package kubemon
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +24,8 @@ type StatefulSetProperties struct {
 
 	// The KubernetesMonitoring container image pull policy.
 	// +kubebuilder:validation:Optional
-	ImagePullPolicy image.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Node selector to control the selection of nodes.
 	// +kubebuilder:validation:Optional

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -275,7 +275,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 	container := corev1.Container{
 		Name:            ContainerName,
 		Image:           imageURI,
-		ImagePullPolicy: dk.KubernetesMonitoring().GetPullPolicy(),
+		ImagePullPolicy: dk.KubernetesMonitoring().ImagePullPolicy,
 		Resources:       dk.KubernetesMonitoring().Resources,
 		Env:             buildEnvs(dk),
 		VolumeMounts:    buildVolumeMounts(dk),


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

I don't want to have
```go
func (km *Spec) GetPullPolicy() corev1.PullPolicy {
	if km == nil {
		return ""
	}

	return corev1.PullPolicy(km.ImagePullPolicy)
}
```

to save on `// +kubebuilder:validation:Enum=IfNotPresent;Always;Never`

Extended version that does this everywhere is https://github.com/Dynatrace/dynatrace-operator/pull/7205

## How can this be tested?

No change in behavior.

`imagePullPolicy: bloop` -> validation should catch it.
```
The DynaKube "marcell-dev" is invalid: spec.kubernetesMonitoring.imagePullPolicy: Unsupported value: "bloop": supported values: "IfNotPresent", "Always", "Never"
```