### PR TITLE
Remove the `image.PullPolicy` type

### DIFF
--- a/pkg/api/latest/dynakube/activegate/props.go
+++ b/pkg/api/latest/dynakube/activegate/props.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -157,11 +156,6 @@ func (ag *Spec) GetDefaultImage(version string) string {
 // GetCustomImage provides the image reference for the ActiveGate provided in the Spec.
 func (ag *Spec) GetCustomImage() string {
 	return ag.Image
-}
-
-// GetPullPolicy provides the image pull policy.
-func (ag *Spec) GetPullPolicy() corev1.PullPolicy {
-	return corev1.PullPolicy(ag.ImagePullPolicy)
 }
 
 // GetTerminationGracePeriodSeconds provides the configured value for the terminatGracePeriodSeconds parameter of the pod.

--- a/pkg/api/latest/dynakube/activegate/spec.go
+++ b/pkg/api/latest/dynakube/activegate/spec.go
@@ -4,7 +4,6 @@
 package activegate
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -154,7 +153,8 @@ type CapabilityProperties struct {
 	Image string `json:"image,omitempty"`
 
 	// The ActiveGate container image pull policy.
-	ImagePullPolicy image.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Set activation group for ActiveGate
 	// +kubebuilder:validation:Optional

--- a/pkg/api/latest/dynakube/kubemon/props.go
+++ b/pkg/api/latest/dynakube/kubemon/props.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -61,14 +60,6 @@ func (km *KubeMon) GetTenantSecretName() string {
 
 func (km *KubeMon) GetAuthTokenSecretName() string {
 	return km.name + NameSuffix + "-authtoken-secret"
-}
-
-func (km *Spec) GetPullPolicy() corev1.PullPolicy {
-	if km == nil {
-		return ""
-	}
-
-	return corev1.PullPolicy(km.ImagePullPolicy)
 }
 
 // GetCustomImage returns the user-provided image override, or "" if unset.

--- a/pkg/api/latest/dynakube/kubemon/spec.go
+++ b/pkg/api/latest/dynakube/kubemon/spec.go
@@ -4,7 +4,6 @@
 package kubemon
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +24,8 @@ type StatefulSetProperties struct {
 
 	// The KubernetesMonitoring container image pull policy.
 	// +kubebuilder:validation:Optional
-	ImagePullPolicy image.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Node selector to control the selection of nodes.
 	// +kubebuilder:validation:Optional

--- a/pkg/api/latest/dynakube/oneagent/props.go
+++ b/pkg/api/latest/dynakube/oneagent/props.go
@@ -210,11 +210,11 @@ func (oa *OneAgent) GetCustomImage() string {
 func (oa *OneAgent) GetImagePullPolicy() corev1.PullPolicy {
 	switch {
 	case oa.IsClassicFullStackMode():
-		return corev1.PullPolicy(oa.ClassicFullStack.ImagePullPolicy)
+		return oa.ClassicFullStack.ImagePullPolicy
 	case oa.IsHostMonitoringMode():
-		return corev1.PullPolicy(oa.HostMonitoring.ImagePullPolicy)
+		return oa.HostMonitoring.ImagePullPolicy
 	case oa.IsCloudNativeFullstackMode():
-		return corev1.PullPolicy(oa.CloudNativeFullStack.ImagePullPolicy)
+		return oa.CloudNativeFullStack.ImagePullPolicy
 	default:
 		return ""
 	}
@@ -314,9 +314,9 @@ func (oa *OneAgent) GetCustomCodeModulesImage() string {
 // GetCodeModulesImagePullPolicy provides the image pull policy for the CodeModules provided in the Spec.
 func (oa *OneAgent) GetCodeModulesImagePullPolicy() corev1.PullPolicy {
 	if oa.IsCloudNativeFullstackMode() {
-		return corev1.PullPolicy(oa.CloudNativeFullStack.CodeModulesImagePullPolicy)
+		return oa.CloudNativeFullStack.CodeModulesImagePullPolicy
 	} else if oa.IsApplicationMonitoringMode() {
-		return corev1.PullPolicy(oa.ApplicationMonitoring.CodeModulesImagePullPolicy)
+		return oa.ApplicationMonitoring.CodeModulesImagePullPolicy
 	}
 
 	return ""

--- a/pkg/api/latest/dynakube/oneagent/props_test.go
+++ b/pkg/api/latest/dynakube/oneagent/props_test.go
@@ -89,18 +89,18 @@ func TestCustomOneAgentImage(t *testing.T) {
 
 func TestGetOneAgentImagePullPolicy(t *testing.T) {
 	t.Run("hostmonitoring", func(t *testing.T) {
-		oneAgent := OneAgent{Spec: &Spec{ClassicFullStack: &HostInjectSpec{ImagePullPolicy: "foo"}}}
-		assert.EqualValues(t, "foo", oneAgent.GetImagePullPolicy())
+		oneAgent := OneAgent{Spec: &Spec{ClassicFullStack: &HostInjectSpec{ImagePullPolicy: corev1.PullAlways}}}
+		assert.Equal(t, corev1.PullAlways, oneAgent.GetImagePullPolicy())
 	})
 
 	t.Run("CFS", func(t *testing.T) {
-		oneAgent := OneAgent{Spec: &Spec{HostMonitoring: &HostInjectSpec{ImagePullPolicy: "foo"}}}
-		assert.EqualValues(t, "foo", oneAgent.GetImagePullPolicy())
+		oneAgent := OneAgent{Spec: &Spec{HostMonitoring: &HostInjectSpec{ImagePullPolicy: corev1.PullAlways}}}
+		assert.Equal(t, corev1.PullAlways, oneAgent.GetImagePullPolicy())
 	})
 
 	t.Run("CNFS", func(t *testing.T) {
-		oneAgent := OneAgent{Spec: &Spec{CloudNativeFullStack: &CloudNativeFullStackSpec{HostInjectSpec: HostInjectSpec{ImagePullPolicy: "foo"}}}}
-		assert.EqualValues(t, "foo", oneAgent.GetImagePullPolicy())
+		oneAgent := OneAgent{Spec: &Spec{CloudNativeFullStack: &CloudNativeFullStackSpec{HostInjectSpec: HostInjectSpec{ImagePullPolicy: corev1.PullAlways}}}}
+		assert.Equal(t, corev1.PullAlways, oneAgent.GetImagePullPolicy())
 	})
 }
 

--- a/pkg/api/latest/dynakube/oneagent/spec.go
+++ b/pkg/api/latest/dynakube/oneagent/spec.go
@@ -4,7 +4,6 @@
 package oneagent
 
 import (
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,7 +94,8 @@ type HostInjectSpec struct {
 	Image string `json:"image,omitempty"`
 
 	// Define an image pull policy for the OneAgent image.
-	ImagePullPolicy image.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Set the DNS Policy for OneAgent pods. For details, see Pods DNS Policy (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
 	// +kubebuilder:validation:Optional
@@ -183,7 +183,8 @@ type AppInjectionSpec struct {
 	CodeModulesImage string `json:"codeModulesImage,omitempty"`
 
 	// Define an image pull policy for the CodeModule image.
-	CodeModulesImagePullPolicy image.PullPolicy `json:"codeModulesImagePullPolicy,omitempty"`
+	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
+	CodeModulesImagePullPolicy corev1.PullPolicy `json:"codeModulesImagePullPolicy,omitempty"`
 
 	// Applicable only for applicationMonitoring or cloudNativeFullStack configuration types. The namespaces where you want Dynatrace Operator to inject.
 	// For more information, see Configure monitoring for namespaces and pods (https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/get-started-with-kubernetes-monitoring/dto-config-options-k8s#annotate).

--- a/pkg/api/shared/image/types.go
+++ b/pkg/api/shared/image/types.go
@@ -22,7 +22,8 @@ type Ref struct {
 	Digest string `json:"digest,omitempty"`
 
 	// Image pull policy to use
-	PullPolicy PullPolicy `json:"pullPolicy,omitempty"`
+	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
+	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
 }
 
 // StringWithDefaults will use the provided default values for fields that were not already set.
@@ -59,13 +60,3 @@ func (ref *Ref) HasImage() bool {
 
 	return ref.Repository != "" && (ref.Tag != "" || ref.Digest != "")
 }
-
-// GetPolicy returns the image pull policy.
-func (ref Ref) GetPullPolicy() corev1.PullPolicy {
-	return corev1.PullPolicy(ref.PullPolicy)
-}
-
-// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
-
-// PullPolicy is the image pull policy. Use a custom type to share the validation marker.
-type PullPolicy string

--- a/pkg/api/v1beta5/dynakube/convert_to_test.go
+++ b/pkg/api/v1beta5/dynakube/convert_to_test.go
@@ -221,7 +221,7 @@ func TestConvertTo(t *testing.T) {
 
 		assert.NotEmpty(t, to.Spec.Templates.OpenTelemetryCollector.ImageRef.Repository)
 		assert.NotEmpty(t, to.Spec.Templates.OpenTelemetryCollector.ImageRef.Tag)
-		assert.Equal(t, image.PullPolicy("Always"), to.Spec.Templates.OpenTelemetryCollector.ImageRef.PullPolicy)
+		assert.Equal(t, corev1.PullPolicy("Always"), to.Spec.Templates.OpenTelemetryCollector.ImageRef.PullPolicy)
 		assert.Contains(t, to.Annotations, conversion.DefaultOTelColImageKey)
 
 		compareBase(t, from, to)

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -75,7 +75,7 @@ func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
 		{
 			Name:            initContainerTemplateName,
 			Image:           mod.dk.ActiveGate().GetImage(),
-			ImagePullPolicy: mod.dk.ActiveGate().GetPullPolicy(),
+			ImagePullPolicy: mod.dk.ActiveGate().ImagePullPolicy,
 			WorkingDir:      k8scrt2jksWorkingDir,
 			Command:         []string{"/bin/bash"},
 			Args:            []string{"-c", k8scrt2jksPath},

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/statefulset.go
@@ -219,7 +219,7 @@ func (statefulSetBuilder Builder) buildBaseContainer(sts *appsv1.StatefulSet) []
 	container := corev1.Container{
 		Name:            consts.ActiveGateContainerName,
 		Image:           statefulSetBuilder.dynakube.ActiveGate().GetImage(),
-		ImagePullPolicy: statefulSetBuilder.dynakube.ActiveGate().GetPullPolicy(),
+		ImagePullPolicy: statefulSetBuilder.dynakube.ActiveGate().ImagePullPolicy,
 		Resources:       statefulSetBuilder.buildResources(),
 		Env:             statefulSetBuilder.buildCommonEnvs(),
 		ReadinessProbe:  probe.Readiness(),

--- a/pkg/controllers/dynakube/extension/databases/deployment.go
+++ b/pkg/controllers/dynakube/extension/databases/deployment.go
@@ -94,7 +94,7 @@ func buildContainer(dk *dynakube.DynaKube, dbSpec extensions.DatabaseSpec, image
 	container := corev1.Container{
 		Name:            containerName,
 		Image:           imageURI,
-		ImagePullPolicy: dk.Spec.Templates.SQLExtensionExecutor.ImageRef.GetPullPolicy(),
+		ImagePullPolicy: dk.Spec.Templates.SQLExtensionExecutor.ImageRef.PullPolicy,
 		Args:            buildContainerArgs(dk),
 		Env:             buildContainerEnvs(),
 		LivenessProbe: &corev1.Probe{

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -172,7 +172,7 @@ func buildContainer(dk *dynakube.DynaKube, imageURI string) corev1.Container {
 	return corev1.Container{
 		Name:            containerName,
 		Image:           imageURI,
-		ImagePullPolicy: dk.Spec.Templates.ExtensionExecutionController.ImageRef.GetPullPolicy(),
+		ImagePullPolicy: dk.Spec.Templates.ExtensionExecutionController.ImageRef.PullPolicy,
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/controllers/dynakube/kspm/daemonset/container.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/container.go
@@ -25,7 +25,7 @@ func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 	container := corev1.Container{
 		Name:            containerName,
 		Image:           dk.KSPM().ImageRef.StringWithDefaults(defaultImageRepo, defaultImageTag),
-		ImagePullPolicy: dk.KSPM().ImageRef.GetPullPolicy(),
+		ImagePullPolicy: dk.KSPM().ImageRef.PullPolicy,
 		VolumeMounts:    getMounts(dk),
 		Env:             getEnvs(dk, tenantUUID),
 		SecurityContext: &securityContext,

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -275,7 +275,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 	container := corev1.Container{
 		Name:            ContainerName,
 		Image:           imageURI,
-		ImagePullPolicy: dk.KubernetesMonitoring().GetPullPolicy(),
+		ImagePullPolicy: dk.KubernetesMonitoring().ImagePullPolicy,
 		Resources:       dk.KubernetesMonitoring().Resources,
 		Env:             buildEnvs(dk),
 		VolumeMounts:    buildVolumeMounts(dk),

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/container.go
@@ -42,7 +42,7 @@ func getContainer(dk dynakube.DynaKube, tenantUUID, imageURI string) corev1.Cont
 	container := corev1.Container{
 		Name:            containerName,
 		Image:           imageURI,
-		ImagePullPolicy: dk.LogMonitoring().Template().ImageRef.GetPullPolicy(),
+		ImagePullPolicy: dk.LogMonitoring().Template().ImageRef.PullPolicy,
 		VolumeMounts:    getVolumeMounts(tenantUUID),
 		Env:             getEnvs(),
 		Resources:       dk.LogMonitoring().Template().Resources,
@@ -68,7 +68,7 @@ func getInitContainer(dk dynakube.DynaKube, tenantUUID, imageURI string) corev1.
 	container := corev1.Container{
 		Name:            initContainerName,
 		Image:           image,
-		ImagePullPolicy: dk.LogMonitoring().Template().ImageRef.GetPullPolicy(),
+		ImagePullPolicy: dk.LogMonitoring().Template().ImageRef.PullPolicy,
 		VolumeMounts:    []corev1.VolumeMount{getDTVolumeMounts(tenantUUID)},
 		Command:         []string{bootstrapCommand},
 		Env:             getInitEnvs(dk),

--- a/pkg/controllers/dynakube/otelc/statefulset/container.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/container.go
@@ -23,7 +23,7 @@ func getContainer(dk *dynakube.DynaKube, replicas int32) corev1.Container {
 	container := corev1.Container{
 		Name:            containerName,
 		Image:           dk.Spec.Templates.OpenTelemetryCollector.ImageRef.String(),
-		ImagePullPolicy: dk.Spec.Templates.OpenTelemetryCollector.ImageRef.GetPullPolicy(),
+		ImagePullPolicy: dk.Spec.Templates.OpenTelemetryCollector.ImageRef.PullPolicy,
 		SecurityContext: buildSecurityContext(dk),
 		Env:             getEnvs(dk, replicas),
 		Resources:       dk.Spec.Templates.OpenTelemetryCollector.Resources,

--- a/pkg/controllers/edgeconnect/deployment/deployment.go
+++ b/pkg/controllers/edgeconnect/deployment/deployment.go
@@ -115,7 +115,7 @@ func edgeConnectContainer(ec *edgeconnect.EdgeConnect) corev1.Container {
 	return corev1.Container{
 		Name:            consts.EdgeConnectContainerName,
 		Image:           ec.Status.Version.ImageID,
-		ImagePullPolicy: ec.Spec.ImageRef.GetPullPolicy(),
+		ImagePullPolicy: ec.Spec.ImageRef.PullPolicy,
 		Env:             ec.Spec.Env,
 		Resources:       prepareResourceRequirements(ec),
 		SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Extended version of https://github.com/Dynatrace/dynatrace-operator/pull/7204

In order to save on a few `// +kubebuilder:validation:Enum=IfNotPresent;Always;Never` we introduced a bunch of getters and conversion. (and IMO confusion)

## How can this be tested?

No change in CRD ✅  so all enum validation are still present
`imagePullPolicy: bloop` -> validation should catch it. (any image pull policy in our CRs)