### PR TITLE
Revert "fix: deduplicate FormattedCommunicationEndpoints in ConnectionInfo - ICP-3025"

### DIFF
--- a/pkg/clients/dynatrace/oneagent/connection_info.go
+++ b/pkg/clients/dynatrace/oneagent/connection_info.go
@@ -5,7 +5,6 @@ package oneagent
 
 import (
 	"context"
-	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -16,27 +15,19 @@ const (
 	connectionInfoPath = "/v1/deployment/installer/agent/connectioninfo"
 )
 
-// connectionInfoResponse is the raw shape returned by the connectioninfo API.
-// It is unmarshalled directly from JSON and never exposed outside this package.
-type connectionInfoResponse struct {
-	TenantUUID             string   `json:"tenantUUID"`
-	TenantToken            string   `json:"tenantToken"`
-	CommunicationEndpoints []string `json:"communicationEndpoints"`
-}
-
-// ConnectionInfo is the public result of GetConnectionInfo. Endpoints is
-// always deduplicated and comma-separated, consumers never see the raw
-// endpoint list returned by the API
 type ConnectionInfo struct {
-	TenantUUID  string
-	TenantToken string
-	Endpoints   string
+	TenantUUID  string `json:"tenantUUID"`
+	TenantToken string `json:"tenantToken"`
+	Endpoints   string `json:"formattedCommunicationEndpoints"`
+	// NOTE: connectionInfoPath also returns
+	// communicationEndpoints []string (individual endpoints as a slice), but we only
+	// use the pre-formatted Endpoints string above. The slice is available if needed in the future.
 }
 
 func (c *ClientImpl) GetConnectionInfo(ctx context.Context) (ConnectionInfo, error) {
 	ctx, log := logd.NewFromContext(ctx, loggerName)
 
-	var resp connectionInfoResponse
+	var resp ConnectionInfo
 
 	params := map[string]string{}
 	if c.networkZone != "" {
@@ -59,35 +50,5 @@ func (c *ClientImpl) GetConnectionInfo(ctx context.Context) (ConnectionInfo, err
 		return ConnectionInfo{}, errors.WithStack(err)
 	}
 
-	return ConnectionInfo{
-		TenantUUID:  resp.TenantUUID,
-		TenantToken: resp.TenantToken,
-		Endpoints:   deduplicateEndpoints(resp.CommunicationEndpoints),
-	}, nil
-}
-
-// deduplicateEndpoints removes duplicate entries from the communication
-// endpoints returned by the API and joins the unique ones into a single,
-// comma-separated string. The order of first occurrence is preserved,
-// surrounding whitespace is trimmed and empty entries are dropped.
-func deduplicateEndpoints(endpoints []string) string {
-	seen := make(map[string]struct{})
-
-	var unique []string
-
-	for _, endpoint := range endpoints {
-		endpoint = strings.TrimSpace(endpoint)
-		if endpoint == "" {
-			continue
-		}
-
-		if _, ok := seen[endpoint]; ok {
-			continue
-		}
-
-		seen[endpoint] = struct{}{}
-		unique = append(unique, endpoint)
-	}
-
-	return strings.Join(unique, ",")
+	return resp, nil
 }

--- a/pkg/clients/dynatrace/oneagent/connection_info_test.go
+++ b/pkg/clients/dynatrace/oneagent/connection_info_test.go
@@ -27,10 +27,10 @@ const (
 
 func Test_GetConnectionInfo(t *testing.T) {
 	ctx := t.Context()
-	response := &connectionInfoResponse{
-		TenantUUID:             testTenantUUID,
-		TenantToken:            testTenantToken,
-		CommunicationEndpoints: []string{testCommunicationEndpoint},
+	response := &ConnectionInfo{
+		TenantUUID:  testTenantUUID,
+		TenantToken: testTenantToken,
+		Endpoints:   testCommunicationEndpoint,
 	}
 
 	expectedResponse := ConnectionInfo{
@@ -39,17 +39,17 @@ func Test_GetConnectionInfo(t *testing.T) {
 		Endpoints:   testCommunicationEndpoint,
 	}
 
-	setupMockedClient := func(t *testing.T, params map[string]string, networkZone string, response *connectionInfoResponse, err error) *ClientImpl {
+	setupMockedClient := func(t *testing.T, params map[string]string, networkZone string, response *ConnectionInfo, err error) *ClientImpl {
 		req := coremock.NewRequest(t)
 		req.EXPECT().WithPaasToken().Return(req).Once()
 		req.EXPECT().WithQueryParams(params).Return(req).Once()
 		req.EXPECT().
-			Execute(&connectionInfoResponse{}).
+			Execute(&ConnectionInfo{}).
 			Run(func(model any) {
-				resp := model.(*connectionInfoResponse)
+				resp := model.(*ConnectionInfo)
 				resp.TenantUUID = response.TenantUUID
 				resp.TenantToken = response.TenantToken
-				resp.CommunicationEndpoints = response.CommunicationEndpoints
+				resp.Endpoints = response.Endpoints
 			}).
 			Return(err).Once()
 		coreClient := coremock.NewClient(t)
@@ -80,42 +80,16 @@ func Test_GetConnectionInfo(t *testing.T) {
 		assert.Equal(t, expectedResponse, connectionInfo)
 	})
 
-	t.Run("endpoints are derived from the deduplicated communicationEndpoints slice", func(t *testing.T) {
-		dupResponse := &connectionInfoResponse{
-			TenantUUID:             testTenantUUID,
-			TenantToken:            testTenantToken,
-			CommunicationEndpoints: []string{testCommunicationEndpoint, testCommunicationEndpoint},
-		}
-		expected := ConnectionInfo{
-			TenantUUID:  testTenantUUID,
-			TenantToken: testTenantToken,
-			Endpoints:   testCommunicationEndpoint,
-		}
-
-		oaClient := setupMockedClient(t, map[string]string{}, "", dupResponse, nil)
-		connectionInfo, err := oaClient.GetConnectionInfo(ctx)
-		require.NoError(t, err)
-
-		assert.Equal(t, expected, connectionInfo)
-	})
-
 	t.Run("no communication endpoints", func(t *testing.T) {
-		emptyResponse := &connectionInfoResponse{
-			TenantUUID:  testTenantUUID,
-			TenantToken: testTenantToken,
-		}
-		expected := ConnectionInfo{
-			TenantUUID:  testTenantUUID,
-			TenantToken: testTenantToken,
-			Endpoints:   "",
-		}
+		response.Endpoints = ""
+		expectedResponse.Endpoints = ""
 
-		oaClient := setupMockedClient(t, map[string]string{}, "", emptyResponse, nil)
+		oaClient := setupMockedClient(t, map[string]string{}, "", response, nil)
 		connectionInfo, err := oaClient.GetConnectionInfo(ctx)
 		require.NoError(t, err)
 		assert.NotNil(t, connectionInfo)
 
-		assert.Equal(t, expected, connectionInfo)
+		assert.Equal(t, expectedResponse, connectionInfo)
 	})
 
 	t.Run("bad request error", func(t *testing.T) {
@@ -133,70 +107,4 @@ func Test_GetConnectionInfo(t *testing.T) {
 		_, err := oaClient.GetConnectionInfo(ctx)
 		assert.ErrorIs(t, err, expectErr)
 	})
-}
-
-func Test_deduplicateEndpoints(t *testing.T) {
-	const (
-		epA = "https://tenant.dev.dynatracelabs.com:443"
-		epB = "https://other.dev.dynatracelabs.com:8443"
-		epC = "https://third.dev.dynatracelabs.com:443"
-	)
-
-	tests := []struct {
-		name     string
-		input    []string
-		expected string
-	}{
-		{
-			name:     "nil slice",
-			input:    nil,
-			expected: "",
-		},
-		{
-			name:     "empty slice",
-			input:    []string{},
-			expected: "",
-		},
-		{
-			name:     "single endpoint",
-			input:    []string{epA},
-			expected: epA,
-		},
-		{
-			name:     "no duplicates is a no-op, order preserved",
-			input:    []string{epA, epB, epC},
-			expected: epA + "," + epB + "," + epC,
-		},
-		{
-			name:     "some duplicates preserve first-occurrence order",
-			input:    []string{epB, epA, epB, epC, epA},
-			expected: epB + "," + epA + "," + epC,
-		},
-		{
-			name:     "all duplicates collapse to one",
-			input:    []string{epA, epA, epA},
-			expected: epA,
-		},
-		{
-			name:     "entries differing only by surrounding whitespace are trimmed and deduplicated",
-			input:    []string{epA, " " + epA, epA + "\t"},
-			expected: epA,
-		},
-		{
-			name:     "empty and whitespace-only entries are dropped",
-			input:    []string{epA, "", "   ", epB},
-			expected: epA + "," + epB,
-		},
-		{
-			name:     "entries differing only by case are kept as distinct",
-			input:    []string{epA, "HTTPS://TENANT.DEV.DYNATRACELABS.COM:443"},
-			expected: epA + "," + "HTTPS://TENANT.DEV.DYNATRACELABS.COM:443",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, deduplicateEndpoints(tt.input))
-		})
-	}
 }

--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts.go
@@ -5,6 +5,7 @@ package connectioninfo
 
 import (
 	"fmt"
+	"maps"
 	"net/url"
 	"slices"
 	"strconv"
@@ -63,18 +64,25 @@ func NewCommunicationHost(endpoint string) (CommunicationHost, error) {
 	}, nil
 }
 
-// ParseCommunicationHosts creates CommunicationHost slice from `,` separated endpoints.
-// It sorts the result for deterministic output.
-func ParseCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+// ParseOACommunicationHosts creates CommunicationHost slice from `;` separated endpoints.
+// It removes duplicates and sorts the result for deterministic output.
+func ParseOACommunicationHosts(endpoints string) ([]CommunicationHost, error) {
+	return newCommunicationHosts(endpoints, ";")
+}
+
+// ParseAGCommunicationHosts creates CommunicationHost slice from `,` separated endpoints.
+// It removes duplicates and sorts the result for deterministic output.
+func ParseAGCommunicationHosts(endpoints string) ([]CommunicationHost, error) {
 	return newCommunicationHosts(endpoints, ",")
 }
 
 func newCommunicationHosts(endpoints string, sep string) ([]CommunicationHost, error) {
+	// we want to avoid duplicates, because they cause problems with the istio "integration", as you should not have duplicate hosts in the ServiceEntries
+	comHosts := map[string]CommunicationHost{}
+
 	if len(endpoints) == 0 {
 		return []CommunicationHost{}, nil
 	}
-
-	var comHosts []CommunicationHost
 
 	for endpoint := range strings.SplitSeq(endpoints, sep) {
 		ch, err := NewCommunicationHost(endpoint)
@@ -82,13 +90,14 @@ func newCommunicationHosts(endpoints string, sep string) ([]CommunicationHost, e
 			return nil, err
 		}
 
-		comHosts = append(comHosts, ch)
+		comHosts[ch.String()] = ch
 	}
 
-	// sort for deterministic output
-	slices.SortFunc(comHosts, func(a, b CommunicationHost) int {
+	// we have to sort the hosts to have a deterministic order for easier testing.
+
+	sortedHosts := slices.SortedFunc(maps.Values(comHosts), func(a, b CommunicationHost) int {
 		return strings.Compare(a.String(), b.String())
 	})
 
-	return comHosts, nil
+	return sortedHosts, nil
 }

--- a/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/communication_hosts_test.go
@@ -94,7 +94,78 @@ func TestNewCommunicationHost(t *testing.T) {
 	}
 }
 
-func TestParseCommunicationHosts(t *testing.T) {
+func TestParseOACommunicationHosts(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    []CommunicationHost
+		expectError bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []CommunicationHost{},
+		},
+		{
+			name:  "single endpoint",
+			input: "https://example.live.dynatrace.com/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+			},
+		},
+		{
+			name:  "multiple endpoints separated by semicolons",
+			input: "https://example.live.dynatrace.com/communication;https://managedhost.com:9999/here/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+				{
+					Protocol: "https",
+					Host:     "managedhost.com",
+					Port:     9999,
+				},
+			},
+		},
+		{
+			name:  "duplicate endpoints are deduplicated",
+			input: "https://example.live.dynatrace.com/communication;https://example.live.dynatrace.com/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+			},
+		},
+		{
+			name:        "invalid endpoint in list",
+			input:       "https://valid.com/communication;invalidendpoint",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hosts, err := ParseOACommunicationHosts(tc.input)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, hosts)
+			}
+		})
+	}
+}
+
+func TestParseAGCommunicationHosts(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       string
@@ -134,6 +205,17 @@ func TestParseCommunicationHosts(t *testing.T) {
 			},
 		},
 		{
+			name:  "duplicate endpoints are deduplicated",
+			input: "https://example.live.dynatrace.com/communication,https://example.live.dynatrace.com/communication",
+			expected: []CommunicationHost{
+				{
+					Protocol: "https",
+					Host:     "example.live.dynatrace.com",
+					Port:     443,
+				},
+			},
+		},
+		{
 			name:  "mixed protocols",
 			input: "https://secure.example.com/communication,http://insecure.example.com/communication",
 			expected: []CommunicationHost{
@@ -163,7 +245,7 @@ func TestParseCommunicationHosts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			hosts, err := ParseCommunicationHosts(tc.input)
+			hosts, err := ParseAGCommunicationHosts(tc.input)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone.go
@@ -40,7 +40,7 @@ func hasStaleNetworkZoneEndpoints(dk *dynakube.DynaKube, endpoints string) bool 
 		return false
 	}
 
-	hosts, err := connectioninfo.ParseCommunicationHosts(endpoints)
+	hosts, err := connectioninfo.ParseOACommunicationHosts(endpoints)
 	if err != nil {
 		return false
 	}

--- a/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone_test.go
+++ b/pkg/controllers/dynakube/connectioninfo/oneagent/networkzone_test.go
@@ -50,7 +50,7 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 			},
 		}
 
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
@@ -60,13 +60,13 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 
 		// Stale IP that would normally trigger; gate must suppress it because no
 		// network zone is configured.
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("no AG ServiceIPs → not stale (best effort skip)", func(t *testing.T) {
 		dk := newDynaKubeWithAG(nil)
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
@@ -77,44 +77,44 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 
 	t.Run("ServiceIP present alongside local AG DNS endpoint → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("ServiceIP present alongside unrelated endpoints → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		endpoints := "https://1.2.3.4:443/communication,https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://1.2.3.4:443/communication;https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("IPv6 ServiceIP present (bracketed in endpoint URL) → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"2001:db8::1"})
-		endpoints := "https://[2001:db8::1]:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://[2001:db8::1]:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("ServiceIP missing from endpoints → stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.2"})
-		endpoints := "https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.True(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("endpoints contain no IP-based entries at all → stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
-		endpoints := "https://other-activegate.dynatrace:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://other-activegate.dynatrace:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.True(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("dual-stack: all ServiceIPs present → not stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1", "2001:db8::1"})
-		endpoints := "https://10.0.0.1:443/communication,https://[2001:db8::1]:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://[2001:db8::1]:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
 	t.Run("dual-stack: one ServiceIP missing → stale", func(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1", "2001:db8::1"})
 		// Cluster still advertises the previous IPv6 address.
-		endpoints := "https://10.0.0.1:443/communication,https://[2001:db8::2]:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "https://10.0.0.1:443/communication;https://[2001:db8::2]:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.True(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 
@@ -122,7 +122,7 @@ func TestHasStaleNetworkZoneEndpoints(t *testing.T) {
 		dk := newDynaKubeWithAG([]string{"10.0.0.1"})
 		// "garbage" makes ParseOACommunicationHosts return an error; the function defers
 		// rather than blocking deployment on an input shape it cannot reason about.
-		endpoints := "garbage,https://10.0.0.1:443/communication,https://" + localServiceHost + ":443/communication"
+		endpoints := "garbage;https://10.0.0.1:443/communication;https://" + localServiceHost + ":443/communication"
 		assert.False(t, hasStaleNetworkZoneEndpoints(dk, endpoints))
 	})
 }

--- a/pkg/controllers/dynakube/istio/reconciler.go
+++ b/pkg/controllers/dynakube/istio/reconciler.go
@@ -113,7 +113,7 @@ func (r *Reconciler) ReconcileCodeModules(ctx context.Context, dk *dynakube.Dyna
 		return nil
 	}
 
-	oaCommunicationHosts, err := connectioninfo.ParseCommunicationHosts(dk.Status.OneAgent.ConnectionInfo.Endpoints)
+	oaCommunicationHosts, err := connectioninfo.ParseOACommunicationHosts(dk.Status.OneAgent.ConnectionInfo.Endpoints)
 	if err != nil {
 		setServiceEntryFailedConditionForComponent(dk.Conditions(), codeModuleConditionName)
 
@@ -163,7 +163,7 @@ func (r *Reconciler) ReconcileActiveGate(ctx context.Context, dk *dynakube.DynaK
 		return nil
 	}
 
-	agCommunicationHosts, err := connectioninfo.ParseCommunicationHosts(dk.Status.ActiveGate.ConnectionInfo.Endpoints)
+	agCommunicationHosts, err := connectioninfo.ParseAGCommunicationHosts(dk.Status.ActiveGate.ConnectionInfo.Endpoints)
 	if err != nil {
 		setServiceEntryFailedConditionForComponent(dk.Conditions(), activeGateConditionName)
 

--- a/pkg/controllers/dynakube/istio/reconciler_test.go
+++ b/pkg/controllers/dynakube/istio/reconciler_test.go
@@ -531,7 +531,7 @@ func createTestDynaKube() *dynakube.DynaKube {
 		Status: dynakube.DynaKubeStatus{
 			OneAgent: oneagent.Status{
 				ConnectionInfo: communication.ConnectionInfo{
-					Endpoints: fqdnHost.String() + "," + ipHost.String(),
+					Endpoints: fqdnHost.String() + ";" + ipHost.String(),
 				},
 			},
 			ActiveGate: activegate.Status{


### PR DESCRIPTION
Reverts Dynatrace/dynatrace-operator#7195

Issue:
breaks the code-modules, due to an unnecessary optimization in what delimiter we use. (changed it from ; to ,)
Now the codemodule takes our , separated list and uses the whole thing as a url