### PR TITLE
Set DTPrometeus phase on DynaKube deletion

### DIFF
--- a/pkg/controllers/dtprometheus/reconciler.go
+++ b/pkg/controllers/dtprometheus/reconciler.go
@@ -5,6 +5,7 @@ package dtprometheus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -28,6 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var (
+	errDynaKubeNotFound = errors.New("dynakube not found")
+	errDynaKubeNotReady = errors.New("dynakube not ready")
 )
 
 func Add(mgr manager.Manager, _ string) error {
@@ -93,13 +99,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 
 		log.Info("skipping reconcile due to missing DynaKube")
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, errDynaKubeNotFound
 	}
 
 	if dk.Status.Phase != status.Running {
 		log.Info("skipping reconcile due to pending DynaKube", "phase", dk.Status.Phase)
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, errDynaKubeNotReady
 	}
 
 	dtClient, err := r.buildDynatraceClient(ctx, dk)
@@ -139,6 +145,22 @@ func (r *Reconciler) buildDynatraceClient(ctx context.Context, dk *dynakube.Dyna
 //   - Reconciliation ongoing: condition status False/Unknown and reason Reconciling
 //   - Reconciliation failed: anything that does not fit the above
 func setPhase(dtp *dtprometheus.DTPrometheus, err error) error {
+	if errors.Is(errDynaKubeNotFound, err) {
+		if len(dtp.Status.Conditions) == 0 {
+			dtp.Status.Phase = status.Deploying
+		} else {
+			dtp.Status.Phase = status.Error
+		}
+
+		return nil
+	}
+
+	if errors.Is(errDynaKubeNotReady, err) {
+		dtp.Status.Phase = status.Deploying
+
+		return nil
+	}
+
 	if len(dtp.Status.Conditions) == 0 {
 		if err != nil {
 			dtp.Status.Phase = status.Error
@@ -237,7 +259,7 @@ func newDynaKubePhaseChangedPredicate() predicate.Funcs {
 			return false
 		},
 		DeleteFunc: func(event.TypedDeleteEvent[client.Object]) bool {
-			return false
+			return true
 		},
 		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
 			oldDK, _ := e.ObjectOld.(*dynakube.DynaKube)

--- a/pkg/controllers/dtprometheus/reconciler_integration_test.go
+++ b/pkg/controllers/dtprometheus/reconciler_integration_test.go
@@ -215,4 +215,20 @@ func TestSetupWithManager(t *testing.T) {
 			integrationtests.CreateDynakube(t, t.Context(), clt, unreferencedDK)
 		})
 	})
+
+	t.Run("DynaKube deletion triggers reconcile", func(t *testing.T) {
+		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-delete", "dk-delete")
+
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: "https://dummy.dynatrace.com/api"},
+			Status:     dynakube.DynaKubeStatus{Phase: status.Running},
+		}
+
+		integrationtests.CreateDynakube(t, t.Context(), clt, dk)
+
+		assertReconcileTriggered(t, key, func() {
+			require.NoError(t, clt.Delete(t.Context(), dk))
+		})
+	})
 }

--- a/pkg/controllers/dtprometheus/reconciler_test.go
+++ b/pkg/controllers/dtprometheus/reconciler_test.go
@@ -152,38 +152,16 @@ func Test_setPhase(t *testing.T) {
 		expectedPhase status.DeploymentPhase
 		expectedErr   error
 	}{
-		{
-			name:          "generic error without conditions",
-			err:           boom,
-			expectedPhase: status.Error,
-			expectedErr:   boom,
-		},
-		{
-			name:          "no error without conditions",
-			expectedPhase: status.Deploying,
-		},
-		{
-			name:          "no error with all conditions true",
-			conditions:    []metav1.Condition{conditionTrue, conditionTrue, conditionTrue},
-			expectedPhase: status.Running,
-		},
-		{
-			name:          "no error with reconciling condition",
-			conditions:    []metav1.Condition{conditionTrue, conditionReconciling, conditionTrue},
-			expectedPhase: status.Deploying,
-		},
-		{
-			name:          "error condition has highest precedence",
-			conditions:    []metav1.Condition{conditionTrue, conditionReconciling, conditionError},
-			expectedPhase: status.Error,
-		},
-		{
-			name:          "generic error alongside healthy conditions preserves both the error and the running phase",
-			err:           boom,
-			conditions:    []metav1.Condition{conditionTrue},
-			expectedPhase: status.Error,
-			expectedErr:   boom,
-		},
+		{"missing dynakube on creation", errDynaKubeNotFound, nil, status.Deploying, nil},
+		{"missing dynakube after creation", errDynaKubeNotFound, []metav1.Condition{conditionTrue}, status.Error, nil},
+		{"not ready dynakube on creation", errDynaKubeNotReady, nil, status.Deploying, nil},
+		{"not ready dynakube after creation", errDynaKubeNotReady, []metav1.Condition{conditionTrue}, status.Deploying, nil},
+		{"generic error without conditions", boom, nil, status.Error, boom},
+		{"no error without conditions", nil, nil, status.Deploying, nil},
+		{"no error with all conditions true", nil, []metav1.Condition{conditionTrue, conditionTrue, conditionTrue}, status.Running, nil},
+		{"no error with reconciling condition", nil, []metav1.Condition{conditionTrue, conditionReconciling, conditionTrue}, status.Deploying, nil},
+		{"error condition has highest precedence", nil, []metav1.Condition{conditionTrue, conditionReconciling, conditionError}, status.Error, nil},
+		{"generic error alongside healthy conditions preserves both the error and the running phase", boom, []metav1.Condition{conditionTrue}, status.Error, boom},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

The DTPrometheus reconciler only watches for DynaKube phase changes, so a deletion usually won't trigger a reconcile.
Also fixed the phase calculation to account for missing DynaKube after everything was ready.

ICP-7433

## How can this be tested?

Deploy a DK and DTP, then delete the DK -> phase error
Create the DK again -> phase running
