### PR TITLE
Add custom annotations to the webhook service

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/service.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/service.yaml
@@ -5,6 +5,10 @@ kind: Service
 metadata:
   name: dynatrace-webhook
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.webhook.annotations }}
+  annotations:
+    {{- toYaml .Values.webhook.annotations | nindent 4 }}
+  {{- end }}
   labels:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
 spec:

--- a/config/helm/chart/default/tests/Common/webhook/service_test.yaml
+++ b/config/helm/chart/default/tests/Common/webhook/service_test.yaml
@@ -44,3 +44,29 @@ tests:
               targetPort: server-port
       - isNotEmpty:
           path: spec.selector
+
+  - it: should not have annotations by default
+    set:
+      platform: kubernetes
+    asserts:
+      - isKind:
+          of: Service
+      - notExists:
+          path: metadata.annotations
+
+  - it: should take custom annotations
+    set:
+      platform: kubernetes
+      webhook.annotations:
+        testKey: testValue
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.annotations
+          value:
+            testKey: testValue
+            service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      - isNotEmpty:
+          path: metadata.labels

--- a/config/helm/chart/default/values.yaml
+++ b/config/helm/chart/default/values.yaml
@@ -68,7 +68,7 @@ webhook:
   nodeSelector: {}
   tolerations: []
   labels: {}
-  annotations: {}
+  annotations: {} # applied to the webhook deployment, its pods and the dynatrace-webhook service
   apparmor: false
   securityContext:
     privileged: false


### PR DESCRIPTION
The dynatrace-webhook Service had a hardcoded metadata block, so users could not attach annotations to it. This blocks common setups that are driven by Service annotations, such as internal load balancers, service mesh opt-out and Prometheus scrape configuration.

Apply the existing webhook.annotations value to the Service metadata, following the same pattern webhook.labels and webhook.annotations already use on the webhook Deployment and its pod template, so no new values key is introduced.

Add helm-unittest cases covering the annotated and the default (absent) case.