### PR TITLE
Add warning for increased log verbosity

### DIFF
--- a/config/helm/chart/default/templates/NOTES.txt
+++ b/config/helm/chart/default/templates/NOTES.txt
@@ -22,3 +22,6 @@ WARNING: Golang profiling endpoint is enabled. Make sure to restrict external ac
 {{- if (.Values.experimental).enableKubemonOperand }}
 WARNING: The kubemon operand is enabled. It is under development and not ready for production use.
 {{- end }}
+{{- if .Values.dtClientLogLevel }}
+WARNING: Enabled extended Dynatrace API logging verbosity. This may expose confidential information to your logging infrastructure.
+{{- end }}


### PR DESCRIPTION
## Description

The API client log filtering is best effort and we should tell users that enable it for some reason.
This is only meant for debugging.

ICP-8512
