### PR TITLE
Include HTTP status 500 as unreachable

### DIFF
--- a/pkg/clients/dynatrace/core/error.go
+++ b/pkg/clients/dynatrace/core/error.go
@@ -72,18 +72,11 @@ func IsNotFound(err error) bool {
 	return HasStatusCode(err, http.StatusNotFound)
 }
 
-// IsTooManyRequests checks if the given error represents an HTTP 429 Too Many Requests error
-func IsTooManyRequests(err error) bool {
-	return HasStatusCode(err, http.StatusTooManyRequests)
-}
-
-// IsServiceUnavailable checks if the given error represents an HTTP 503 Service Unavailable error
-func IsServiceUnavailable(err error) bool {
-	return HasStatusCode(err, http.StatusServiceUnavailable)
-}
-
+// IsUnreachable checks if the given error indicates a transient server outage. Clients should retry after some grace period.
 func IsUnreachable(err error) bool {
-	return IsTooManyRequests(err) || IsServiceUnavailable(err)
+	code := StatusCode(err)
+
+	return code == http.StatusTooManyRequests || code == http.StatusInternalServerError || code == http.StatusServiceUnavailable
 }
 
 // StatusCode extracts the status code from an HTTPError. Returns 0 if error type doesn't match.

--- a/pkg/clients/dynatrace/core/error_test.go
+++ b/pkg/clients/dynatrace/core/error_test.go
@@ -115,7 +115,8 @@ func TestStatusCode(t *testing.T) {
 		{"type mismatch", errors.New("test"), 0},
 		{"from status", &HTTPError{StatusCode: 404}, 404},
 		{"from body", &HTTPError{StatusCode: 404, ServerErrors: []ServerError{{Code: 429}}}, 429},
-		{"pick first", &HTTPError{ServerErrors: []ServerError{{Code: 404}, {Code: 429}}}, 404},
+		{"pick first single", &HTTPError{ServerErrors: []ServerError{{Code: 404}, {Code: 429}}}, 404},
+		{"pick first joined", errors.Join(&HTTPError{StatusCode: 404}, &HTTPError{StatusCode: 429}, &HTTPError{StatusCode: 500}), 404},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Previously only 429 and 503 had special handling as "unreachable". Add 500 as well since we're seeing it in some environments.
