### PR TITLE
Set GOMEMLIMIT for targetallocator

### DIFF
--- a/pkg/controllers/dtprometheus/targetallocator/reconciler.go
+++ b/pkg/controllers/dtprometheus/targetallocator/reconciler.go
@@ -347,7 +347,7 @@ func buildContainer(spec *dtprometheus.TargetAllocator, namespace string, curren
 			{Name: configVolume, MountPath: "/conf", ReadOnly: true},
 			// TODO: TLS volume
 		},
-		Env:       k8senv.AppendMemoryLimit([]corev1.EnvVar{{Name: "OTELCOL_NAMESPACE", Value: namespace}}, spec.Resources),
+		Env:       k8senv.AppendGoMemoryLimit([]corev1.EnvVar{{Name: "OTELCOL_NAMESPACE", Value: namespace}}, spec.Resources),
 		Resources: spec.Resources,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged:               new(false),

--- a/pkg/controllers/dtprometheus/targetallocator/reconciler.go
+++ b/pkg/controllers/dtprometheus/targetallocator/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/dtprometheus"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sdeployment"
@@ -346,9 +347,7 @@ func buildContainer(spec *dtprometheus.TargetAllocator, namespace string, curren
 			{Name: configVolume, MountPath: "/conf", ReadOnly: true},
 			// TODO: TLS volume
 		},
-		Env: []corev1.EnvVar{
-			{Name: "OTELCOL_NAMESPACE", Value: namespace},
-		},
+		Env:       k8senv.AppendMemoryLimit([]corev1.EnvVar{{Name: "OTELCOL_NAMESPACE", Value: namespace}}, spec.Resources),
 		Resources: spec.Resources,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged:               new(false),

--- a/pkg/controllers/dtprometheus/targetallocator/reconciler_test.go
+++ b/pkg/controllers/dtprometheus/targetallocator/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,7 +34,23 @@ import (
 )
 
 func newTestDTP(name, namespace string) *dtprometheus.DTPrometheus {
-	return &dtprometheus.DTPrometheus{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID("dtp-uid")}}
+	return &dtprometheus.DTPrometheus{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID("dtp-uid")},
+		Spec: dtprometheus.DTPrometheusSpec{
+			TargetAllocator: dtprometheus.TargetAllocatorSpec{
+				PodSpec: dtprometheus.PodSpec{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("250Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("125Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // assertGolden compares obj, marshaled to YAML, against testdata/name. The fake

--- a/pkg/controllers/dtprometheus/targetallocator/testdata/deployment.yaml
+++ b/pkg/controllers/dtprometheus/targetallocator/testdata/deployment.yaml
@@ -40,6 +40,8 @@ spec:
       - env:
         - name: OTELCOL_NAMESPACE
           value: dynatrace
+        - name: GOMEMLIMIT
+          value: "235929600"
         image: registry.example.com/target-allocator:1.2.3
         imagePullPolicy: Always
         livenessProbe:
@@ -64,7 +66,11 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources: {}
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            memory: 125Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/util/kubernetes/fields/k8senv/env.go
+++ b/pkg/util/kubernetes/fields/k8senv/env.go
@@ -272,8 +272,8 @@ func GetMetadaSizeLimit(ctx context.Context) int {
 	return value
 }
 
-// AppendMemoryLimit appends GOMEMLIMIT env var
-func AppendMemoryLimit(envs []corev1.EnvVar, resources corev1.ResourceRequirements) []corev1.EnvVar {
+// AppendGoMemoryLimit appends GOMEMLIMIT env var
+func AppendGoMemoryLimit(envs []corev1.EnvVar, resources corev1.ResourceRequirements) []corev1.EnvVar {
 	if memLimit := resources.Limits.Memory(); !memLimit.IsZero() {
 		gomemlimit := memLimit.Value() / 10 * 9 //nolint:mnd // 90%
 		envs = append(envs, corev1.EnvVar{Name: "GOMEMLIMIT", Value: strconv.FormatInt(gomemlimit, 10)})

--- a/pkg/util/kubernetes/fields/k8senv/env.go
+++ b/pkg/util/kubernetes/fields/k8senv/env.go
@@ -271,3 +271,13 @@ func GetMetadaSizeLimit(ctx context.Context) int {
 
 	return value
 }
+
+// AppendMemoryLimit appends GOMEMLIMIT env var
+func AppendMemoryLimit(envs []corev1.EnvVar, resources corev1.ResourceRequirements) []corev1.EnvVar {
+	if memLimit := resources.Limits.Memory(); !memLimit.IsZero() {
+		gomemlimit := memLimit.Value() / 10 * 9 //nolint:mnd // 90%
+		envs = append(envs, corev1.EnvVar{Name: "GOMEMLIMIT", Value: strconv.FormatInt(gomemlimit, 10)})
+	}
+
+	return envs
+}

--- a/pkg/util/kubernetes/fields/k8senv/env_test.go
+++ b/pkg/util/kubernetes/fields/k8senv/env_test.go
@@ -387,7 +387,7 @@ func TestAppendMemoryLimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AppendMemoryLimit(tt.envs, tt.resources)
+			got := AppendGoMemoryLimit(tt.envs, tt.resources)
 			assert.Equal(t, tt.expect, got)
 		})
 	}

--- a/pkg/util/kubernetes/fields/k8senv/env_test.go
+++ b/pkg/util/kubernetes/fields/k8senv/env_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -361,6 +362,32 @@ func TestGetDTExtractCodeModulesImageLinks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(DTExtractCodeModulesImageLinksEnvVar, tt.env)
 			got := GetDTExtractCodeModulesImageLinks(t.Context())
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func TestAppendMemoryLimit(t *testing.T) {
+	memoryLimit := func(quantity string) corev1.ResourceRequirements {
+		return corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(quantity)},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		envs      []corev1.EnvVar
+		resources corev1.ResourceRequirements
+		expect    []corev1.EnvVar
+	}{
+		{"no resources", nil, corev1.ResourceRequirements{}, nil},
+		{"zero memory limit", nil, memoryLimit("0"), nil},
+		{"binary memory limit", []corev1.EnvVar{{Name: "a"}}, memoryLimit("512Mi"), []corev1.EnvVar{{Name: "a"}, {Name: "GOMEMLIMIT", Value: "483183819"}}},
+		{"decimal memory limit", []corev1.EnvVar{{Name: "a"}}, memoryLimit("100M"), []corev1.EnvVar{{Name: "a"}, {Name: "GOMEMLIMIT", Value: "90000000"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AppendMemoryLimit(tt.envs, tt.resources)
 			assert.Equal(t, tt.expect, got)
 		})
 	}


### PR DESCRIPTION
## Description

Implement leftover AC for targetallocator. All DTPromtheus deployed workloads should set the GOMEMLIMIT value to 90% of the memory limit (if it is configured).

ICP-8189

## How can this be tested?

Deploy targetallocator and play around with the resource values
