### PR TITLE
Make classic nonroot via FF

### DIFF
--- a/pkg/api/exp/oneagent.go
+++ b/pkg/api/exp/oneagent.go
@@ -12,6 +12,7 @@ const (
 	OAInitialConnectRetryKey = FFPrefix + "oneagent-initial-connect-retry-ms"
 	OAPrivilegedKey          = FFPrefix + "oneagent-privileged"
 	OASkipLivenessProbeKey   = FFPrefix + "oneagent-skip-liveness-probe"
+	OAClassicNonrootKey      = FFPrefix + "oneagent-classic-nonroot"
 
 	OANodeImagePullKey = FFPrefix + "node-image-pull"
 	// OANodeImagePullTechnologiesKey can be set on a Pod or DynaKube to configure which code module technologies to download. It's set to
@@ -50,6 +51,10 @@ func (ff *FeatureFlags) GetAgentInitialConnectRetry(isIstio bool) int {
 
 func (ff *FeatureFlags) IsOneAgentPrivileged() bool {
 	return ff.getBoolWithDefault(OAPrivilegedKey, false)
+}
+
+func (ff *FeatureFlags) IsClassicOneAgentNonroot() bool {
+	return ff.getBoolWithDefault(OAClassicNonrootKey, false)
 }
 
 func (ff *FeatureFlags) SkipOneAgentLivenessProbe() bool {

--- a/pkg/api/exp/oneagent.go
+++ b/pkg/api/exp/oneagent.go
@@ -12,7 +12,7 @@ const (
 	OAInitialConnectRetryKey = FFPrefix + "oneagent-initial-connect-retry-ms"
 	OAPrivilegedKey          = FFPrefix + "oneagent-privileged"
 	OASkipLivenessProbeKey   = FFPrefix + "oneagent-skip-liveness-probe"
-	OAClassicNonrootKey      = FFPrefix + "oneagent-classic-nonroot"
+	OAClassicNonRootKey      = FFPrefix + "oneagent-classic-nonroot"
 
 	OANodeImagePullKey = FFPrefix + "node-image-pull"
 	// OANodeImagePullTechnologiesKey can be set on a Pod or DynaKube to configure which code module technologies to download. It's set to
@@ -53,8 +53,8 @@ func (ff *FeatureFlags) IsOneAgentPrivileged() bool {
 	return ff.getBoolWithDefault(OAPrivilegedKey, false)
 }
 
-func (ff *FeatureFlags) IsClassicOneAgentNonroot() bool {
-	return ff.getBoolWithDefault(OAClassicNonrootKey, false)
+func (ff *FeatureFlags) IsClassicOneAgentNonRoot() bool {
+	return ff.getBoolWithDefault(OAClassicNonRootKey, false)
 }
 
 func (ff *FeatureFlags) SkipOneAgentLivenessProbe() bool {

--- a/pkg/api/exp/oneagent_test.go
+++ b/pkg/api/exp/oneagent_test.go
@@ -212,10 +212,10 @@ func TestIsClassicOneAgentNonroot(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
 			ff := FeatureFlags{annotations: map[string]string{
-				OAClassicNonrootKey: c.in,
+				OAClassicNonRootKey: c.in,
 			}}
 
-			out := ff.IsClassicOneAgentNonroot()
+			out := ff.IsClassicOneAgentNonRoot()
 
 			assert.Equal(t, c.out, out)
 		})

--- a/pkg/api/exp/oneagent_test.go
+++ b/pkg/api/exp/oneagent_test.go
@@ -189,6 +189,39 @@ func TestIsOneAgentPrivileged(t *testing.T) {
 	}
 }
 
+func TestIsClassicOneAgentNonroot(t *testing.T) {
+	type testCase struct {
+		title string
+		in    string
+		out   bool
+	}
+
+	cases := []testCase{
+		{
+			title: "default",
+			in:    "",
+			out:   false,
+		},
+		{
+			title: "overrule",
+			in:    "true",
+			out:   true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			ff := FeatureFlags{annotations: map[string]string{
+				OAClassicNonrootKey: c.in,
+			}}
+
+			out := ff.IsClassicOneAgentNonroot()
+
+			assert.Equal(t, c.out, out)
+		})
+	}
+}
+
 func TestSkipOneAgentLivenessProbe(t *testing.T) {
 	type testCase struct {
 		title string

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -21,50 +21,51 @@ const (
 	errorInvalidNoProxy            = "The DynaKube's specification has an invalid value set using the " + exp.NoProxyKey + " annotation. Make sure to remove forbidden characters (newline, tab, carriage return, null) from the value in your custom resource."
 )
 
-var deprecatedFeatureFlags = []string{
-	exp.OAProxyIgnoredKey,   //nolint:staticcheck
-	exp.AGUpdatesKey,        //nolint:staticcheck
-	exp.AGDisableUpdatesKey, //nolint:staticcheck
-	exp.OAMaxUnavailableKey, //nolint:staticcheck
-	exp.AGK8sAppEnabledKey,  //nolint:staticcheck
-}
+var (
+	deprecatedFeatureFlags = []string{
+		// oneagent.go
+		exp.OAProxyIgnoredKey,   //nolint:staticcheck
+		exp.OAMaxUnavailableKey, //nolint:staticcheck
+		// activegate.go
+		exp.AGK8sAppEnabledKey,  //nolint:staticcheck
+		exp.AGUpdatesKey,        //nolint:staticcheck
+		exp.AGDisableUpdatesKey, //nolint:staticcheck
+		exp.AGIgnoreProxyKey,    //nolint:staticcheck
+		// injection.go
+		exp.InjectionSeccompKey, //nolint:staticcheck
+	}
 
-var knownFeatureFlags = []string{
-	// flag.go
-	exp.NoProxyKey,
-	exp.UseEECLegacyMountsKey,
-	exp.UsePublicRegistryKey,
-	// activegate.go
-	exp.AGDisableUpdatesKey, //nolint:staticcheck
-	exp.AGIgnoreProxyKey,    //nolint:staticcheck
-	exp.AGUpdatesKey,        //nolint:staticcheck
-	exp.AGAppArmorKey,
-	exp.AGAutomaticK8sAPIMonitoringKey,
-	exp.AGAutomaticK8sAPIMonitoringClusterNameKey,
-	exp.AGK8sAppEnabledKey, //nolint:staticcheck
-	exp.AGAutomaticTLSCertificateKey,
-	// csi.go
-	exp.CSIMaxFailedMountAttemptsKey,
-	exp.CSIMaxMountTimeoutKey,
-	// enrichment.go
-	exp.EnrichmentEnableAttributesDTKubernetes,
-	// injection.go
-	exp.InjectionIgnoredNamespacesKey,
-	exp.InjectionAutomaticKey,
-	exp.InjectionLabelVersionDetectionKey,
-	exp.InjectionFailurePolicyKey,
-	exp.InjectionSeccompKey, //nolint:staticcheck
-	// oneagent.go
-	exp.OAProxyIgnoredKey,   //nolint:staticcheck
-	exp.OAMaxUnavailableKey, //nolint:staticcheck
-	exp.OAInitialConnectRetryKey,
-	exp.OAPrivilegedKey,
-	exp.OASkipLivenessProbeKey,
-	exp.OANodeImagePullKey,
-	exp.OANodeImagePullTechnologiesKey,
-	// otlp.go
-	exp.OTLPInjectionSetNoProxy,
-}
+	knownFeatureFlags = append([]string{
+		// flag.go
+		exp.NoProxyKey,
+		exp.UseEECLegacyMountsKey,
+		exp.UsePublicRegistryKey,
+		// activegate.go
+		exp.AGAppArmorKey,
+		exp.AGAutomaticK8sAPIMonitoringKey,
+		exp.AGAutomaticK8sAPIMonitoringClusterNameKey,
+		exp.AGAutomaticTLSCertificateKey,
+		// csi.go
+		exp.CSIMaxFailedMountAttemptsKey,
+		exp.CSIMaxMountTimeoutKey,
+		// enrichment.go
+		exp.EnrichmentEnableAttributesDTKubernetes,
+		// injection.go
+		exp.InjectionIgnoredNamespacesKey,
+		exp.InjectionAutomaticKey,
+		exp.InjectionLabelVersionDetectionKey,
+		exp.InjectionFailurePolicyKey,
+		// oneagent.go
+		exp.OAInitialConnectRetryKey,
+		exp.OAPrivilegedKey,
+		exp.OAClassicNonrootKey,
+		exp.OASkipLivenessProbeKey,
+		exp.OANodeImagePullKey,
+		exp.OANodeImagePullTechnologiesKey,
+		// otlp.go
+		exp.OTLPInjectionSetNoProxy,
+	}, deprecatedFeatureFlags...)
+)
 
 func deprecatedFeatureFlag(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {
 	var results []string

--- a/pkg/api/validation/dynakube/featureflag.go
+++ b/pkg/api/validation/dynakube/featureflag.go
@@ -58,7 +58,7 @@ var (
 		// oneagent.go
 		exp.OAInitialConnectRetryKey,
 		exp.OAPrivilegedKey,
-		exp.OAClassicNonrootKey,
+		exp.OAClassicNonRootKey,
 		exp.OASkipLivenessProbeKey,
 		exp.OANodeImagePullKey,
 		exp.OANodeImagePullTechnologiesKey,

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -371,11 +371,11 @@ func (b *builder) securityContext(ctx context.Context) *corev1.SecurityContext {
 	}
 
 	if b.dk.OneAgent().IsReadOnlyFSSupported() {
-		setNonroot(securityContext)
+		setNonRoot(securityContext)
 		securityContext.ReadOnlyRootFilesystem = new(b.isRootFsReadonly(ctx))
 	} else {
-		if b.dk.FF().IsClassicOneAgentNonroot() {
-			setNonroot(securityContext)
+		if b.dk.FF().IsClassicOneAgentNonRoot() {
+			setNonRoot(securityContext)
 		}
 
 		securityContext.ReadOnlyRootFilesystem = new(false)
@@ -400,7 +400,7 @@ func (b *builder) securityContext(ctx context.Context) *corev1.SecurityContext {
 	return securityContext
 }
 
-func setNonroot(sc *corev1.SecurityContext) {
+func setNonRoot(sc *corev1.SecurityContext) {
 	sc.RunAsNonRoot = new(true)
 	sc.RunAsUser = new(userGroupID)
 	sc.RunAsGroup = new(userGroupID)

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -371,11 +371,13 @@ func (b *builder) securityContext(ctx context.Context) *corev1.SecurityContext {
 	}
 
 	if b.dk.OneAgent().IsReadOnlyFSSupported() {
-		securityContext.RunAsNonRoot = new(true)
-		securityContext.RunAsUser = new(userGroupID)
-		securityContext.RunAsGroup = new(userGroupID)
+		setNonroot(securityContext)
 		securityContext.ReadOnlyRootFilesystem = new(b.isRootFsReadonly(ctx))
 	} else {
+		if b.dk.FF().IsClassicOneAgentNonroot() {
+			setNonroot(securityContext)
+		}
+
 		securityContext.ReadOnlyRootFilesystem = new(false)
 	}
 
@@ -396,6 +398,12 @@ func (b *builder) securityContext(ctx context.Context) *corev1.SecurityContext {
 	securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(annotations, containerName)
 
 	return securityContext
+}
+
+func setNonroot(sc *corev1.SecurityContext) {
+	sc.RunAsNonRoot = new(true)
+	sc.RunAsUser = new(userGroupID)
+	sc.RunAsGroup = new(userGroupID)
 }
 
 func defaultSecurityContextCapabilities() *corev1.Capabilities {

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset.go
@@ -366,8 +366,11 @@ func (b *builder) imagePullSecrets() []corev1.LocalObjectReference {
 
 func (b *builder) securityContext(ctx context.Context) *corev1.SecurityContext {
 	securityContext := &corev1.SecurityContext{}
+	if b.dk == nil || b.hostInjectSpec == nil {
+		return securityContext
+	}
 
-	if b.dk != nil && b.dk.OneAgent().IsReadOnlyFSSupported() {
+	if b.dk.OneAgent().IsReadOnlyFSSupported() {
 		securityContext.RunAsNonRoot = new(true)
 		securityContext.RunAsUser = new(userGroupID)
 		securityContext.RunAsGroup = new(userGroupID)
@@ -376,39 +379,21 @@ func (b *builder) securityContext(ctx context.Context) *corev1.SecurityContext {
 		securityContext.ReadOnlyRootFilesystem = new(false)
 	}
 
-	if b.dk != nil && b.dk.OneAgent().IsPrivilegedNeeded() {
+	if b.dk.OneAgent().IsPrivilegedNeeded() {
 		securityContext.Privileged = new(true)
 	} else {
 		securityContext.Capabilities = defaultSecurityContextCapabilities()
 
-		if b.dk != nil {
-			switch {
-			case b.dk.OneAgent().IsHostMonitoringMode() && b.dk.Spec.OneAgent.HostMonitoring.SecCompProfile != "":
-				secCompName := b.dk.Spec.OneAgent.HostMonitoring.SecCompProfile
-				securityContext.SeccompProfile = &corev1.SeccompProfile{
-					Type:             corev1.SeccompProfileTypeLocalhost,
-					LocalhostProfile: &secCompName,
-				}
-			case b.dk.OneAgent().IsClassicFullStackMode() && b.dk.Spec.OneAgent.ClassicFullStack.SecCompProfile != "":
-				secCompName := b.dk.Spec.OneAgent.ClassicFullStack.SecCompProfile
-				securityContext.SeccompProfile = &corev1.SeccompProfile{
-					Type:             corev1.SeccompProfileTypeLocalhost,
-					LocalhostProfile: &secCompName,
-				}
-			case b.dk.OneAgent().IsCloudNativeFullstackMode() && b.dk.Spec.OneAgent.CloudNativeFullStack.SecCompProfile != "":
-				secCompName := b.dk.Spec.OneAgent.CloudNativeFullStack.SecCompProfile
-				securityContext.SeccompProfile = &corev1.SeccompProfile{
-					Type:             corev1.SeccompProfileTypeLocalhost,
-					LocalhostProfile: &secCompName,
-				}
+		if secompName := b.dk.OneAgent().GetSecCompProfile(); secompName != "" {
+			securityContext.SeccompProfile = &corev1.SeccompProfile{
+				Type:             corev1.SeccompProfileTypeLocalhost,
+				LocalhostProfile: &secompName,
 			}
 		}
 	}
 
-	if b.hostInjectSpec != nil {
-		annotations := maputils.MergeMap(map[string]string{appArmorAnnotation: appArmorUnconfined}, b.hostInjectSpec.Annotations)
-		securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(annotations, containerName)
-	}
+	annotations := maputils.MergeMap(map[string]string{appArmorAnnotation: appArmorUnconfined}, b.hostInjectSpec.Annotations)
+	securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(annotations, containerName)
 
 	return securityContext
 }

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -265,11 +265,13 @@ func TestSecurityContextCapabilities(t *testing.T) {
 func TestHostMonitoring_SecurityContext(t *testing.T) {
 	t.Cleanup(k8sversion.DisableCacheForTest(123))
 
-	t.Run("returns default context if instance is nil", func(t *testing.T) {
+	t.Run("returns empty context if dk or hostInjectSpec is nil", func(t *testing.T) {
 		dsBuilder := builder{}
 		securityContext := dsBuilder.securityContext(t.Context())
 
-		assert.Equal(t, defaultSecurityContextCapabilities(), securityContext.Capabilities)
+		assert.Nil(t, securityContext.Capabilities)
+		assert.Nil(t, securityContext.Privileged)
+		assert.Nil(t, securityContext.RunAsUser)
 	})
 	t.Run("User and group id set when read only mode is enabled", func(t *testing.T) {
 		dk := dynakube.DynaKube{
@@ -385,6 +387,35 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		assert.Equal(t, new(true), securityContext.Privileged)
 		assert.Empty(t, securityContext.Capabilities)
 		assert.Nil(t, securityContext.SeccompProfile)
+	})
+
+	t.Run("nonroot security context when classic nonroot feature flag is enabled", func(t *testing.T) {
+		dk := dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					exp.OAClassicNonrootKey: "true",
+				},
+			},
+			Spec: dynakube.DynaKubeSpec{
+				APIURL: testURL,
+				OneAgent: oneagent.Spec{
+					ClassicFullStack: &oneagent.HostInjectSpec{},
+				},
+			},
+		}
+		dsBuilder := NewClassicFullStack(&dk, testClusterID)
+		ds, err := dsBuilder.BuildDaemonSet(t.Context())
+		require.NoError(t, err)
+
+		securityContext := ds.Spec.Template.Spec.Containers[0].SecurityContext
+
+		assert.NotNil(t, securityContext)
+		assert.Equal(t, new(true), securityContext.RunAsNonRoot)
+		assert.Equal(t, new(userGroupID), securityContext.RunAsUser)
+		assert.Equal(t, new(userGroupID), securityContext.RunAsGroup)
+		require.NotNil(t, securityContext.ReadOnlyRootFilesystem)
+		assert.False(t, *securityContext.ReadOnlyRootFilesystem)
+		assert.Nil(t, securityContext.Privileged)
 	})
 
 	t.Run("privileged security context when feature flag is enabled for classic fullstack", func(t *testing.T) {

--- a/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/daemonset_test.go
@@ -393,7 +393,7 @@ func TestHostMonitoring_SecurityContext(t *testing.T) {
 		dk := dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					exp.OAClassicNonrootKey: "true",
+					exp.OAClassicNonRootKey: "true",
 				},
 			},
 			Spec: dynakube.DynaKubeSpec{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-8013](https://dt-rnd.atlassian.net/browse/ICP-8013)

Adds a new opt-in FF: `feature.dynatrace.com/oneagent-classic-nonroot`
- Makes the Classic OA DaemonSet use the same user/group as a CloudNative OA DaemonSet.

(+) some cleanup in touched code

## How can this be tested?

> [!NOTE]
>  1. Make sure you have a phase1/phase2 tenant so it has a tenant registry.
> 2. If you use GKE to test, make sure the host OS is ubuntu, it won't work otherwise. 

Minimal dynakube:
```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: marcell-dev-ubuntu
  namespace: dynatrace
  annotations:
   feature.dynatrace.com/oneagent-classic-nonroot: "true"
spec:
  apiUrl: https://tec31546.dev.dynatracelabs.com/api
  oneAgent:
    classicFullStack:
        env:
        - name: ONEAGENT_ENABLE_VOLUME_STORAGE
          value: "true"
```

Check that the `runAs...` is 1000 and that `runAsNonRoot: true`

[ICP-8013]: https://dt-rnd.atlassian.net/browse/ICP-8013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ