### PR TITLE
Allow classic+custom-image when public-registry feature is used

### DIFF
--- a/pkg/api/validation/dynakube/public_registry.go
+++ b/pkg/api/validation/dynakube/public_registry.go
@@ -39,7 +39,7 @@ func publicRegistryFlagIgnoredForPlatformToken(ctx context.Context, dv *Validato
 }
 
 func publicRegistryNotAllowedForClassic(ctx context.Context, dv *Validator, dk *dynakube.DynaKube) string {
-	if !dk.OneAgent().IsClassicFullStackMode() {
+	if !dk.OneAgent().IsClassicFullStackMode() || dk.OneAgent().GetCustomImage() != "" {
 		return ""
 	}
 

--- a/pkg/api/validation/dynakube/public_registry_test.go
+++ b/pkg/api/validation/dynakube/public_registry_test.go
@@ -121,6 +121,21 @@ func TestPublicRegistryNotAllowedForClassic(t *testing.T) {
 		dk := newClassicDynakube()
 		assertAllowedWithoutWarnings(t, dk)
 	})
+
+	t.Run("classic mode with custom image and use-public-registry FF returns no error", func(t *testing.T) {
+		dk := newClassicDynakube()
+		dk.Spec.OneAgent.ClassicFullStack.Image = "my.custom.image.com/agent:latest"
+		dk.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+
+		assertAllowedWithoutWarnings(t, dk)
+	})
+
+	t.Run("classic mode with custom image and platform token returns no error", func(t *testing.T) {
+		dk := newClassicDynakube()
+		dk.Spec.OneAgent.ClassicFullStack.Image = "my.custom.image.com/agent:latest"
+
+		assertAllowedWithoutWarnings(t, dk, platformTokenSecret())
+	})
 }
 
 func TestPublicRegistryFlagIgnoredForPlatformToken(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

https://dt-rnd.atlassian.net/browse/ICP-8902

If somehow the user has a `image` and `classicFullstack` set, we will let it through.

## How can this be tested?

Sample DK:
```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  annotations:
    feature.dynatrace.com/use-public-registry: "true" # or platform token
spec:
  apiUrl: https://hvs0985d.dev.dynatracelabs.com/api
  oneAgent:
    classicFullStack:
      image: docker.io/dynatrace/oneagent:latest
      env:
       - name: ONEAGENT_ENABLE_VOLUME_STORAGE # only because of GKE
          value: "true"
      - name: ONEAGENT_INSTALLER_SCRIPT_URL
         value: https://hvs0985d.dev.dynatracelabs.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86
      - name: ONEAGENT_INSTALLER_DOWNLOAD_TOKEN
         value: <your token>
```

this should pass validation (if you remove the `image` it should get blocked)