### PR TITLE
Fix kubemon KSPM e2e test

### DIFF
--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -57,7 +57,6 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 		false,
 		helm.WithArgs("--reuse-values"),
 		helm.WithArgs("--set", "experimental.enableKubemonOperand=true"),
-		helm.WithArgs("--wait"),
 	), true))
 
 	options := []componentDynakube.Option{
@@ -79,7 +78,6 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 		false,
 		helm.WithArgs("--reuse-values"),
 		helm.WithArgs("--set", "experimental.enableKubemonOperand=false"),
-		helm.WithArgs("--wait"),
 	), false))
 
 	return builder.Feature()

--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -57,6 +57,7 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 		false,
 		helm.WithArgs("--reuse-values"),
 		helm.WithArgs("--set", "experimental.enableKubemonOperand=true"),
+		helm.WithArgs("--wait"),
 	), true))
 
 	options := []componentDynakube.Option{
@@ -78,6 +79,7 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 		false,
 		helm.WithArgs("--reuse-values"),
 		helm.WithArgs("--set", "experimental.enableKubemonOperand=false"),
+		helm.WithArgs("--wait"),
 	), false))
 
 	return builder.Feature()

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -227,7 +227,7 @@ func getHelmOptions(releaseTag, platform string, withCSI bool) ([]helm.Option, e
 		helm.WithNamespace("dynatrace"),
 		helm.WithArgs("--create-namespace"),
 		helm.WithArgs("--install"),
-		helm.WithArgs("--wait"),
+		helm.WithArgs("--rollback-on-failure"),
 		helm.WithArgs("--set", fmt.Sprintf("platform=%s", platform)),
 		helm.WithArgs("--set", "installCRD=true"),
 		helm.WithArgs("--set", fmt.Sprintf("csidriver.enabled=%t", withCSI)),

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -227,6 +227,7 @@ func getHelmOptions(releaseTag, platform string, withCSI bool) ([]helm.Option, e
 		helm.WithNamespace("dynatrace"),
 		helm.WithArgs("--create-namespace"),
 		helm.WithArgs("--install"),
+		helm.WithArgs("--wait"),
 		helm.WithArgs("--set", fmt.Sprintf("platform=%s", platform)),
 		helm.WithArgs("--set", "installCRD=true"),
 		helm.WithArgs("--set", fmt.Sprintf("csidriver.enabled=%t", withCSI)),

--- a/test/e2e/helpers/components/operator/installation_test.go
+++ b/test/e2e/helpers/components/operator/installation_test.go
@@ -36,7 +36,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
-				"--wait",
+				"--rollback-on-failure",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=true",
@@ -57,7 +57,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
-				"--wait",
+				"--rollback-on-failure",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=true",
@@ -79,7 +79,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
-				"--wait",
+				"--rollback-on-failure",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=true",
@@ -108,7 +108,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
-				"--wait",
+				"--rollback-on-failure",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=false",
@@ -131,7 +131,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
-				"--wait",
+				"--rollback-on-failure",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=false",

--- a/test/e2e/helpers/components/operator/installation_test.go
+++ b/test/e2e/helpers/components/operator/installation_test.go
@@ -36,6 +36,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
+				"--wait",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=true",
@@ -56,6 +57,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
+				"--wait",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=true",
@@ -77,6 +79,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
+				"--wait",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=true",
@@ -105,6 +108,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
+				"--wait",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=false",
@@ -127,6 +131,7 @@ func TestGetHelmOptions(t *testing.T) {
 			Args: []string{
 				"--create-namespace",
 				"--install",
+				"--wait",
 				"--set", "platform=test",
 				"--set", "installCRD=true",
 				"--set", "csidriver.enabled=false",


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Fix kubemon kspm e2e test. Problem was that if you try to upgrade the operator in tests, our setup checks just for readiness (no generation) and might create a race condition between the old and new version resulting in a test can run in an outdated env. Flag ~[`--wait`](https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback)~ `--rollback-on-failure`  solves the issue globally.

[ICP-9002](https://dt-rnd.atlassian.net/browse/ICP-9002)

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
`make test/e2e/kspm/kubemon`


<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

[ICP-9002]: https://dt-rnd.atlassian.net/browse/ICP-9002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ