### PR TITLE
Preserve KSPM host path list in the `v1beta5` API

### DIFF
--- a/pkg/api/v1beta5/dynakube/convert_from.go
+++ b/pkg/api/v1beta5/dynakube/convert_from.go
@@ -73,7 +73,9 @@ func (dst *DynaKube) fromLogMonitoringSpec(src *dynakubelatest.DynaKube) {
 
 func (dst *DynaKube) fromKspmSpec(src *dynakubelatest.DynaKube) {
 	if src.Spec.KSPM != nil {
-		dst.Spec.Kspm = &kspm.Spec{}
+		dst.Spec.Kspm = &kspm.Spec{
+			MappedHostPaths: src.Spec.KSPM.MappedHostPaths,
+		}
 	}
 }
 

--- a/pkg/api/v1beta5/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta5/dynakube/convert_from_test.go
@@ -168,7 +168,7 @@ func TestConvertFrom(t *testing.T) {
 			mappedHostPaths []string
 		}{
 			{
-				name:            "tight allowlist is preserved",
+				name:            "single entry is preserved",
 				mappedHostPaths: []string{"/boot"},
 			},
 			{
@@ -176,11 +176,11 @@ func TestConvertFrom(t *testing.T) {
 				mappedHostPaths: []string{"/boot", "/etc"},
 			},
 			{
-				name:            "empty allowlist is preserved",
+				name:            "empty slice is preserved",
 				mappedHostPaths: []string{},
 			},
 			{
-				name:            "nil allowlist is preserved",
+				name:            "nil slice is preserved",
 				mappedHostPaths: nil,
 			},
 		}

--- a/pkg/api/v1beta5/dynakube/convert_from_test.go
+++ b/pkg/api/v1beta5/dynakube/convert_from_test.go
@@ -163,15 +163,44 @@ func TestConvertFrom(t *testing.T) {
 	})
 
 	t.Run("migrate kspm from latest to v1beta5", func(t *testing.T) {
-		from := getNewDynakubeBase()
-		from.Spec.KSPM = &kspmlatest.Spec{}
-		to := DynaKube{}
+		testCases := []struct {
+			name            string
+			mappedHostPaths []string
+		}{
+			{
+				name:            "tight allowlist is preserved",
+				mappedHostPaths: []string{"/boot"},
+			},
+			{
+				name:            "multiple entries are preserved",
+				mappedHostPaths: []string{"/boot", "/etc"},
+			},
+			{
+				name:            "empty allowlist is preserved",
+				mappedHostPaths: []string{},
+			},
+			{
+				name:            "nil allowlist is preserved",
+				mappedHostPaths: nil,
+			},
+		}
 
-		err := to.ConvertFrom(&from)
-		require.NoError(t, err)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				from := getNewDynakubeBase()
+				from.Spec.KSPM = &kspmlatest.Spec{
+					MappedHostPaths: tc.mappedHostPaths,
+				}
+				to := DynaKube{}
 
-		assert.NotNil(t, to.Spec.Kspm)
-		compareBase(t, to, from)
+				err := to.ConvertFrom(&from)
+				require.NoError(t, err)
+
+				require.NotNil(t, to.Spec.Kspm)
+				assert.Equal(t, tc.mappedHostPaths, to.Spec.Kspm.MappedHostPaths)
+				compareBase(t, to, from)
+			})
+		}
 	})
 
 	t.Run("migrate extensions templates from latest to v1beta5", func(t *testing.T) {

--- a/pkg/api/v1beta5/dynakube/convert_to.go
+++ b/pkg/api/v1beta5/dynakube/convert_to.go
@@ -73,8 +73,9 @@ func (src *DynaKube) toLogMonitoringSpec(dst *dynakubelatest.DynaKube) {
 
 func (src *DynaKube) toKspmSpec(dst *dynakubelatest.DynaKube) {
 	if src.Spec.Kspm != nil {
-		dst.Spec.KSPM = &kspmlatest.Spec{}
-		dst.Spec.KSPM.MappedHostPaths = []string{"/"}
+		dst.Spec.KSPM = &kspmlatest.Spec{
+			MappedHostPaths: src.Spec.Kspm.MappedHostPaths,
+		}
 	}
 }
 

--- a/pkg/api/v1beta5/dynakube/convert_to_test.go
+++ b/pkg/api/v1beta5/dynakube/convert_to_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/conversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	dynakubelatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	kspmlatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
 	telemetryingestlatest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/telemetryingest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
@@ -159,16 +160,49 @@ func TestConvertTo(t *testing.T) {
 	})
 
 	t.Run("migrate kspm from v1beta5 to latest", func(t *testing.T) {
-		from := getOldDynakubeBase()
-		from.Spec.Kspm = &kspm.Spec{}
-		to := dynakubelatest.DynaKube{}
+		testCases := []struct {
+			name            string
+			mappedHostPaths []string
+			expected        []string
+		}{
+			{
+				name:            "tight allowlist is preserved, not loosened to root",
+				mappedHostPaths: []string{"/boot"},
+				expected:        []string{"/boot"},
+			},
+			{
+				name:            "multiple entries are preserved",
+				mappedHostPaths: []string{"/boot", "/etc"},
+				expected:        []string{"/boot", "/etc"},
+			},
+			{
+				name:            "empty allowlist is preserved, not loosened to root",
+				mappedHostPaths: []string{},
+				expected:        []string{},
+			},
+			{
+				name:            "nil allowlist is preserved, not loosened to root",
+				mappedHostPaths: nil,
+				expected:        nil,
+			},
+		}
 
-		err := from.ConvertTo(&to)
-		require.NoError(t, err)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				from := getOldDynakubeBase()
+				from.Spec.Kspm = &kspm.Spec{
+					MappedHostPaths: tc.mappedHostPaths,
+				}
+				to := dynakubelatest.DynaKube{}
 
-		assert.NotNil(t, to.Spec.KSPM)
-		assert.Equal(t, []string{"/"}, to.Spec.KSPM.MappedHostPaths)
-		compareBase(t, from, to)
+				err := from.ConvertTo(&to)
+				require.NoError(t, err)
+
+				require.NotNil(t, to.Spec.KSPM)
+				assert.Equal(t, tc.expected, to.Spec.KSPM.MappedHostPaths)
+				compareBase(t, from, to)
+			})
+		}
 	})
 
 	t.Run("migrate extensions templates from v1beta5 to latest", func(t *testing.T) {
@@ -341,6 +375,55 @@ func TestConvertTo(t *testing.T) {
 		assert.Equal(t, from.Spec.TelemetryIngest.Protocols, to.Spec.TelemetryIngest.Protocols)
 		assert.Equal(t, from.Spec.TelemetryIngest.ServiceName, to.Spec.TelemetryIngest.ServiceName)
 		assert.Equal(t, from.Spec.TelemetryIngest.TLSRefName, to.Spec.TelemetryIngest.TLSRefName)
+	})
+
+	t.Run("migrate kspm MappedHostPaths from v1beta5 to latest and back", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			mappedHostPaths []string
+			expected        []string
+		}{
+			{
+				name:            "narrow allowlist is preserved",
+				mappedHostPaths: []string{"/boot"},
+				expected:        []string{"/boot"},
+			},
+			{
+				name:            "multiple entries are preserved",
+				mappedHostPaths: []string{"/boot", "/etc"},
+				expected:        []string{"/boot", "/etc"},
+			},
+			{
+				name:            "empty allowlist is preserved",
+				mappedHostPaths: []string{},
+				expected:        []string{},
+			},
+			{
+				name:            "nil allowlist is preserved",
+				mappedHostPaths: nil,
+				expected:        nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				original := getNewDynakubeBase()
+				original.Spec.KSPM = &kspmlatest.Spec{
+					MappedHostPaths: tc.mappedHostPaths,
+				}
+
+				// latest -> v1beta5
+				intermediateDk := DynaKube{}
+				require.NoError(t, intermediateDk.ConvertFrom(&original))
+
+				// v1beta5 -> latest
+				migratedDk := dynakubelatest.DynaKube{}
+				require.NoError(t, intermediateDk.ConvertTo(&migratedDk))
+
+				require.NotNil(t, migratedDk.Spec.KSPM)
+				assert.Equal(t, tc.expected, migratedDk.Spec.KSPM.MappedHostPaths)
+			})
+		}
 	})
 }
 

--- a/pkg/api/v1beta5/dynakube/convert_to_test.go
+++ b/pkg/api/v1beta5/dynakube/convert_to_test.go
@@ -166,7 +166,7 @@ func TestConvertTo(t *testing.T) {
 			expected        []string
 		}{
 			{
-				name:            "tight allowlist is preserved, not loosened to root",
+				name:            "single entry is preserved, not loosened to root",
 				mappedHostPaths: []string{"/boot"},
 				expected:        []string{"/boot"},
 			},
@@ -176,12 +176,12 @@ func TestConvertTo(t *testing.T) {
 				expected:        []string{"/boot", "/etc"},
 			},
 			{
-				name:            "empty allowlist is preserved, not loosened to root",
+				name:            "empty slice is preserved, not loosened to root",
 				mappedHostPaths: []string{},
 				expected:        []string{},
 			},
 			{
-				name:            "nil allowlist is preserved, not loosened to root",
+				name:            "nil slice is preserved, not loosened to root",
 				mappedHostPaths: nil,
 				expected:        nil,
 			},
@@ -384,7 +384,7 @@ func TestConvertTo(t *testing.T) {
 			expected        []string
 		}{
 			{
-				name:            "narrow allowlist is preserved",
+				name:            "single entry is preserved",
 				mappedHostPaths: []string{"/boot"},
 				expected:        []string{"/boot"},
 			},
@@ -394,12 +394,12 @@ func TestConvertTo(t *testing.T) {
 				expected:        []string{"/boot", "/etc"},
 			},
 			{
-				name:            "empty allowlist is preserved",
+				name:            "empty slice is preserved",
 				mappedHostPaths: []string{},
 				expected:        []string{},
 			},
 			{
-				name:            "nil allowlist is preserved",
+				name:            "nil slice is preserved",
 				mappedHostPaths: nil,
 				expected:        nil,
 			},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Currently, reading and reapplying a DynaKube (without any changes) via the `v1beta5` API broad widens the KSPM `mappedHostPaths` allowlist to `/` (see repro instructions below).
Address this by ensuring `MappedHostPaths` is always preserved, regardless of the conversion direction.

Fixes ICP-7551.

## How can this be tested?

1. Install the latest nightly build.
2. Apply this DynaKube:

```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: icp-7551-repro
  namespace: dynatrace
spec:
  apiUrl: <your tenant>
  tokens: dynakube
  activeGate:
    capabilities:
    - kubernetes-monitoring
    image: public.ecr.aws/dynatrace/dynatrace-activegate:1.341.38.20260715-213002
  kspm:
    mappedHostPaths:
    - /boot
  templates:
    kspmNodeConfigurationCollector:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector
        tag: 1.5.12
```

3. Confirm the allowlist is stored as-is:
```bash
kubectl -n dynatrace get dynakube icp-7551-repro -o jsonpath='{.spec.kspm.mappedHostPaths}'
```

4. Read and reapply the DK via the `v1beta5` API:
```bash
kubectl -n dynatrace get dynakubes.v1beta5.dynatrace.com icp-7551-repro -o yaml | kubectl apply -n dynatrace -f -
```

5. Check the allowlist again:
```bash
kubectl -n dynatrace get dynakube icp-7551-repro -o jsonpath='{.spec.kspm.mappedHostPaths}'
# Should be ["/"]
```

6. Install the PR build and repeat steps 2-5.

7. Check the allowlist again:
```bash
kubectl -n dynatrace get dynakube icp-7551-repro -o jsonpath='{.spec.kspm.mappedHostPaths}'
# Should be ["/boot"]
```