### PR TITLE
Use correct webhook service selector

### DIFF
--- a/config/helm/chart/default/templates/Common/webhook/service.yaml
+++ b/config/helm/chart/default/templates/Common/webhook/service.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
 spec:
   selector:
-  {{- include "dynatrace-operator.webhookLabels" . | nindent 4 }}
+  {{- include "dynatrace-operator.webhookSelectorLabels" . | nindent 4 }}
   ports:
     - port: 443
       protocol: TCP


### PR DESCRIPTION
## Description

The webhook selector was changed in #640 to include the version. In some cases this can cause the service to point to pods that are still being created during an upgrade which can lead to transient webhook failures.

ICP-8674

## How can this be tested?

Upgrade the operator to this branch and check that the endpointslice contains both versions at some point.
