### PR TITLE
bump to the latest ubi10 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,13 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
 RUN cyclonedx-gomod app -licenses -assert-licenses -json -main cmd/ -output ./build/_output/bin/dynatrace-operator-bin-sbom.cdx.json
 
 # platform is required, otherwise the copy command will copy the wrong architecture files, don't trust GitHub Actions linting warnings
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9-micro:9.8-1784702951@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef AS base
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9:9.8-1785388874@sha256:aecc1f893388841178ce0276e2f7b087e63e1e4521ec86a96d9c9416c6d419fa AS dependency
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi10-micro:10.2-1786324819@sha256:cabedb588644e9da2c95ebb173a67b78d58aaedcb0eaa42a86f880bcef8a0b2f AS base
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi10:10.2-1787608172@sha256:2186e040d4218876009633aabff936882a10173b73b2c6f924dc5262bd651491 AS dependency
 RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \
       util-linux-core \
-      --releasever 9 \
+      --releasever 10 \
       --setopt install_weak_deps=false \
       --nodocs -y \
  && dnf --installroot /tmp/rootfs-dependency clean all \


### PR DESCRIPTION
## Description

Bump base image to the latest [ubi10-micro](https://catalog.redhat.com/en/software/containers/ubi10-micro/66f2abd91123095c735db44f#overview). 

Tracked by ICP-9040.

## How can this be tested?

The e2e seems to be broken, so just tested locally that the operator is running.

```sh
make build-local deploy-local
...
k get pods
NAME                                  READY   STATUS    RESTARTS   AGE
dynatrace-oneagent-csi-driver-22z52   4/4     Running   0          54m
dynatrace-oneagent-csi-driver-mt2bw   4/4     Running   0          54m
dynatrace-oneagent-csi-driver-n8fcw   4/4     Running   0          54m
dynatrace-operator-74b8787fbf-mf8md   1/1     Running   0          54m
dynatrace-webhook-7945c775b5-5rvxq    1/1     Running   0          54m
dynatrace-webhook-7945c775b5-jtsl4    1/1     Running   0          54m
```
