### PR TITLE
Set the split-mount annotation on kubemon by default

### DIFF
--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sstatefulset"
 	maputil "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -324,9 +325,10 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		k8sstatefulset.SetReplicas(replicas),
 		k8sstatefulset.SetAllLabels(coreLabels.BuildLabels(), coreLabels.BuildMatchLabels(), coreLabels.BuildLabels(), km.Labels),
 		k8sstatefulset.SetAllAnnotations(nil, maputil.MergeMap(km.Annotations, map[string]string{
-			AnnotationTenantTokenHash:      tokenHash,
-			AnnotationAuthTokenHash:        authTokenHash,
-			AnnotationCustomPropertiesHash: customPropertiesHash,
+			AnnotationTenantTokenHash:              tokenHash,
+			AnnotationAuthTokenHash:                authTokenHash,
+			AnnotationCustomPropertiesHash:         customPropertiesHash,
+			mutator.AnnotationInjectionSplitMounts: "true",
 		})),
 		k8sstatefulset.SetServiceAccount(km.GetServiceAccountName()),
 		k8sstatefulset.SetNodeSelector(km.NodeSelector),

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/statefulset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sstatefulset"
+	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	imageclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
 	versionclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/version"
 	"github.com/pkg/errors"
@@ -338,6 +339,13 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
 
 		assert.Empty(t, sts.Spec.Template.Spec.ImagePullSecrets)
+	})
+
+	t.Run("injection split-mounts annotation is always set to true", func(t *testing.T) {
+		dk := newTestDynaKube(true)
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		assert.Equal(t, "true", sts.Spec.Template.Annotations[mutator.AnnotationInjectionSplitMounts])
 	})
 
 	t.Run("image pull secrets: custom pull secret is included alongside the tenant registry secret", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

If you want to inject into the Kubemon AG, you would break the AG due to overlapping their `var/lib/dynatrace` folder.
- this is mainly done internally

## How can this be tested?

> [!NOTE]
> Don't forget to set the `experimental.enableKubemonOperand: true` helm value.

Example DK, that can do "self-injection":
```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: example
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/ignored-namespaces: '["^kube-.*","^openshift(-.*)?","^gke-.*","^gmp-.*"]'
spec:
  apiUrl: https://example.dev.dynatracelabs.com/api

  kubernetesMonitoring:
    registration: {}
  oneAgent:
    applicationMonitoring: {}
```

You will likely need to restart you AG so it gets actually injected.
- you could also do this in 2 DKs, where you could just do it in a proper order

It "works" if the AG deployes, injected, and doesn't crashloop, and also is monitored.