### PR TITLE
Add node taint analysis collector to support archive

### DIFF
--- a/cmd/supportarchive/cmd.go
+++ b/cmd/supportarchive/cmd.go
@@ -149,6 +149,7 @@ func runCollectors(log logd.Logger, supportArchive archiver) error {
 		newFsLogCollector(ctx, kubeConfig, &DefaultExecutor{}, log, supportArchive, pods, appName, collectManagedLogsFlagValue),
 		newK8sObjectCollector(ctx, log, supportArchive, namespaceFlagValue, appName, apiReader),
 		newTroubleshootCollector(ctx, log, supportArchive, namespaceFlagValue, apiReader, *kubeConfig),
+		newNodeTaintAnalysisCollector(ctx, log, supportArchive, namespaceFlagValue, apiReader),
 	}
 
 	for _, c := range collectors {

--- a/cmd/supportarchive/config.go
+++ b/cmd/supportarchive/config.go
@@ -14,6 +14,8 @@ const CRDDirectoryName = "crds"
 const WebhookConfigurationsDirectoryName = "webhook_configurations"
 const ManifestsFileExtension = ".yaml"
 
+const NodeTaintAnalysisFileName = "node-taint-analysis.txt"
+
 const CRDKindName = "CustomResourceDefinition"
 const ValidatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
 const MutatingWebhookConfigurationKind = "MutatingWebhookConfiguration"

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -1,0 +1,273 @@
+package supportarchive
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const nodeTaintAnalysisCollectorName = "nodeTaintAnalysisCollector"
+
+type nodeTaintAnalysisCollector struct {
+	collectorCommon
+	ctx       context.Context
+	apiReader client.Reader
+	namespace string
+}
+
+func newNodeTaintAnalysisCollector(ctx context.Context, log logd.Logger, supportArchive archiver, namespace string, apiReader client.Reader) collector {
+	return nodeTaintAnalysisCollector{
+		collectorCommon: collectorCommon{
+			log:            log,
+			supportArchive: supportArchive,
+		},
+		ctx:       ctx,
+		apiReader: apiReader,
+		namespace: namespace,
+	}
+}
+
+func (c nodeTaintAnalysisCollector) Name() string {
+	return nodeTaintAnalysisCollectorName
+}
+
+func (c nodeTaintAnalysisCollector) Do() error {
+	logInfof(c.log, "Starting node taint analysis")
+
+	report, err := c.buildReport()
+	if err != nil {
+		logErrorf(c.log, err, "Failed to complete node taint analysis")
+
+		return err
+	}
+
+	if err := c.supportArchive.addFile(NodeTaintAnalysisFileName, strings.NewReader(report)); err != nil {
+		return err
+	}
+
+	logInfof(c.log, "Stored node taint analysis into %s", NodeTaintAnalysisFileName)
+
+	return nil
+}
+
+func (c nodeTaintAnalysisCollector) buildReport() (string, error) {
+	nodes, err := c.getNodes()
+	if err != nil {
+		return "", err
+	}
+
+	dynakubes, err := c.getDynaKubes()
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("Node count: %d\n\n", len(nodes.Items)))
+
+	c.analyzeOneAgentDaemonSets(&sb, nodes, dynakubes)
+	c.analyzeCSIDaemonSet(&sb, nodes)
+
+	return sb.String(), nil
+}
+
+func (c nodeTaintAnalysisCollector) analyzeOneAgentDaemonSets(sb *strings.Builder, nodes *corev1.NodeList, dynakubes *dynakube.DynaKubeList) {
+	if len(dynakubes.Items) == 0 {
+		sb.WriteString("No DynaKube resources found, skipping OneAgent DaemonSet analysis\n")
+
+		return
+	}
+
+	for i := range dynakubes.Items {
+		dk := &dynakubes.Items[i]
+		dsName := dk.OneAgent().GetDaemonsetName()
+
+		sb.WriteString(fmt.Sprintf("--- OneAgent DaemonSet: %s (DynaKube: %s) ---\n", dsName, dk.Name))
+
+		var ds appsv1.DaemonSet
+
+		err := c.apiReader.Get(c.ctx, client.ObjectKey{Name: dsName, Namespace: c.namespace}, &ds)
+		if err != nil {
+			sb.WriteString(fmt.Sprintf("  DaemonSet not found: %s\n\n", err.Error()))
+
+			continue
+		}
+
+		c.analyzeDaemonSet(sb, &ds, nodes)
+		sb.WriteString("\n")
+	}
+}
+
+func (c nodeTaintAnalysisCollector) analyzeCSIDaemonSet(sb *strings.Builder, nodes *corev1.NodeList) {
+	sb.WriteString(fmt.Sprintf("--- CSI Driver DaemonSet: %s ---\n", dtcsi.DaemonSetName))
+
+	var ds appsv1.DaemonSet
+
+	err := c.apiReader.Get(c.ctx, client.ObjectKey{Name: dtcsi.DaemonSetName, Namespace: c.namespace}, &ds)
+	if err != nil {
+		sb.WriteString(fmt.Sprintf("  DaemonSet not found: %s\n\n", err.Error()))
+
+		return
+	}
+
+	c.analyzeDaemonSet(sb, &ds, nodes)
+	sb.WriteString("\n")
+}
+
+func (c nodeTaintAnalysisCollector) analyzeDaemonSet(sb *strings.Builder, ds *appsv1.DaemonSet, nodes *corev1.NodeList) {
+	desired := ds.Status.DesiredNumberScheduled
+	ready := ds.Status.NumberReady
+
+	sb.WriteString(fmt.Sprintf("  Desired: %d | Ready: %d | Nodes: %d\n", desired, ready, len(nodes.Items)))
+
+	tolerations := ds.Spec.Template.Spec.Tolerations
+	sb.WriteString("  Configured tolerations:\n")
+
+	if len(tolerations) == 0 {
+		sb.WriteString("    (none)\n")
+	}
+
+	for _, t := range tolerations {
+		sb.WriteString(fmt.Sprintf("    %s\n", formatToleration(t)))
+	}
+
+	untoleratedNodes := findNodesWithUntoleratedTaints(nodes, tolerations)
+	if len(untoleratedNodes) == 0 {
+		sb.WriteString("  All node taints are tolerated\n")
+
+		return
+	}
+
+	sb.WriteString(fmt.Sprintf("  WARNING: %d node(s) have untolerated taints:\n", len(untoleratedNodes)))
+
+	for _, entry := range untoleratedNodes {
+		sb.WriteString(fmt.Sprintf("    Node: %s\n", entry.nodeName))
+
+		for _, taint := range entry.untoleratedTaints {
+			sb.WriteString(fmt.Sprintf("      - %s\n", formatTaint(taint)))
+		}
+	}
+}
+
+type nodeWithUntoleratedTaints struct {
+	nodeName         string
+	untoleratedTaints []corev1.Taint
+}
+
+func findNodesWithUntoleratedTaints(nodes *corev1.NodeList, tolerations []corev1.Toleration) []nodeWithUntoleratedTaints {
+	var result []nodeWithUntoleratedTaints
+
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if len(node.Spec.Taints) == 0 {
+			continue
+		}
+
+		var untolerated []corev1.Taint
+
+		for _, taint := range node.Spec.Taints {
+			if !isTaintTolerated(taint, tolerations) {
+				untolerated = append(untolerated, taint)
+			}
+		}
+
+		if len(untolerated) > 0 {
+			result = append(result, nodeWithUntoleratedTaints{
+				nodeName:         node.Name,
+				untoleratedTaints: untolerated,
+			})
+		}
+	}
+
+	return result
+}
+
+func isTaintTolerated(taint corev1.Taint, tolerations []corev1.Toleration) bool {
+	for _, toleration := range tolerations {
+		if tolerationMatchesTaint(toleration, taint) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func tolerationMatchesTaint(toleration corev1.Toleration, taint corev1.Taint) bool {
+	// Empty key with Exists operator matches all taints
+	if toleration.Key == "" && toleration.Operator == corev1.TolerationOpExists {
+		if toleration.Effect == "" || toleration.Effect == taint.Effect {
+			return true
+		}
+
+		return false
+	}
+
+	if toleration.Key != taint.Key {
+		return false
+	}
+
+	if toleration.Effect != "" && toleration.Effect != taint.Effect {
+		return false
+	}
+
+	if toleration.Operator == corev1.TolerationOpExists {
+		return true
+	}
+
+	return toleration.Value == taint.Value
+}
+
+func formatToleration(t corev1.Toleration) string {
+	parts := []string{}
+
+	if t.Key == "" {
+		parts = append(parts, "key=*")
+	} else {
+		parts = append(parts, fmt.Sprintf("key=%s", t.Key))
+	}
+
+	parts = append(parts, fmt.Sprintf("operator=%s", t.Operator))
+
+	if t.Value != "" {
+		parts = append(parts, fmt.Sprintf("value=%s", t.Value))
+	}
+
+	if t.Effect != "" {
+		parts = append(parts, fmt.Sprintf("effect=%s", t.Effect))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func formatTaint(t corev1.Taint) string {
+	if t.Value != "" {
+		return fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
+	}
+
+	return fmt.Sprintf("%s:%s", t.Key, t.Effect)
+}
+
+func (c nodeTaintAnalysisCollector) getNodes() (*corev1.NodeList, error) {
+	nodes := &corev1.NodeList{}
+	if err := c.apiReader.List(c.ctx, nodes); err != nil {
+		return nil, err
+	}
+
+	return nodes, nil
+}
+
+func (c nodeTaintAnalysisCollector) getDynaKubes() (*dynakube.DynaKubeList, error) {
+	dkList := &dynakube.DynaKubeList{}
+	if err := c.apiReader.List(c.ctx, dkList, client.InNamespace(c.namespace)); err != nil {
+		return nil, err
+	}
+
+	return dkList, nil
+}

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -1,3 +1,6 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package supportarchive
 
 import (

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -212,7 +212,8 @@ func findNodesWithUntoleratedTaints(nodes *corev1.NodeList, tolerations []corev1
 
 func isTaintTolerated(taint corev1.Taint, tolerations []corev1.Toleration) bool {
 	for i := range tolerations {
-		if tolerations[i].ToleratesTaint(klog.Background(), &taint, true /*enableComparisonOperators*/) {
+		// true = enableComparisonOperators, allows Lt/Gt operator matching
+		if tolerations[i].ToleratesTaint(klog.Background(), &taint, true) {
 			return true
 		}
 	}

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -226,7 +226,7 @@ func formatToleration(t corev1.Toleration) string {
 		key = "*"
 	}
 
-	if t.Operator == corev1.TolerationOpExists || t.Operator == "" && t.Value == "" {
+	if t.Operator == corev1.TolerationOpExists || (t.Operator == "" && t.Value == "") {
 		if t.Effect == "" {
 			return key
 		}
@@ -234,11 +234,22 @@ func formatToleration(t corev1.Toleration) string {
 		return fmt.Sprintf("%s:%s", key, t.Effect)
 	}
 
-	if t.Effect == "" {
-		return fmt.Sprintf("%s=%s", key, t.Value)
+	var op string
+
+	switch t.Operator {
+	case corev1.TolerationOpLt:
+		op = "<"
+	case corev1.TolerationOpGt:
+		op = ">"
+	default:
+		op = "="
 	}
 
-	return fmt.Sprintf("%s=%s:%s", key, t.Value, t.Effect)
+	if t.Effect == "" {
+		return fmt.Sprintf("%s%s%s", key, op, t.Value)
+	}
+
+	return fmt.Sprintf("%s%s%s:%s", key, op, t.Value, t.Effect)
 }
 
 func formatTaint(t corev1.Taint) string {

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -221,25 +221,24 @@ func isTaintTolerated(taint corev1.Taint, tolerations []corev1.Toleration) bool 
 }
 
 func formatToleration(t corev1.Toleration) string {
-	parts := []string{}
-
-	if t.Key == "" {
-		parts = append(parts, "key=*")
-	} else {
-		parts = append(parts, "key="+t.Key)
+	key := t.Key
+	if key == "" {
+		key = "*"
 	}
 
-	parts = append(parts, fmt.Sprintf("operator=%s", t.Operator))
+	if t.Operator == corev1.TolerationOpExists || t.Operator == "" && t.Value == "" {
+		if t.Effect == "" {
+			return key
+		}
 
-	if t.Value != "" {
-		parts = append(parts, "value="+t.Value)
+		return fmt.Sprintf("%s:%s", key, t.Effect)
 	}
 
-	if t.Effect != "" {
-		parts = append(parts, fmt.Sprintf("effect=%s", t.Effect))
+	if t.Effect == "" {
+		return fmt.Sprintf("%s=%s", key, t.Value)
 	}
 
-	return strings.Join(parts, " ")
+	return fmt.Sprintf("%s=%s:%s", key, t.Value, t.Effect)
 }
 
 func formatTaint(t corev1.Taint) string {

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -212,7 +212,7 @@ func findNodesWithUntoleratedTaints(nodes *corev1.NodeList, tolerations []corev1
 
 func isTaintTolerated(taint corev1.Taint, tolerations []corev1.Toleration) bool {
 	for i := range tolerations {
-		if tolerations[i].ToleratesTaint(klog.Background(), &taint, true) {
+		if tolerations[i].ToleratesTaint(klog.Background(), &taint, true /*enableComparisonOperators*/) {
 			return true
 		}
 	}

--- a/cmd/supportarchive/node_taint_analysis.go
+++ b/cmd/supportarchive/node_taint_analysis.go
@@ -10,6 +10,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -43,8 +45,6 @@ func (c nodeTaintAnalysisCollector) Do() error {
 
 	report, err := c.buildReport()
 	if err != nil {
-		logErrorf(c.log, err, "Failed to complete node taint analysis")
-
 		return err
 	}
 
@@ -70,7 +70,7 @@ func (c nodeTaintAnalysisCollector) buildReport() (string, error) {
 
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Node count: %d\n\n", len(nodes.Items)))
+	fmt.Fprintf(&sb, "Node count: %d\n\n", len(nodes.Items))
 
 	c.analyzeOneAgentDaemonSets(&sb, nodes, dynakubes)
 	c.analyzeCSIDaemonSet(&sb, nodes)
@@ -87,15 +87,23 @@ func (c nodeTaintAnalysisCollector) analyzeOneAgentDaemonSets(sb *strings.Builde
 
 	for i := range dynakubes.Items {
 		dk := &dynakubes.Items[i]
+		if !dk.OneAgent().IsDaemonsetRequired() {
+			continue
+		}
+
 		dsName := dk.OneAgent().GetDaemonsetName()
 
-		sb.WriteString(fmt.Sprintf("--- OneAgent DaemonSet: %s (DynaKube: %s) ---\n", dsName, dk.Name))
+		fmt.Fprintf(sb, "--- OneAgent DaemonSet: %s (DynaKube: %s) ---\n", dsName, dk.Name)
 
 		var ds appsv1.DaemonSet
 
 		err := c.apiReader.Get(c.ctx, client.ObjectKey{Name: dsName, Namespace: c.namespace}, &ds)
 		if err != nil {
-			sb.WriteString(fmt.Sprintf("  DaemonSet not found: %s\n\n", err.Error()))
+			if k8serrors.IsNotFound(err) {
+				sb.WriteString("  DaemonSet not found\n\n")
+			} else {
+				fmt.Fprintf(sb, "  Error fetching DaemonSet: %s\n\n", err.Error())
+			}
 
 			continue
 		}
@@ -106,13 +114,17 @@ func (c nodeTaintAnalysisCollector) analyzeOneAgentDaemonSets(sb *strings.Builde
 }
 
 func (c nodeTaintAnalysisCollector) analyzeCSIDaemonSet(sb *strings.Builder, nodes *corev1.NodeList) {
-	sb.WriteString(fmt.Sprintf("--- CSI Driver DaemonSet: %s ---\n", dtcsi.DaemonSetName))
+	fmt.Fprintf(sb, "--- CSI Driver DaemonSet: %s ---\n", dtcsi.DaemonSetName)
 
 	var ds appsv1.DaemonSet
 
 	err := c.apiReader.Get(c.ctx, client.ObjectKey{Name: dtcsi.DaemonSetName, Namespace: c.namespace}, &ds)
 	if err != nil {
-		sb.WriteString(fmt.Sprintf("  DaemonSet not found: %s\n\n", err.Error()))
+		if k8serrors.IsNotFound(err) {
+			sb.WriteString("  DaemonSet not found\n\n")
+		} else {
+			fmt.Fprintf(sb, "  Error fetching DaemonSet: %s\n\n", err.Error())
+		}
 
 		return
 	}
@@ -125,9 +137,10 @@ func (c nodeTaintAnalysisCollector) analyzeDaemonSet(sb *strings.Builder, ds *ap
 	desired := ds.Status.DesiredNumberScheduled
 	ready := ds.Status.NumberReady
 
-	sb.WriteString(fmt.Sprintf("  Desired: %d | Ready: %d | Nodes: %d\n", desired, ready, len(nodes.Items)))
+	fmt.Fprintf(sb, "  Desired: %d | Ready: %d | Total cluster nodes: %d\n", desired, ready, len(nodes.Items))
 
 	tolerations := ds.Spec.Template.Spec.Tolerations
+
 	sb.WriteString("  Configured tolerations:\n")
 
 	if len(tolerations) == 0 {
@@ -135,7 +148,7 @@ func (c nodeTaintAnalysisCollector) analyzeDaemonSet(sb *strings.Builder, ds *ap
 	}
 
 	for _, t := range tolerations {
-		sb.WriteString(fmt.Sprintf("    %s\n", formatToleration(t)))
+		fmt.Fprintf(sb, "    %s\n", formatToleration(t))
 	}
 
 	untoleratedNodes := findNodesWithUntoleratedTaints(nodes, tolerations)
@@ -145,19 +158,19 @@ func (c nodeTaintAnalysisCollector) analyzeDaemonSet(sb *strings.Builder, ds *ap
 		return
 	}
 
-	sb.WriteString(fmt.Sprintf("  WARNING: %d node(s) have untolerated taints:\n", len(untoleratedNodes)))
+	fmt.Fprintf(sb, "  WARNING: %d node(s) have untolerated taints:\n", len(untoleratedNodes))
 
 	for _, entry := range untoleratedNodes {
-		sb.WriteString(fmt.Sprintf("    Node: %s\n", entry.nodeName))
+		fmt.Fprintf(sb, "    Node: %s\n", entry.nodeName)
 
 		for _, taint := range entry.untoleratedTaints {
-			sb.WriteString(fmt.Sprintf("      - %s\n", formatTaint(taint)))
+			fmt.Fprintf(sb, "      - %s\n", formatTaint(taint))
 		}
 	}
 }
 
 type nodeWithUntoleratedTaints struct {
-	nodeName         string
+	nodeName          string
 	untoleratedTaints []corev1.Taint
 }
 
@@ -173,6 +186,11 @@ func findNodesWithUntoleratedTaints(nodes *corev1.NodeList, tolerations []corev1
 		var untolerated []corev1.Taint
 
 		for _, taint := range node.Spec.Taints {
+			// PreferNoSchedule is advisory: DaemonSet controller schedules regardless of whether the taint is tolerated
+			if taint.Effect == corev1.TaintEffectPreferNoSchedule {
+				continue
+			}
+
 			if !isTaintTolerated(taint, tolerations) {
 				untolerated = append(untolerated, taint)
 			}
@@ -180,7 +198,7 @@ func findNodesWithUntoleratedTaints(nodes *corev1.NodeList, tolerations []corev1
 
 		if len(untolerated) > 0 {
 			result = append(result, nodeWithUntoleratedTaints{
-				nodeName:         node.Name,
+				nodeName:          node.Name,
 				untoleratedTaints: untolerated,
 			})
 		}
@@ -190,38 +208,13 @@ func findNodesWithUntoleratedTaints(nodes *corev1.NodeList, tolerations []corev1
 }
 
 func isTaintTolerated(taint corev1.Taint, tolerations []corev1.Toleration) bool {
-	for _, toleration := range tolerations {
-		if tolerationMatchesTaint(toleration, taint) {
+	for i := range tolerations {
+		if tolerations[i].ToleratesTaint(klog.Background(), &taint, true) {
 			return true
 		}
 	}
 
 	return false
-}
-
-func tolerationMatchesTaint(toleration corev1.Toleration, taint corev1.Taint) bool {
-	// Empty key with Exists operator matches all taints
-	if toleration.Key == "" && toleration.Operator == corev1.TolerationOpExists {
-		if toleration.Effect == "" || toleration.Effect == taint.Effect {
-			return true
-		}
-
-		return false
-	}
-
-	if toleration.Key != taint.Key {
-		return false
-	}
-
-	if toleration.Effect != "" && toleration.Effect != taint.Effect {
-		return false
-	}
-
-	if toleration.Operator == corev1.TolerationOpExists {
-		return true
-	}
-
-	return toleration.Value == taint.Value
 }
 
 func formatToleration(t corev1.Toleration) string {
@@ -230,13 +223,13 @@ func formatToleration(t corev1.Toleration) string {
 	if t.Key == "" {
 		parts = append(parts, "key=*")
 	} else {
-		parts = append(parts, fmt.Sprintf("key=%s", t.Key))
+		parts = append(parts, "key="+t.Key)
 	}
 
 	parts = append(parts, fmt.Sprintf("operator=%s", t.Operator))
 
 	if t.Value != "" {
-		parts = append(parts, fmt.Sprintf("value=%s", t.Value))
+		parts = append(parts, "value="+t.Value)
 	}
 
 	if t.Effect != "" {

--- a/cmd/supportarchive/node_taint_analysis_test.go
+++ b/cmd/supportarchive/node_taint_analysis_test.go
@@ -1,0 +1,293 @@
+package supportarchive
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNodeTaintAnalysisCollector_Name(t *testing.T) {
+	logBuffer := bytes.Buffer{}
+	c := newNodeTaintAnalysisCollector(context.Background(), newSupportArchiveLogger(&logBuffer), nil, testOperatorNamespace, nil)
+	assert.Equal(t, nodeTaintAnalysisCollectorName, c.Name())
+}
+
+func TestNodeTaintAnalysisCollector_AllTaintsTolerated(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-1", corev1.Taint{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule}),
+		createNode("node-2"),
+	}
+
+	dk := createTestDynaKube("my-dynakube")
+	oaDS := createDaemonSet("my-dynakube-oneagent", testOperatorNamespace, 2, 2,
+		corev1.Toleration{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	)
+	csiDS := createDaemonSet(dtcsi.DaemonSetName, testOperatorNamespace, 2, 2,
+		corev1.Toleration{Key: "", Operator: corev1.TolerationOpExists},
+	)
+
+	content := runNodeTaintAnalysis(t, nodes, []dynakube.DynaKube{dk}, []appsv1.DaemonSet{oaDS, csiDS})
+
+	assert.Contains(t, content, "Node count: 2")
+	assert.Contains(t, content, "OneAgent DaemonSet: my-dynakube-oneagent")
+	assert.Contains(t, content, "Desired: 2 | Ready: 2 | Nodes: 2")
+	assert.Contains(t, content, "All node taints are tolerated")
+	assert.NotContains(t, content, "WARNING")
+}
+
+func TestNodeTaintAnalysisCollector_UntoleratedTaints(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-ok"),
+		createNode("node-tainted",
+			corev1.Taint{Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule},
+			corev1.Taint{Key: "nvidia.com/gpu", Effect: corev1.TaintEffectNoSchedule},
+		),
+	}
+
+	dk := createTestDynaKube("prod-dynakube")
+	oaDS := createDaemonSet("prod-dynakube-oneagent", testOperatorNamespace, 1, 1)
+	csiDS := createDaemonSet(dtcsi.DaemonSetName, testOperatorNamespace, 1, 1)
+
+	content := runNodeTaintAnalysis(t, nodes, []dynakube.DynaKube{dk}, []appsv1.DaemonSet{oaDS, csiDS})
+
+	assert.Contains(t, content, "Node count: 2")
+	assert.Contains(t, content, "WARNING: 1 node(s) have untolerated taints")
+	assert.Contains(t, content, "Node: node-tainted")
+	assert.Contains(t, content, "dedicated=gpu:NoSchedule")
+	assert.Contains(t, content, "nvidia.com/gpu:NoSchedule")
+}
+
+func TestNodeTaintAnalysisCollector_NoDynaKubes(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-1"),
+	}
+	csiDS := createDaemonSet(dtcsi.DaemonSetName, testOperatorNamespace, 1, 1)
+
+	content := runNodeTaintAnalysis(t, nodes, nil, []appsv1.DaemonSet{csiDS})
+
+	assert.Contains(t, content, "No DynaKube resources found")
+	assert.Contains(t, content, "CSI Driver DaemonSet")
+}
+
+func TestNodeTaintAnalysisCollector_MissingDaemonSets(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-1"),
+	}
+	dk := createTestDynaKube("my-dk")
+
+	content := runNodeTaintAnalysis(t, nodes, []dynakube.DynaKube{dk}, nil)
+
+	assert.Contains(t, content, "DaemonSet not found")
+}
+
+func TestNodeTaintAnalysisCollector_WildcardToleration(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-1",
+			corev1.Taint{Key: "anything", Value: "whatever", Effect: corev1.TaintEffectNoExecute},
+			corev1.Taint{Key: "other", Effect: corev1.TaintEffectNoSchedule},
+		),
+	}
+
+	dk := createTestDynaKube("dk")
+	oaDS := createDaemonSet("dk-oneagent", testOperatorNamespace, 1, 1,
+		corev1.Toleration{Operator: corev1.TolerationOpExists},
+	)
+	csiDS := createDaemonSet(dtcsi.DaemonSetName, testOperatorNamespace, 1, 1,
+		corev1.Toleration{Operator: corev1.TolerationOpExists},
+	)
+
+	content := runNodeTaintAnalysis(t, nodes, []dynakube.DynaKube{dk}, []appsv1.DaemonSet{oaDS, csiDS})
+
+	assert.Contains(t, content, "All node taints are tolerated")
+	assert.NotContains(t, content, "WARNING")
+}
+
+func TestNodeTaintAnalysisCollector_PartialToleration(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-1",
+			corev1.Taint{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			corev1.Taint{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+		),
+	}
+
+	dk := createTestDynaKube("dk")
+	// Only tolerates key1, not key2
+	oaDS := createDaemonSet("dk-oneagent", testOperatorNamespace, 0, 0,
+		corev1.Toleration{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+	)
+
+	content := runNodeTaintAnalysis(t, nodes, []dynakube.DynaKube{dk}, []appsv1.DaemonSet{oaDS})
+
+	assert.Contains(t, content, "WARNING: 1 node(s) have untolerated taints")
+	assert.Contains(t, content, "Node: node-1")
+	assert.Contains(t, content, "key2=val2:NoExecute")
+	assert.NotContains(t, content, "key1=val1:NoSchedule")
+}
+
+func TestTolerationMatching(t *testing.T) {
+	tests := []struct {
+		name       string
+		taint      corev1.Taint
+		toleration corev1.Toleration
+		matches    bool
+	}{
+		{
+			name:       "exact match",
+			taint:      corev1.Taint{Key: "k", Value: "v", Effect: corev1.TaintEffectNoSchedule},
+			toleration: corev1.Toleration{Key: "k", Operator: corev1.TolerationOpEqual, Value: "v", Effect: corev1.TaintEffectNoSchedule},
+			matches:    true,
+		},
+		{
+			name:       "exists operator matches any value",
+			taint:      corev1.Taint{Key: "k", Value: "v", Effect: corev1.TaintEffectNoSchedule},
+			toleration: corev1.Toleration{Key: "k", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			matches:    true,
+		},
+		{
+			name:       "wildcard matches everything",
+			taint:      corev1.Taint{Key: "anything", Value: "val", Effect: corev1.TaintEffectNoExecute},
+			toleration: corev1.Toleration{Operator: corev1.TolerationOpExists},
+			matches:    true,
+		},
+		{
+			name:       "wrong key",
+			taint:      corev1.Taint{Key: "k1", Value: "v", Effect: corev1.TaintEffectNoSchedule},
+			toleration: corev1.Toleration{Key: "k2", Operator: corev1.TolerationOpEqual, Value: "v", Effect: corev1.TaintEffectNoSchedule},
+			matches:    false,
+		},
+		{
+			name:       "wrong effect",
+			taint:      corev1.Taint{Key: "k", Value: "v", Effect: corev1.TaintEffectNoExecute},
+			toleration: corev1.Toleration{Key: "k", Operator: corev1.TolerationOpEqual, Value: "v", Effect: corev1.TaintEffectNoSchedule},
+			matches:    false,
+		},
+		{
+			name:       "empty effect tolerates all effects",
+			taint:      corev1.Taint{Key: "k", Value: "v", Effect: corev1.TaintEffectNoExecute},
+			toleration: corev1.Toleration{Key: "k", Operator: corev1.TolerationOpEqual, Value: "v"},
+			matches:    true,
+		},
+		{
+			name:       "wrong value",
+			taint:      corev1.Taint{Key: "k", Value: "v1", Effect: corev1.TaintEffectNoSchedule},
+			toleration: corev1.Toleration{Key: "k", Operator: corev1.TolerationOpEqual, Value: "v2", Effect: corev1.TaintEffectNoSchedule},
+			matches:    false,
+		},
+		{
+			name:       "wildcard with effect only matches that effect",
+			taint:      corev1.Taint{Key: "k", Value: "v", Effect: corev1.TaintEffectNoExecute},
+			toleration: corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			matches:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.matches, tolerationMatchesTaint(tt.toleration, tt.taint))
+		})
+	}
+}
+
+func runNodeTaintAnalysis(t *testing.T, nodes []corev1.Node, dks []dynakube.DynaKube, daemonSets []appsv1.DaemonSet) string {
+	t.Helper()
+
+	var objects []client.Object
+
+	for i := range nodes {
+		objects = append(objects, &nodes[i])
+	}
+
+	for i := range dks {
+		objects = append(objects, &dks[i])
+	}
+
+	for i := range daemonSets {
+		objects = append(objects, &daemonSets[i])
+	}
+
+	clt := fake.NewClientWithIndex(objects...)
+
+	logBuffer := bytes.Buffer{}
+	buffer := bytes.Buffer{}
+	archive := newZipArchive(bufio.NewWriter(&buffer))
+
+	collector := newNodeTaintAnalysisCollector(context.Background(), newSupportArchiveLogger(&logBuffer), archive, testOperatorNamespace, clt)
+	require.NoError(t, collector.Do())
+	require.NoError(t, archive.Close())
+
+	zipReader, err := zip.NewReader(bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	require.NoError(t, err)
+	require.Len(t, zipReader.File, 1)
+	assert.Equal(t, NodeTaintAnalysisFileName, zipReader.File[0].Name)
+
+	reader, err := zipReader.File[0].Open()
+	require.NoError(t, err)
+	defer assertNoErrorOnClose(t, reader)
+
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	return string(content)
+}
+
+func createNode(name string, taints ...corev1.Taint) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.NodeSpec{
+			Taints: taints,
+		},
+	}
+}
+
+func createTestDynaKube(name string) dynakube.DynaKube {
+	return dynakube.DynaKube{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testOperatorNamespace,
+		},
+	}
+}
+
+func createDaemonSet(name, namespace string, desired, ready int32, tolerations ...corev1.Toleration) appsv1.DaemonSet {
+	return appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Tolerations: tolerations,
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test:latest"},
+					},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: desired,
+			NumberReady:            ready,
+		},
+	}
+}

--- a/cmd/supportarchive/node_taint_analysis_test.go
+++ b/cmd/supportarchive/node_taint_analysis_test.go
@@ -1,3 +1,6 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package supportarchive
 
 import (
@@ -9,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +47,7 @@ func TestNodeTaintAnalysisCollector_AllTaintsTolerated(t *testing.T) {
 
 	assert.Contains(t, content, "Node count: 2")
 	assert.Contains(t, content, "OneAgent DaemonSet: my-dynakube-oneagent")
-	assert.Contains(t, content, "Desired: 2 | Ready: 2 | Nodes: 2")
+	assert.Contains(t, content, "Desired: 2 | Ready: 2 | Total cluster nodes: 2")
 	assert.Contains(t, content, "All node taints are tolerated")
 	assert.NotContains(t, content, "WARNING")
 }
@@ -196,7 +200,7 @@ func TestTolerationMatching(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.matches, tolerationMatchesTaint(tt.toleration, tt.taint))
+			assert.Equal(t, tt.matches, isTaintTolerated(tt.taint, []corev1.Toleration{tt.toleration}))
 		})
 	}
 }
@@ -259,6 +263,11 @@ func createTestDynaKube(name string) dynakube.DynaKube {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testOperatorNamespace,
+		},
+		Spec: dynakube.DynaKubeSpec{
+			OneAgent: oneagent.Spec{
+				HostMonitoring: &oneagent.HostInjectSpec{},
+			},
 		},
 	}
 }

--- a/cmd/supportarchive/node_taint_analysis_test.go
+++ b/cmd/supportarchive/node_taint_analysis_test.go
@@ -222,6 +222,18 @@ func TestTolerationMatching(t *testing.T) {
 	}
 }
 
+func TestFormatToleration_LtGt(t *testing.T) {
+	assert.Equal(t, "cpu-score<25:NoSchedule", formatToleration(corev1.Toleration{
+		Key: "cpu-score", Operator: corev1.TolerationOpLt, Value: "25", Effect: corev1.TaintEffectNoSchedule,
+	}))
+	assert.Equal(t, "memory-pressure>100:NoExecute", formatToleration(corev1.Toleration{
+		Key: "memory-pressure", Operator: corev1.TolerationOpGt, Value: "100", Effect: corev1.TaintEffectNoExecute,
+	}))
+	assert.Equal(t, "cpu-score<25", formatToleration(corev1.Toleration{
+		Key: "cpu-score", Operator: corev1.TolerationOpLt, Value: "25",
+	}))
+}
+
 func runNodeTaintAnalysis(t *testing.T, nodes []corev1.Node, dks []dynakube.DynaKube, daemonSets []appsv1.DaemonSet) string {
 	t.Helper()
 

--- a/cmd/supportarchive/node_taint_analysis_test.go
+++ b/cmd/supportarchive/node_taint_analysis_test.go
@@ -119,6 +119,23 @@ func TestNodeTaintAnalysisCollector_WildcardToleration(t *testing.T) {
 	assert.NotContains(t, content, "WARNING")
 }
 
+func TestNodeTaintAnalysisCollector_PreferNoScheduleIgnored(t *testing.T) {
+	nodes := []corev1.Node{
+		createNode("node-1",
+			corev1.Taint{Key: "soft", Value: "hint", Effect: corev1.TaintEffectPreferNoSchedule},
+		),
+	}
+
+	dk := createTestDynaKube("dk")
+	oaDS := createDaemonSet("dk-oneagent", testOperatorNamespace, 1, 1)
+	csiDS := createDaemonSet(dtcsi.DaemonSetName, testOperatorNamespace, 1, 1)
+
+	content := runNodeTaintAnalysis(t, nodes, []dynakube.DynaKube{dk}, []appsv1.DaemonSet{oaDS, csiDS})
+
+	assert.Contains(t, content, "All node taints are tolerated")
+	assert.NotContains(t, content, "WARNING")
+}
+
 func TestNodeTaintAnalysisCollector_PartialToleration(t *testing.T) {
 	nodes := []corev1.Node{
 		createNode("node-1",

--- a/cmd/supportarchive/node_taint_analysis_test.go
+++ b/cmd/supportarchive/node_taint_analysis_test.go
@@ -138,7 +138,7 @@ func TestNodeTaintAnalysisCollector_PartialToleration(t *testing.T) {
 	assert.Contains(t, content, "WARNING: 1 node(s) have untolerated taints")
 	assert.Contains(t, content, "Node: node-1")
 	assert.Contains(t, content, "key2=val2:NoExecute")
-	assert.NotContains(t, content, "key1=val1:NoSchedule")
+	assert.NotContains(t, content, "- key1=val1:NoSchedule")
 }
 
 func TestTolerationMatching(t *testing.T) {

--- a/test/e2e/features/supportarchive/files.go
+++ b/test/e2e/features/supportarchive/files.go
@@ -63,6 +63,7 @@ func (r requiredFiles) collectRequiredFiles() []string {
 			supportarchive.OperatorVersionFileName,
 			supportarchive.TroublshootOutputFileName,
 			supportarchive.SupportArchiveOutputFileName,
+			supportarchive.NodeTaintAnalysisFileName,
 		},
 		r.getRequiredPodFiles(k8slabel.AppNameLabel, true),
 		r.getRequiredPodFiles(k8slabel.AppManagedByLabel, r.collectManaged),


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-4195
taken over from: https://github.com/Dynatrace/dynatrace-operator/pull/6408

- Adds a new nodeTaintAnalysisCollector to the support archive that analyzes node taints against OneAgent and CSI DaemonSet tolerations
- For each DaemonSet, reports desired/ready pod counts vs total node count, lists configured tolerations, and highlights nodes with untolerated taints
- Helps diagnose scheduling issues where OneAgent or CSI pods are missing from nodes due to taint/toleration mismatches

Example output:
```
Node count: 3

--- OneAgent DaemonSet: gke-k8s-2026-07-27-agents-oneagent (DynaKube: gke-k8s-2026-07-27-agents) ---
  Desired: 1 | Ready: 1 | Total cluster nodes: 3
  Configured tolerations:
    node-role.kubernetes.io/master:NoSchedule
    node-role.kubernetes.io/control-plane:NoSchedule
  WARNING: 2 node(s) have untolerated taints:
    Node: gke-ninoe-dev-default-pool-1dba91cd-7zjg
      - dedicated=gpu:NoExecute
    Node: gke-ninoe-dev-default-pool-1dba91cd-853x
      - team=platform:NoSchedule

--- CSI Driver DaemonSet: dynatrace-oneagent-csi-driver ---
  Desired: 2 | Ready: 2 | Total cluster nodes: 3
  Configured tolerations:
    node-role.kubernetes.io/master:NoSchedule
    node-role.kubernetes.io/control-plane:NoSchedule
    kubernetes.io/arch=arm64:NoSchedule
    kubernetes.io/arch=amd64:NoSchedule
    kubernetes.io/arch=ppc64le:NoSchedule
    kubernetes.io/arch=s390x:NoSchedule
    ToBeDeletedByClusterAutoscaler:NoSchedule
  WARNING: 2 node(s) have untolerated taints:
    Node: gke-ninoe-dev-default-pool-1dba91cd-7zjg
      - dedicated=gpu:NoExecute
    Node: gke-ninoe-dev-default-pool-1dba91cd-853x
      - team=platform:NoSchedule
```

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- `make go/test`
- deploy to a cluster and execute the `troubleshoot` command [docs/troubleshooting](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/deployment/troubleshooting)
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->