### PR TITLE
Validate the CM version from the API

### DIFF
--- a/pkg/controllers/csi/provisioner/install.go
+++ b/pkg/controllers/csi/provisioner/install.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/job/helmconfig"
 	"github.com/Dynatrace/dynatrace-operator/pkg/injection/codemodule/installer/symlink"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 const (
@@ -122,6 +123,8 @@ func (provisioner *OneAgentProvisioner) getTargetDir(dk *dynakube.DynaKube) stri
 	} else {
 		dirName = dk.OneAgent().GetCodeModulesVersion()
 	}
+
+	dirName = sanitize.FilePath(dirName)
 
 	return provisioner.path.AgentSharedBinaryDirForAgent(dirName)
 }

--- a/pkg/controllers/csi/provisioner/install_test.go
+++ b/pkg/controllers/csi/provisioner/install_test.go
@@ -27,4 +27,40 @@ func TestGetTargetDir(t *testing.T) {
 		targetDir := prov.getTargetDir(dk)
 		require.Contains(t, targetDir, expectedDir)
 	})
+
+	t.Run("version with double-dot => double-dot stripped from dir", func(t *testing.T) {
+		prov := createProvisioner(t)
+		dk := createDynaKubeWithVersion(t)
+		dk.Status.CodeModules.Version = "1.0../evil"
+
+		targetDir := prov.getTargetDir(dk)
+		require.NotContains(t, targetDir, "..")
+	})
+
+	t.Run("version with colon => colon stripped from dir", func(t *testing.T) {
+		prov := createProvisioner(t)
+		dk := createDynaKubeWithVersion(t)
+		dk.Status.CodeModules.Version = "version:1.0"
+
+		targetDir := prov.getTargetDir(dk)
+		require.NotContains(t, targetDir, ":")
+	})
+
+	t.Run("version with comma => comma stripped from dir", func(t *testing.T) {
+		prov := createProvisioner(t)
+		dk := createDynaKubeWithVersion(t)
+		dk.Status.CodeModules.Version = "v1,0"
+
+		targetDir := prov.getTargetDir(dk)
+		require.NotContains(t, targetDir, ",")
+	})
+
+	t.Run("version disguising root separator => dir name is empty", func(t *testing.T) {
+		prov := createProvisioner(t)
+		dk := createDynaKubeWithVersion(t)
+		dk.Status.CodeModules.Version = "../"
+
+		targetDir := prov.getTargetDir(dk)
+		require.Equal(t, prov.path.AgentSharedBinaryDirBase(), targetDir)
+	})
 }

--- a/pkg/controllers/dynakube/version/codemodules.go
+++ b/pkg/controllers/dynakube/version/codemodules.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/installer"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/version"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/dtversion"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"k8s.io/apimachinery/pkg/api/meta"
 )
@@ -113,6 +114,11 @@ func (updater *codeModulesUpdater) UseTenantRegistry(ctx context.Context) error 
 		log.Info("could not get agent paas unix version")
 		k8sconditions.SetDynatraceAPIError(updater.dk.Conditions(), cmConditionType, err)
 
+		return err
+	}
+
+	_, err = dtversion.ToSemver(latestAgentVersionUnixPaas)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/controllers/dynakube/version/codemodules_test.go
+++ b/pkg/controllers/dynakube/version/codemodules_test.go
@@ -106,6 +106,27 @@ func TestCodeModulesUseDefault(t *testing.T) {
 		assert.Equal(t, verifiedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	})
+	t.Run("invalid version from Dynatrace => error returned", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{
+					ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{},
+				},
+			},
+			Status: dynakube.DynaKubeStatus{
+				CodeModules: oldCodeModulesStatus(),
+			},
+		}
+		mockImageClient := imageclientmock.NewClient(t)
+		mockVersionClient := versionclientmock.NewClient(t)
+		mockLatestAgentVersion(mockVersionClient, "not-a-version", 1)
+
+		updater := newCodeModulesUpdater(dk, mockImageClient, mockVersionClient)
+
+		err := updater.UseTenantRegistry(ctx)
+		require.Error(t, err)
+		assert.Equal(t, "prev", dk.Status.CodeModules.ImageID)
+	})
 	t.Run("problem with Dynatrace request => visible in conditions", func(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{

--- a/pkg/util/sanitize/sanitize.go
+++ b/pkg/util/sanitize/sanitize.go
@@ -5,6 +5,7 @@
 package sanitize
 
 import (
+	"os"
 	"strings"
 	"sync"
 )
@@ -42,4 +43,22 @@ func CommandLineArgs(args []string) []string {
 	}
 
 	return sanitized
+}
+
+var filePathSanitizer = strings.NewReplacer("..", "", "//", "/", ",", "", ":", "")
+
+// FilePath removes characters that are unsafe to use as a filesystem path component: "..", "//", ",", and ":".
+// Sanitization runs before the root-separator check so that inputs that disguise a bare separator
+// (e.g. "../" → "/" after stripping "..") are also stripped.
+//
+// [filepath.Clean] is not used here because it normalizes a full path rather than stripping characters
+// from an untrusted name component. A relative input such as "../secret" passes through Clean unchanged.
+func FilePath(path string) string {
+	path = filePathSanitizer.Replace(path)
+
+	if path == string(os.PathSeparator) {
+		return ""
+	}
+
+	return path
 }

--- a/pkg/util/sanitize/sanitize_test.go
+++ b/pkg/util/sanitize/sanitize_test.go
@@ -42,6 +42,36 @@ func TestCommandLineArg(t *testing.T) {
 	}
 }
 
+func TestFilePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "empty string", in: "", out: ""},
+		{name: "root separator returns empty", in: "/", out: ""},
+		{name: "clean path is unchanged", in: "/foo/bar", out: "/foo/bar"},
+		{name: "removes double dots", in: "/foo..bar", out: "/foobar"},
+		{name: "removes double dots standalone", in: "..", out: ""},
+		{name: "converts double slash", in: "/foo//bar", out: "/foo/bar"},
+		{name: "removes comma", in: "/foo,bar", out: "/foobar"},
+		{name: "removes colon", in: "/foo:bar", out: "/foobar"},
+		{name: "removes all invalid patterns at once", in: "/foo:bar,baz//qux..end", out: "/foobarbaz/quxend"},
+		{name: "./ is ok", in: "./", out: "./"},
+		// inputs that reduce to the path separator after sanitization must also return empty
+		{name: "double-dot prefix disguising root", in: "../", out: ""},
+		{name: "comma prefix disguising root", in: ",/", out: ""},
+		{name: "colon prefix disguising root", in: ":/", out: ""},
+		{name: "multiple tricks disguising root", in: ",..:/", out: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, FilePath(tt.in))
+		})
+	}
+}
+
 func TestCommandLineArgs(t *testing.T) {
 	t.Run("nil slice returns empty slice", func(t *testing.T) {
 		assert.Equal(t, []string{}, CommandLineArgs(nil))


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-8425](https://dt-rnd.atlassian.net/browse/ICP-8425)

Fixes an exploit the relies on the fact that the CM version we get from the API is something we trust AND use to create a filepath in the CSI driver. I did a mitigation on both the Operator and CSI level, just to be sure.

1. [Validate the CM version from the API](https://github.com/Dynatrace/dynatrace-operator/commit/cbb0e13fd7a1f2eb8b09b5a8fe8bf91f7c7b3e4f)
2. [Sanitize the targetDir in the provisioner](https://github.com/Dynatrace/dynatrace-operator/commit/cc64df49853d8b372cb34e19fe32b621368db88b)

## How can this be tested?

A detailed reproducer can be found in https://dt-rnd.atlassian.net/browse/ICP-8425?focusedCommentId=4768678.

But the tests are also pretty straight forward.

**More important to check that this doesn't break current logic.**

[ICP-8425]: https://dt-rnd.atlassian.net/browse/ICP-8425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ