### PR TITLE
fix: cleanupOrphanedDownloads in installAgent

### DIFF
--- a/pkg/injection/codemodule/installer/binary/installer.go
+++ b/pkg/injection/codemodule/installer/binary/installer.go
@@ -102,6 +102,8 @@ func (installer Installer) installAgent(ctx context.Context, targetDir string) e
 		path = filepath.Dir(targetDir)
 	}
 
+	cleanupOrphanedDownloads(ctx, path)
+
 	tmpFile, err := os.CreateTemp(path, "download")
 	if err != nil {
 		log.Info("failed to create temp file download", "err", err)
@@ -196,4 +198,19 @@ func (installer Installer) downloadOneAgent(ctx context.Context, tmpFile *os.Fil
 
 func isStandaloneInstall(targetDir string) bool {
 	return consts.AgentInitBinDirMount == targetDir
+}
+
+func cleanupOrphanedDownloads(ctx context.Context, path string) {
+	log := logd.FromContext(ctx)
+
+	// Glob only errors on malformed patterns; "download*" is always valid.
+	matches, _ := filepath.Glob(filepath.Join(path, "download*"))
+
+	for _, match := range matches {
+		if removeErr := os.Remove(match); removeErr != nil {
+			log.Error(removeErr, "failed to remove orphaned download file", "path", match)
+		} else {
+			log.Info("removed orphaned download file", "path", match)
+		}
+	}
 }

--- a/pkg/injection/codemodule/installer/binary/installer_test.go
+++ b/pkg/injection/codemodule/installer/binary/installer_test.go
@@ -164,6 +164,48 @@ func TestInstallAgentFromUrl(t *testing.T) {
 		err := installer.installAgent(t.Context(), target)
 		require.NoError(t, err)
 	})
+	t.Run("cleans orphaned download files", func(t *testing.T) {
+		getParams.Version = testVersion
+		t.Cleanup(func() { getParams.Version = "" })
+
+		tmpDir := t.TempDir()
+		target := filepath.Join(tmpDir, testVersion)
+
+		orphan, err := os.CreateTemp(tmpDir, "download")
+		require.NoError(t, err)
+		orphan.Close()
+
+		otherFile, err := os.CreateTemp(tmpDir, "other")
+		require.NoError(t, err)
+		otherFile.Close()
+
+		dtClient := oneagentclientmock.NewClient(t)
+		dtClient.EXPECT().Get(t.Context(), getParams, mock.AnythingOfType("*os.File")).
+			Run(func(ctx context.Context, args oneagentclient.GetParams, writer io.Writer) {
+				zipFile := zip.SetupTestArchive(t, zip.TestRawZip)
+				defer func() { _ = zipFile.Close() }()
+
+				_, err := io.Copy(writer, zipFile)
+				require.NoError(t, err)
+			}).
+			Return(nil)
+
+		inst := &Installer{
+			dtClient:  dtClient,
+			extractor: zip.NewOneAgentExtractor(metadata.PathResolver{RootDir: tmpDir}),
+			props: &Properties{
+				OS:            installer.OSUnix,
+				Type:          installer.TypePaaS,
+				Flavor:        arch.FlavorMultidistro,
+				TargetVersion: testVersion,
+			},
+		}
+
+		err = inst.installAgent(t.Context(), target)
+		require.NoError(t, err)
+		assert.NoFileExists(t, orphan.Name())
+		assert.FileExists(t, otherFile.Name())
+	})
 }
 
 func TestIsAlreadyDownloaded(t *testing.T) {


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/ICP-8361


## How can this be tested?
To crash init container I've deployed appMonitoring with limited resources
```
  oneAgent:
    applicationMonitoring:
      initResources:
        limits:
          memory: "15Mi"
```

## Fail path
and observe log with removal of orphaned files
<img width="1094" height="80" alt="image" src="https://github.com/user-attachments/assets/ddf7c999-ec4e-4f36-9658-7fe12ae73d64" />

Next to initContainer and customer's container I've deployed `kubectl debug` container with ephemeral volume mounted
`kubectl debug nginx -n sample-app -it --image=busybox --custom=<(printf '{"volumeMounts":[{"name":"oneagent-bin","mountPath":"/mnt/bin"}]}') -- sh`

and listed the content of `/mnt/bin`
<img width="263" height="76" alt="image" src="https://github.com/user-attachments/assets/8f0bd308-6eda-48ee-9149-16f34018307e" />

And it's getting cleaned up on every attempt from old `download*` files.

## Happy path
Deployed appMon without limitations. It does not face problems due to new step with deleting orphans

> [!WARNING]
> There is no scenario without codechange to force initcontainer to crashloopbackoff and recover from it, so fail path -> happy path was not tested directly. 