### PR TITLE
ICP-8542: support multiple pull-secrets in troubleshoot command

### DIFF
--- a/cmd/troubleshoot/cmd.go
+++ b/cmd/troubleshoot/cmd.go
@@ -121,7 +121,7 @@ func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader cl
 	logNewCheckf(log, "checking if '%s:%s' Dynakube is configured correctly", dk.Namespace, dk.Name)
 	logInfof(log, "using '%s:%s' Dynakube", dk.Namespace, dk.Name)
 
-	pullSecret, err := checkDynakube(ctx, baseLog, apiReader, &dk)
+	err := checkDynakube(ctx, baseLog, apiReader, &dk)
 	if err != nil {
 		return errors.Wrapf(err, "'%s:%s' Dynakube isn't valid. %s",
 			dk.Namespace, dk.Name, dynakubeNotValidMessage())
@@ -129,7 +129,7 @@ func runChecksForDynakube(ctx context.Context, baseLog logd.Logger, apiReader cl
 
 	logOkf(log, "'%s:%s' Dynakube is valid", dk.Namespace, dk.Name)
 
-	keychain, err := dockerkeychain.NewDockerKeychain(ctx, apiReader, pullSecret)
+	keychain, err := dockerkeychain.NewDockerKeychains(ctx, apiReader, dk.Namespace, dk.PullSecretNames())
 	if err != nil {
 		return err
 	}

--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -29,33 +29,34 @@ const (
 
 const dynakubeCheckLoggerName = "dynakube"
 
-func checkDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) (corev1.Secret, error) {
+func checkDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) error {
 	dynatraceAPISecretTokens, err := checkIfDynatraceAPISecretHasAPIToken(ctx, baseLog, apiReader, dk)
 	if err != nil {
-		return corev1.Secret{}, err
+		return err
 	}
 
 	err = checkDynatraceAPITokenScopes(ctx, baseLog, apiReader, dynatraceAPISecretTokens, dk)
 	if err != nil {
-		return corev1.Secret{}, err
+		return err
 	}
 
 	err = checkAPIURLForLatestAgentVersion(ctx, baseLog, apiReader, dk, dynatraceAPISecretTokens)
 	if err != nil {
-		return corev1.Secret{}, err
+		return err
 	}
 
-	pullSecret, err := checkPullSecretExists(ctx, baseLog, apiReader, dk)
+	pullSecrets, err := checkPullSecretExists(ctx, baseLog, apiReader, dk)
 	if err != nil {
-		return corev1.Secret{}, err
+		return err
 	}
 
-	err = checkPullSecretHasRequiredTokens(baseLog, dk, pullSecret)
-	if err != nil {
-		return corev1.Secret{}, err
+	for _, pullSecret := range pullSecrets {
+		if err = checkPullSecretHasRequiredTokens(baseLog, pullSecret); err != nil {
+			return err
+		}
 	}
 
-	return pullSecret, nil
+	return nil
 }
 
 func getSelectedDynakube(ctx context.Context, apiReader client.Reader, namespaceName, dynakubeName string) (dynakube.DynaKube, error) {
@@ -180,26 +181,32 @@ func checkAPIURLForLatestAgentVersion(ctx context.Context, baseLog logd.Logger, 
 	return nil
 }
 
-func checkPullSecretExists(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) (corev1.Secret, error) {
+func checkPullSecretExists(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) ([]corev1.Secret, error) {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
 	query := k8ssecret.Query(nil, apiReader)
 
-	pullSecret, err := query.Get(ctx, types.NamespacedName{Namespace: dk.Namespace, Name: dk.PullSecretName()})
-	if err != nil {
-		return corev1.Secret{}, errors.Wrapf(err, "'%s:%s' pull secret is missing", dk.Namespace, dk.PullSecretName())
+	var secrets []corev1.Secret
+
+	for _, name := range dk.PullSecretNames() {
+		pullSecret, err := query.Get(ctx, types.NamespacedName{Namespace: dk.Namespace, Name: name})
+		if err != nil {
+			return nil, errors.Wrapf(err, "'%s:%s' pull secret is missing", dk.Namespace, name)
+		}
+
+		logInfof(log, "pull secret '%s:%s' exists", dk.Namespace, name)
+
+		secrets = append(secrets, *pullSecret)
 	}
 
-	logInfof(log, "pull secret '%s:%s' exists", dk.Namespace, dk.PullSecretName())
-
-	return *pullSecret, nil
+	return secrets, nil
 }
 
-func checkPullSecretHasRequiredTokens(baseLog logd.Logger, dk *dynakube.DynaKube, pullSecret corev1.Secret) error {
+func checkPullSecretHasRequiredTokens(baseLog logd.Logger, pullSecret corev1.Secret) error {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
 	if _, err := k8ssecret.ExtractToken(&pullSecret, dtpullsecret.DockerConfigJSON); err != nil {
-		return errors.Wrapf(err, "invalid '%s:%s' secret", dk.Namespace, dk.PullSecretName())
+		return errors.Wrapf(err, "invalid '%s:%s' secret", pullSecret.Namespace, pullSecret.Name)
 	}
 
 	logInfof(log, "secret token '%s' exists", dtpullsecret.DockerConfigJSON)

--- a/cmd/troubleshoot/dynakube.go
+++ b/cmd/troubleshoot/dynakube.go
@@ -45,7 +45,7 @@ func checkDynakube(ctx context.Context, baseLog logd.Logger, apiReader client.Re
 		return err
 	}
 
-	pullSecrets, err := checkPullSecretExists(ctx, baseLog, apiReader, dk)
+	pullSecrets, err := checkPullSecretsExist(ctx, baseLog, apiReader, dk)
 	if err != nil {
 		return err
 	}
@@ -181,12 +181,12 @@ func checkAPIURLForLatestAgentVersion(ctx context.Context, baseLog logd.Logger, 
 	return nil
 }
 
-func checkPullSecretExists(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) ([]corev1.Secret, error) {
+func checkPullSecretsExist(ctx context.Context, baseLog logd.Logger, apiReader client.Reader, dk *dynakube.DynaKube) ([]*corev1.Secret, error) {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
 	query := k8ssecret.Query(nil, apiReader)
 
-	var secrets []corev1.Secret
+	var secrets []*corev1.Secret
 
 	for _, name := range dk.PullSecretNames() {
 		pullSecret, err := query.Get(ctx, types.NamespacedName{Namespace: dk.Namespace, Name: name})
@@ -196,16 +196,16 @@ func checkPullSecretExists(ctx context.Context, baseLog logd.Logger, apiReader c
 
 		logInfof(log, "pull secret '%s:%s' exists", dk.Namespace, name)
 
-		secrets = append(secrets, *pullSecret)
+		secrets = append(secrets, pullSecret)
 	}
 
 	return secrets, nil
 }
 
-func checkPullSecretHasRequiredTokens(baseLog logd.Logger, pullSecret corev1.Secret) error {
+func checkPullSecretHasRequiredTokens(baseLog logd.Logger, pullSecret *corev1.Secret) error {
 	log := baseLog.WithName(dynakubeCheckLoggerName)
 
-	if _, err := k8ssecret.ExtractToken(&pullSecret, dtpullsecret.DockerConfigJSON); err != nil {
+	if _, err := k8ssecret.ExtractToken(pullSecret, dtpullsecret.DockerConfigJSON); err != nil {
 		return errors.Wrapf(err, "invalid '%s:%s' secret", pullSecret.Namespace, pullSecret.Name)
 	}
 

--- a/cmd/troubleshoot/dynakube_test.go
+++ b/cmd/troubleshoot/dynakube_test.go
@@ -152,7 +152,7 @@ func TestPullSecret(t *testing.T) {
 			).
 			Build()
 
-		_, err := checkPullSecretExists(t.Context(), getNullLogger(t), clt, dk)
+		_, err := checkPullSecretsExist(t.Context(), getNullLogger(t), clt, dk)
 		require.NoErrorf(t, err, "custom pull secret not found")
 	})
 	t.Run("custom pull secret does not exist", func(t *testing.T) {
@@ -165,14 +165,14 @@ func TestPullSecret(t *testing.T) {
 			).
 			Build()
 
-		_, err := checkPullSecretExists(t.Context(), getNullLogger(t), clt, dk)
+		_, err := checkPullSecretsExist(t.Context(), getNullLogger(t), clt, dk)
 		require.Errorf(t, err, "custom pull secret found")
 	})
 	t.Run("custom pull secret has required tokens", func(t *testing.T) {
-		require.NoErrorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), *testNewSecretBuilder(testNamespace, testSecretName).dataAppend(".dockerconfigjson", testCustomPullSecretToken).build()), "custom pull secret does not have required tokens")
+		require.NoErrorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), testNewSecretBuilder(testNamespace, testSecretName).dataAppend(".dockerconfigjson", testCustomPullSecretToken).build()), "custom pull secret does not have required tokens")
 	})
 	t.Run("custom pull secret does not have required tokens", func(t *testing.T) {
-		require.Errorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), *testNewSecretBuilder(testNamespace, testSecretName).build()), "custom pull secret has required tokens")
+		require.Errorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), testNewSecretBuilder(testNamespace, testSecretName).build()), "custom pull secret has required tokens")
 	})
 }
 

--- a/cmd/troubleshoot/dynakube_test.go
+++ b/cmd/troubleshoot/dynakube_test.go
@@ -148,6 +148,7 @@ func TestPullSecret(t *testing.T) {
 				dk,
 				testBuildNamespace(testNamespace),
 				testNewSecretBuilder(testNamespace, testSecretName).build(),
+				testNewSecretBuilder(testNamespace, testDynakube+dynakube.PullSecretSuffix).build(),
 			).
 			Build()
 
@@ -168,10 +169,10 @@ func TestPullSecret(t *testing.T) {
 		require.Errorf(t, err, "custom pull secret found")
 	})
 	t.Run("custom pull secret has required tokens", func(t *testing.T) {
-		require.NoErrorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), nil, *testNewSecretBuilder(testNamespace, testSecretName).dataAppend(".dockerconfigjson", testCustomPullSecretToken).build()), "custom pull secret does not have required tokens")
+		require.NoErrorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), *testNewSecretBuilder(testNamespace, testSecretName).dataAppend(".dockerconfigjson", testCustomPullSecretToken).build()), "custom pull secret does not have required tokens")
 	})
 	t.Run("custom pull secret does not have required tokens", func(t *testing.T) {
-		require.Errorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), &dynakube.DynaKube{}, *testNewSecretBuilder(testNamespace, testSecretName).build()), "custom pull secret has required tokens")
+		require.Errorf(t, checkPullSecretHasRequiredTokens(getNullLogger(t), *testNewSecretBuilder(testNamespace, testSecretName).build()), "custom pull secret has required tokens")
 	})
 }
 

--- a/cmd/troubleshoot/image_test.go
+++ b/cmd/troubleshoot/image_test.go
@@ -172,8 +172,8 @@ func TestImagePullable(t *testing.T) {
 			logOutput := runWithTestLogger(func(log logd.Logger) {
 				ctx := t.Context()
 				clt := fake.NewClient(secret)
-				pullSecret, _ := checkDynakube(ctx, log, clt, test.dk)
-				keychain, _ := dockerkeychain.NewDockerKeychain(t.Context(), fake.NewClient(secret), pullSecret)
+				_ = checkDynakube(ctx, log, clt, test.dk)
+				keychain, _ := dockerkeychain.NewDockerKeychains(t.Context(), fake.NewClient(secret), test.dk.Namespace, test.dk.PullSecretNames())
 
 				transport, _ := createTransport(ctx, clt, test.dk, dockerServer.Client())
 				pullImage := CreateImagePullFunc(ctx, keychain, transport)
@@ -264,8 +264,8 @@ func TestImageNotPullable(t *testing.T) {
 			logOutput := runWithTestLogger(func(log logd.Logger) {
 				ctx := t.Context()
 				clt := fake.NewClient(secret)
-				pullSecret, _ := checkDynakube(ctx, log, clt, test.dk)
-				keychain, _ := dockerkeychain.NewDockerKeychain(t.Context(), fake.NewClient(secret), pullSecret)
+				_ = checkDynakube(ctx, log, clt, test.dk)
+				keychain, _ := dockerkeychain.NewDockerKeychains(t.Context(), fake.NewClient(secret), test.dk.Namespace, test.dk.PullSecretNames())
 
 				transport, _ := createTransport(ctx, clt, test.dk, dockerServer.Client())
 				pullImage := CreateImagePullFunc(ctx, keychain, transport)
@@ -304,8 +304,8 @@ func TestOneAgentCodeModulesImageNotPullable(t *testing.T) {
 		logOutput := runWithTestLogger(func(log logd.Logger) {
 			ctx := t.Context()
 			clt := fake.NewClient(secret)
-			pullSecret, _ := checkDynakube(ctx, log, clt, &dk)
-			keychain, _ := dockerkeychain.NewDockerKeychain(t.Context(), fake.NewClient(secret), pullSecret)
+			_ = checkDynakube(ctx, log, clt, &dk)
+			keychain, _ := dockerkeychain.NewDockerKeychains(t.Context(), fake.NewClient(secret), dk.Namespace, dk.PullSecretNames())
 
 			transport, _ := createTransport(ctx, clt, &dk, dockerServer.Client())
 			pullImage := CreateImagePullFunc(ctx, keychain, transport)
@@ -325,8 +325,8 @@ func TestOneAgentCodeModulesImageNotPullable(t *testing.T) {
 		logOutput := runWithTestLogger(func(log logd.Logger) {
 			ctx := t.Context()
 			clt := fake.NewClient(secret)
-			pullSecret, _ := checkDynakube(ctx, log, clt, &dk)
-			keychain, _ := dockerkeychain.NewDockerKeychain(t.Context(), fake.NewClient(secret), pullSecret)
+			_ = checkDynakube(ctx, log, clt, &dk)
+			keychain, _ := dockerkeychain.NewDockerKeychains(t.Context(), fake.NewClient(secret), dk.Namespace, dk.PullSecretNames())
 			transport, _ := createTransport(ctx, clt, &dk, dockerServer.Client())
 			pullImage := CreateImagePullFunc(ctx, keychain, transport)
 			verifyImageIsAvailable(log, pullImage, &dk, componentCodeModules, false)

--- a/pkg/util/oci/dockerkeychain/docker_keychain.go
+++ b/pkg/util/oci/dockerkeychain/docker_keychain.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"maps"
+	"slices"
 	"sync"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -61,7 +62,7 @@ func NewDockerKeychains(ctx context.Context, apiReader client.Reader, namespaceN
 
 	if len(configFile.AuthConfigs) > 0 {
 		keychain.dockerConfig = &configFile
-		log.Debug("loaded docker configs", "registries", maps.Keys(configFile.AuthConfigs))
+		log.Debug("loaded docker configs", "registries", slices.Collect(maps.Keys(configFile.AuthConfigs)))
 	} else {
 		log.Debug("no docker configs found")
 	}


### PR DESCRIPTION
## Description

Previously the troubleshoot command only respected `customPullSecret` (when configured) and didn't fall back or combine with alternative secrets in the namespace. Which caused a 401 error. 

This was previously fixed for other parts of the product. Used the then-built function for the troubleshoot command to respect 1 or many relevant secret(s). 

## How can this be tested?

1. Create a classic API token (platform will not work) for your tenant
2. Create the valid token in your cluster:
```
kubectl create secret generic classic-token-secret -n dynatrace \
  --from-literal=apiToken=<your-api-token>
```
3. Create a fake `customPullSecret`:
```
kubectl create secret docker-registry my-fake-acr -n dynatrace \
  --docker-server=some.domain.com \
  --docker-username=fake \
  --docker-password=fake
```
4. Create a minimal Dynakube that specifies my-fake-acr as the `customPullSecret`
5. After reconciliation run the troubleshoot command and verify the output:
```
kubectl -n dynatrace exec deploy/dynatrace-operator -- \
  /usr/local/bin/dynatrace-operator troubleshoot -n dynatrace \
  --dynakube minimal-dynakube
```
6. In the output you can now see that both secrets are recognized:
```
[dynakube  ]        pull secret 'dynatrace:classic-token-secret' exists
[dynakube  ]        pull secret 'dynatrace:my-fake-acr' exists
```