### PR TITLE
add resourceAttributes from DynaKube to gateway config

### DIFF
--- a/pkg/controllers/dtprometheus/gateway/config.go
+++ b/pkg/controllers/dtprometheus/gateway/config.go
@@ -4,6 +4,11 @@
 package gateway
 
 import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+
 	"github.com/Dynatrace/dynatrace-operator/pkg/otelcgen"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pipeline"
@@ -28,7 +33,7 @@ var (
 // buildGatewayOTelConfig assembles the OTel Collector relay config as an otelcgen.Config.
 // The caller marshals it to YAML via cfg.Marshal().
 func buildGatewayOTelConfig(data gatewayConfigData) *otelcgen.Config {
-	processors, processorIDs := buildProcessorMap()
+	processors, processorIDs := buildProcessorMap(data)
 
 	return &otelcgen.Config{
 		Receivers: map[component.ID]component.Config{
@@ -62,7 +67,7 @@ func buildGatewayOTelConfig(data gatewayConfigData) *otelcgen.Config {
 	}
 }
 
-func buildProcessorMap() (map[component.ID]component.Config, []component.ID) {
+func buildProcessorMap(data gatewayConfigData) (map[component.ID]component.Config, []component.ID) {
 	m := map[component.ID]component.Config{
 		memoryLimiterID: map[string]any{
 			"check_interval":         "1s",
@@ -75,7 +80,7 @@ func buildProcessorMap() (map[component.ID]component.Config, []component.ID) {
 			"max_staleness": "10m",
 		},
 		k8sAttributesID: buildK8sAttributesConfig(),
-		transformID:     buildTransformConfig(),
+		transformID:     buildTransformConfig(data.ResourceAttributes),
 	}
 
 	ids := []component.ID{
@@ -179,85 +184,114 @@ func buildK8sAttributesConfig() component.Config {
 	}
 }
 
-func buildTransformConfig() component.Config {
-	return map[string]any{
-		"metric_statements": []map[string]any{
-			{
-				"context": "datapoint",
-				"statements": []string{
-					`set(attributes["http.request.method"], attributes["http_request_method"]) where attributes["http_request_method"] != nil`,
-					`delete_key(attributes, "http_request_method")`,
-					`set(attributes["http.response.status_code"], attributes["http_response_status_code"]) where attributes["http_response_status_code"] != nil`,
-					`delete_key(attributes, "http_response_status_code")`,
-					`set(attributes["network.protocol.name"], attributes["network_protocol_name"]) where attributes["network_protocol_name"] != nil`,
-					`delete_key(attributes, "network_protocol_name")`,
-					`set(attributes["network.protocol.version"], attributes["network_protocol_version"]) where attributes["network_protocol_version"] != nil`,
-					`delete_key(attributes, "network_protocol_version")`,
-					`set(attributes["rpc.method"], attributes["rpc_method"]) where attributes["rpc_method"] != nil`,
-					`delete_key(attributes, "rpc_method")`,
-					`set(attributes["rpc.response.status_code"], attributes["rpc_response_status_code"]) where attributes["rpc_response_status_code"] != nil`,
-					`delete_key(attributes, "rpc_response_status_code")`,
-					`set(attributes["rpc.system.name"], attributes["rpc_system_name"]) where attributes["rpc_system_name"] != nil`,
-					`delete_key(attributes, "rpc_system_name")`,
-					`set(attributes["server.address"], attributes["server_address"]) where attributes["server_address"] != nil`,
-					`delete_key(attributes, "server_address")`,
-					`set(attributes["server.port"], attributes["server_port"]) where attributes["server_port"] != nil`,
-					`delete_key(attributes, "server_port")`,
-					`set(attributes["url.scheme"], attributes["url_scheme"]) where attributes["url_scheme"] != nil`,
-					`delete_key(attributes, "url_scheme")`,
-				},
+// buildTransformConfig assembles the transform processor config.
+func buildTransformConfig(resourceAttributes map[string]string) component.Config {
+	blocks := []map[string]any{
+		{
+			"context": "datapoint",
+			"statements": []string{
+				`set(attributes["http.request.method"], attributes["http_request_method"]) where attributes["http_request_method"] != nil`,
+				`delete_key(attributes, "http_request_method")`,
+				`set(attributes["http.response.status_code"], attributes["http_response_status_code"]) where attributes["http_response_status_code"] != nil`,
+				`delete_key(attributes, "http_response_status_code")`,
+				`set(attributes["network.protocol.name"], attributes["network_protocol_name"]) where attributes["network_protocol_name"] != nil`,
+				`delete_key(attributes, "network_protocol_name")`,
+				`set(attributes["network.protocol.version"], attributes["network_protocol_version"]) where attributes["network_protocol_version"] != nil`,
+				`delete_key(attributes, "network_protocol_version")`,
+				`set(attributes["rpc.method"], attributes["rpc_method"]) where attributes["rpc_method"] != nil`,
+				`delete_key(attributes, "rpc_method")`,
+				`set(attributes["rpc.response.status_code"], attributes["rpc_response_status_code"]) where attributes["rpc_response_status_code"] != nil`,
+				`delete_key(attributes, "rpc_response_status_code")`,
+				`set(attributes["rpc.system.name"], attributes["rpc_system_name"]) where attributes["rpc_system_name"] != nil`,
+				`delete_key(attributes, "rpc_system_name")`,
+				`set(attributes["server.address"], attributes["server_address"]) where attributes["server_address"] != nil`,
+				`delete_key(attributes, "server_address")`,
+				`set(attributes["server.port"], attributes["server_port"]) where attributes["server_port"] != nil`,
+				`delete_key(attributes, "server_port")`,
+				`set(attributes["url.scheme"], attributes["url_scheme"]) where attributes["url_scheme"] != nil`,
+				`delete_key(attributes, "url_scheme")`,
 			},
-			{
-				"context": "resource",
-				"statements": []string{
-					`set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])`,
-					`set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])`,
-					`set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])`,
-					`set(attributes["k8s.workload.name"], attributes["k8s.deployment.name"]) where IsString(attributes["k8s.deployment.name"])`,
-					`set(attributes["k8s.workload.name"], attributes["k8s.daemonset.name"]) where IsString(attributes["k8s.daemonset.name"])`,
-					`set(attributes["k8s.workload.name"], attributes["k8s.cronjob.name"]) where IsString(attributes["k8s.cronjob.name"])`,
-					`set(attributes["k8s.workload.kind"], "statefulset") where IsString(attributes["k8s.statefulset.name"])`,
-					`set(attributes["k8s.workload.kind"], "replicaset") where IsString(attributes["k8s.replicaset.name"])`,
-					`set(attributes["k8s.workload.kind"], "job") where IsString(attributes["k8s.job.name"])`,
-					`set(attributes["k8s.workload.kind"], "deployment") where IsString(attributes["k8s.deployment.name"])`,
-					`set(attributes["k8s.workload.kind"], "daemonset") where IsString(attributes["k8s.daemonset.name"])`,
-					`set(attributes["k8s.workload.kind"], "cronjob") where IsString(attributes["k8s.cronjob.name"])`,
-					`set(attributes["k8s.workload.uid"], attributes["k8s.statefulset.uid"]) where IsString(attributes["k8s.statefulset.uid"])`,
-					`set(attributes["k8s.workload.uid"], attributes["k8s.replicaset.uid"]) where IsString(attributes["k8s.replicaset.uid"])`,
-					`set(attributes["k8s.workload.uid"], attributes["k8s.job.uid"]) where IsString(attributes["k8s.job.uid"])`,
-					`set(attributes["k8s.workload.uid"], attributes["k8s.deployment.uid"]) where IsString(attributes["k8s.deployment.uid"])`,
-					`set(attributes["k8s.workload.uid"], attributes["k8s.daemonset.uid"]) where IsString(attributes["k8s.daemonset.uid"])`,
-					`set(attributes["k8s.workload.uid"], attributes["k8s.cronjob.uid"]) where IsString(attributes["k8s.cronjob.uid"])`,
-					`delete_key(attributes, "k8s.statefulset.name")`,
-					`delete_key(attributes, "k8s.replicaset.name")`,
-					`delete_key(attributes, "k8s.job.name")`,
-					`delete_key(attributes, "k8s.deployment.name")`,
-					`delete_key(attributes, "k8s.daemonset.name")`,
-					`delete_key(attributes, "k8s.cronjob.name")`,
-					`delete_key(attributes, "k8s.statefulset.uid")`,
-					`delete_key(attributes, "k8s.replicaset.uid")`,
-					`delete_key(attributes, "k8s.deployment.uid")`,
-					`delete_key(attributes, "k8s.daemonset.uid")`,
-					`delete_key(attributes, "k8s.job.uid")`,
-					`delete_key(attributes, "k8s.cronjob.uid")`,
-				},
+		},
+		{
+			"context": "resource",
+			"statements": []string{
+				`set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])`,
+				`set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])`,
+				`set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])`,
+				`set(attributes["k8s.workload.name"], attributes["k8s.deployment.name"]) where IsString(attributes["k8s.deployment.name"])`,
+				`set(attributes["k8s.workload.name"], attributes["k8s.daemonset.name"]) where IsString(attributes["k8s.daemonset.name"])`,
+				`set(attributes["k8s.workload.name"], attributes["k8s.cronjob.name"]) where IsString(attributes["k8s.cronjob.name"])`,
+				`set(attributes["k8s.workload.kind"], "statefulset") where IsString(attributes["k8s.statefulset.name"])`,
+				`set(attributes["k8s.workload.kind"], "replicaset") where IsString(attributes["k8s.replicaset.name"])`,
+				`set(attributes["k8s.workload.kind"], "job") where IsString(attributes["k8s.job.name"])`,
+				`set(attributes["k8s.workload.kind"], "deployment") where IsString(attributes["k8s.deployment.name"])`,
+				`set(attributes["k8s.workload.kind"], "daemonset") where IsString(attributes["k8s.daemonset.name"])`,
+				`set(attributes["k8s.workload.kind"], "cronjob") where IsString(attributes["k8s.cronjob.name"])`,
+				`set(attributes["k8s.workload.uid"], attributes["k8s.statefulset.uid"]) where IsString(attributes["k8s.statefulset.uid"])`,
+				`set(attributes["k8s.workload.uid"], attributes["k8s.replicaset.uid"]) where IsString(attributes["k8s.replicaset.uid"])`,
+				`set(attributes["k8s.workload.uid"], attributes["k8s.job.uid"]) where IsString(attributes["k8s.job.uid"])`,
+				`set(attributes["k8s.workload.uid"], attributes["k8s.deployment.uid"]) where IsString(attributes["k8s.deployment.uid"])`,
+				`set(attributes["k8s.workload.uid"], attributes["k8s.daemonset.uid"]) where IsString(attributes["k8s.daemonset.uid"])`,
+				`set(attributes["k8s.workload.uid"], attributes["k8s.cronjob.uid"]) where IsString(attributes["k8s.cronjob.uid"])`,
+				`delete_key(attributes, "k8s.statefulset.name")`,
+				`delete_key(attributes, "k8s.replicaset.name")`,
+				`delete_key(attributes, "k8s.job.name")`,
+				`delete_key(attributes, "k8s.deployment.name")`,
+				`delete_key(attributes, "k8s.daemonset.name")`,
+				`delete_key(attributes, "k8s.cronjob.name")`,
+				`delete_key(attributes, "k8s.statefulset.uid")`,
+				`delete_key(attributes, "k8s.replicaset.uid")`,
+				`delete_key(attributes, "k8s.deployment.uid")`,
+				`delete_key(attributes, "k8s.daemonset.uid")`,
+				`delete_key(attributes, "k8s.job.uid")`,
+				`delete_key(attributes, "k8s.cronjob.uid")`,
 			},
-			{
-				"context": "resource",
-				"statements": []string{
-					`delete_key(attributes, "processor")`,
-					`delete_key(attributes, "otel.signal")`,
-					`delete_key(attributes, "otel.scope.name")`,
-					`delete_key(attributes, "otel.scope.version")`,
-				},
-			},
-			{
-				"context": "resource",
-				"statements": []string{
-					`merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "upsert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")`,
-					`delete_key(attributes, "metadata.dynatrace.com")`,
-				},
+		},
+		{
+			"context": "resource",
+			"statements": []string{
+				`delete_key(attributes, "processor")`,
+				`delete_key(attributes, "otel.signal")`,
+				`delete_key(attributes, "otel.scope.name")`,
+				`delete_key(attributes, "otel.scope.version")`,
 			},
 		},
 	}
+
+	// resourceAttributes are only a fallback: the "== nil" guard in each set() statement
+	// and the annotation merge below (which runs after and always overwrites) make sure
+	// pod/workload/namespace annotations always take precedence.
+	if len(resourceAttributes) > 0 {
+		blocks = append(blocks, map[string]any{
+			"context":    "resource",
+			"statements": buildResourceAttributeStatements(resourceAttributes),
+		})
+	}
+
+	blocks = append(blocks, map[string]any{
+		"context": "resource",
+		"statements": []string{
+			`merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "upsert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")`,
+			`delete_key(attributes, "metadata.dynatrace.com")`,
+		},
+	})
+
+	return map[string]any{"metric_statements": blocks}
+}
+
+// buildResourceAttributeStatements returns sorted set() statements for resourceAttributes.
+func buildResourceAttributeStatements(attrs map[string]string) []string {
+	keys := slices.Sorted(maps.Keys(attrs))
+	statements := make([]string, 0, len(keys))
+
+	for _, k := range keys {
+		quotedKey := strconv.Quote(k)
+		quotedVal := strconv.Quote(attrs[k])
+		statements = append(statements, fmt.Sprintf(
+			`set(attributes[%s], %s) where attributes[%s] == nil`,
+			quotedKey, quotedVal, quotedKey,
+		))
+	}
+
+	return statements
 }

--- a/pkg/controllers/dtprometheus/gateway/config_test.go
+++ b/pkg/controllers/dtprometheus/gateway/config_test.go
@@ -1,0 +1,95 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildResourceAttributeStatements(t *testing.T) {
+	t.Run("empty attrs", func(t *testing.T) {
+		statements := buildResourceAttributeStatements(map[string]string{})
+		assert.Empty(t, statements)
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		statements := buildResourceAttributeStatements(map[string]string{"region": "us-east"})
+		require.Len(t, statements, 1)
+		assert.Equal(t,
+			`set(attributes["region"], "us-east") where attributes["region"] == nil`,
+			statements[0],
+		)
+	})
+
+	t.Run("multiple entries sorted by key", func(t *testing.T) {
+		statements := buildResourceAttributeStatements(map[string]string{
+			"region":  "us-east",
+			"dt.env":  "prod",
+			"cluster": "main",
+		})
+		require.Len(t, statements, 3)
+		assert.Equal(t, `set(attributes["cluster"], "main") where attributes["cluster"] == nil`, statements[0])
+		assert.Equal(t, `set(attributes["dt.env"], "prod") where attributes["dt.env"] == nil`, statements[1])
+		assert.Equal(t, `set(attributes["region"], "us-east") where attributes["region"] == nil`, statements[2])
+	})
+
+	t.Run("quotes in key and value are escaped", func(t *testing.T) {
+		statements := buildResourceAttributeStatements(map[string]string{`k"ey`: `val"ue`})
+		require.Len(t, statements, 1)
+		assert.Equal(t,
+			`set(attributes["k\"ey"], "val\"ue") where attributes["k\"ey"] == nil`,
+			statements[0],
+		)
+	})
+
+	t.Run("backslashes in key and value are escaped", func(t *testing.T) {
+		statements := buildResourceAttributeStatements(map[string]string{`k\ey`: `val\ue`})
+		require.Len(t, statements, 1)
+		assert.Equal(t,
+			`set(attributes["k\\ey"], "val\\ue") where attributes["k\\ey"] == nil`,
+			statements[0],
+		)
+	})
+}
+
+func TestRenderGatewayConfig_ResourceAttributes(t *testing.T) {
+	t.Run("empty resource attributes produces no baseline set block", func(t *testing.T) {
+		data := gatewayConfigData{Endpoint: "https://example.com/v2/otlp"}
+		rendered, err := renderGatewayConfig(data)
+		require.NoError(t, err)
+		// "== nil" only appears in the resource-attributes block; none of the static blocks use it.
+		assert.NotContains(t, rendered, "== nil")
+	})
+
+	t.Run("resource attributes rendered as sorted baseline set statements", func(t *testing.T) {
+		data := gatewayConfigData{
+			Endpoint: "https://example.com/v2/otlp",
+			ResourceAttributes: map[string]string{
+				"region":            "us-east",
+				"dt.k8s.cluster.id": "abc123",
+			},
+		}
+		rendered, err := renderGatewayConfig(data)
+		require.NoError(t, err)
+		assert.Contains(t, rendered, `set(attributes["dt.k8s.cluster.id"], "abc123") where attributes["dt.k8s.cluster.id"] == nil`)
+		assert.Contains(t, rendered, `set(attributes["region"], "us-east") where attributes["region"] == nil`)
+	})
+
+	t.Run("resource attributes block appears before annotation merge block", func(t *testing.T) {
+		data := gatewayConfigData{
+			Endpoint:           "https://example.com/v2/otlp",
+			ResourceAttributes: map[string]string{"region": "us-east"},
+		}
+		rendered, err := renderGatewayConfig(data)
+		require.NoError(t, err)
+
+		setIdx := strings.Index(rendered, `set(attributes["region"], "us-east")`)
+		mergeIdx := strings.Index(rendered, "merge_maps(")
+		assert.Greater(t, mergeIdx, setIdx, "resource attributes block must precede the annotation merge block")
+	})
+}

--- a/pkg/controllers/dtprometheus/gateway/config_test.go
+++ b/pkg/controllers/dtprometheus/gateway/config_test.go
@@ -4,12 +4,30 @@
 package gateway
 
 import (
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
+
+// goldenRelay reads a golden ConfigMap fixture and returns its "relay" data key,
+// so config-rendering tests can compare directly against the same fixtures used
+// by the reconciler tests instead of duplicating expected output.
+func goldenRelay(t *testing.T, name string) string {
+	t.Helper()
+
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, yaml.Unmarshal(b, cm))
+
+	return cm.Data[gatewayConfigKey]
+}
 
 func TestBuildResourceAttributeStatements(t *testing.T) {
 	t.Run("empty attrs", func(t *testing.T) {
@@ -58,38 +76,24 @@ func TestBuildResourceAttributeStatements(t *testing.T) {
 }
 
 func TestRenderGatewayConfig_ResourceAttributes(t *testing.T) {
-	t.Run("empty resource attributes produces no baseline set block", func(t *testing.T) {
-		data := gatewayConfigData{Endpoint: "https://example.com/v2/otlp"}
-		rendered, err := renderGatewayConfig(data)
+	const endpoint = "https://abc12345.live.dynatrace.com/api/v2/otlp"
+
+	t.Run("empty resource attributes matches golden configmap without attributes", func(t *testing.T) {
+		rendered, err := renderGatewayConfig(gatewayConfigData{Endpoint: endpoint})
 		require.NoError(t, err)
-		// "== nil" only appears in the resource-attributes block; none of the static blocks use it.
-		assert.NotContains(t, rendered, "== nil")
+		assert.YAMLEq(t, goldenRelay(t, "configmap.yaml"), rendered)
 	})
 
-	t.Run("resource attributes rendered as sorted baseline set statements", func(t *testing.T) {
+	t.Run("resource attributes rendered as sorted baseline set statements matches golden configmap with attributes", func(t *testing.T) {
 		data := gatewayConfigData{
-			Endpoint: "https://example.com/v2/otlp",
+			Endpoint: endpoint,
 			ResourceAttributes: map[string]string{
-				"region":            "us-east",
-				"dt.k8s.cluster.id": "abc123",
+				"favorite.coffee": "espresso",
+				"deploy.mood":     "yolo",
 			},
 		}
 		rendered, err := renderGatewayConfig(data)
 		require.NoError(t, err)
-		assert.Contains(t, rendered, `set(attributes["dt.k8s.cluster.id"], "abc123") where attributes["dt.k8s.cluster.id"] == nil`)
-		assert.Contains(t, rendered, `set(attributes["region"], "us-east") where attributes["region"] == nil`)
-	})
-
-	t.Run("resource attributes block appears before annotation merge block", func(t *testing.T) {
-		data := gatewayConfigData{
-			Endpoint:           "https://example.com/v2/otlp",
-			ResourceAttributes: map[string]string{"region": "us-east"},
-		}
-		rendered, err := renderGatewayConfig(data)
-		require.NoError(t, err)
-
-		setIdx := strings.Index(rendered, `set(attributes["region"], "us-east")`)
-		mergeIdx := strings.Index(rendered, "merge_maps(")
-		assert.Greater(t, mergeIdx, setIdx, "resource attributes block must precede the annotation merge block")
+		assert.YAMLEq(t, goldenRelay(t, "configmap_with_resource_attributes.yaml"), rendered)
 	})
 }

--- a/pkg/controllers/dtprometheus/gateway/reconciler.go
+++ b/pkg/controllers/dtprometheus/gateway/reconciler.go
@@ -190,13 +190,17 @@ func (r *Reconciler) reconcileConfigMap(ctx context.Context, s *reconcileScope) 
 }
 
 type gatewayConfigData struct {
-	Endpoint     string
-	CustomCAPath string
+	Endpoint           string
+	CustomCAPath       string
+	ResourceAttributes map[string]string
 }
 
 // buildGatewayConfigData resolves the DynaKube-derived inputs to the relay.yaml template.
 func buildGatewayConfigData(dk *dynakube.DynaKube) gatewayConfigData {
-	data := gatewayConfigData{Endpoint: dk.APIURL() + "/v2/otlp"}
+	data := gatewayConfigData{
+		Endpoint:           dk.APIURL() + "/v2/otlp",
+		ResourceAttributes: dk.GetResourceAttributes(),
+	}
 
 	if dk.Spec.TrustedCAs != "" {
 		data.CustomCAPath = filepath.Join(trustedCAVolumeMountPath, trustedCAFile)

--- a/pkg/controllers/dtprometheus/gateway/reconciler_test.go
+++ b/pkg/controllers/dtprometheus/gateway/reconciler_test.go
@@ -9,16 +9,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/dtprometheus"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,31 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/yaml"
 )
 
 func newTestDTP(name, namespace string) *dtprometheus.DTPrometheus {
 	return &dtprometheus.DTPrometheus{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID("dtp-uid")}}
-}
-
-// assertGolden compares obj, marshaled to YAML, against testdata/name. The fake
-// client is the only source of non-determinism (it stamps resourceVersion), so
-// that field is cleared before comparing.
-func assertGolden(t *testing.T, name string, obj client.Object) {
-	t.Helper()
-
-	obj.SetResourceVersion("")
-	// Ensure object has GVK so that TypeMeta is included
-	kinds, _, _ := scheme.Scheme.ObjectKinds(obj)
-	require.Len(t, kinds, 1)
-	obj.GetObjectKind().SetGroupVersionKind(kinds[0])
-
-	got, err := yaml.Marshal(obj)
-	require.NoError(t, err)
-
-	want, err := os.ReadFile(filepath.Join("testdata", name))
-	require.NoError(t, err)
-	assert.YAMLEq(t, string(want), string(got))
 }
 
 func newTestScope(dtp *dtprometheus.DTPrometheus) *reconcileScope {
@@ -142,7 +120,7 @@ func TestReconcileConfigMap(t *testing.T) {
 		cm := &corev1.ConfigMap{}
 		require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: s.Spec.GetStatefulSetName(), Namespace: dtp.Namespace}, cm))
 
-		assertGolden(t, "configmap.yaml", cm)
+		helpers.AssertGolden(t, filepath.Join("testdata", "configmap.yaml"), cm)
 
 		sum := sha256.Sum256([]byte(cm.Data[gatewayConfigKey]))
 		assert.Equal(t, hex.EncodeToString(sum[:]), s.ConfigMapHash)
@@ -152,7 +130,7 @@ func TestReconcileConfigMap(t *testing.T) {
 		dtp := newTestDTP("dtp", "dynatrace")
 		dk := &dynakube.DynaKube{}
 		dk.Spec.APIURL = "https://abc12345.live.dynatrace.com/api"
-		dk.Spec.ResourceAttributes = map[string]string{"region": "us-east"}
+		dk.Spec.ResourceAttributes = map[string]string{"favorite.coffee": "espresso", "deploy.mood": "yolo"}
 		s := newTestScopeWithDynaKube(dtp, dk)
 		c := fake.NewClient()
 		r := &Reconciler{Client: c}
@@ -161,7 +139,7 @@ func TestReconcileConfigMap(t *testing.T) {
 
 		cm := &corev1.ConfigMap{}
 		require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: s.Spec.GetStatefulSetName(), Namespace: dtp.Namespace}, cm))
-		assert.Contains(t, cm.Data[gatewayConfigKey], `set(attributes["region"], "us-east") where attributes["region"] == nil`)
+		helpers.AssertGolden(t, filepath.Join("testdata", "configmap_with_resource_attributes.yaml"), cm)
 	})
 
 	t.Run("changing resource attributes changes the config hash, triggering a rollout", func(t *testing.T) {
@@ -219,7 +197,7 @@ func TestReconcileService(t *testing.T) {
 		svc := &corev1.Service{}
 		require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: s.Spec.GetStatefulSetName(), Namespace: dtp.Namespace}, svc))
 
-		assertGolden(t, "service.yaml", svc)
+		helpers.AssertGolden(t, filepath.Join("testdata", "service.yaml"), svc)
 	})
 
 	t.Run("merge labels", func(t *testing.T) {

--- a/pkg/controllers/dtprometheus/gateway/reconciler_test.go
+++ b/pkg/controllers/dtprometheus/gateway/reconciler_test.go
@@ -107,6 +107,27 @@ func TestReconcileCondition(t *testing.T) {
 	}
 }
 
+func TestBuildGatewayConfigData(t *testing.T) {
+	t.Run("resource attributes are read from the DynaKube", func(t *testing.T) {
+		dk := &dynakube.DynaKube{}
+		dk.Spec.APIURL = "https://abc12345.live.dynatrace.com/api"
+		dk.Spec.ResourceAttributes = map[string]string{"region": "us-east"}
+
+		data := buildGatewayConfigData(dk)
+
+		assert.Equal(t, map[string]string{"region": "us-east"}, data.ResourceAttributes)
+	})
+
+	t.Run("no resource attributes set on the DynaKube", func(t *testing.T) {
+		dk := &dynakube.DynaKube{}
+		dk.Spec.APIURL = "https://abc12345.live.dynatrace.com/api"
+
+		data := buildGatewayConfigData(dk)
+
+		assert.Empty(t, data.ResourceAttributes)
+	})
+}
+
 func TestReconcileConfigMap(t *testing.T) {
 	t.Run("apply spec", func(t *testing.T) {
 		dtp := newTestDTP("dtp", "dynatrace")
@@ -125,6 +146,39 @@ func TestReconcileConfigMap(t *testing.T) {
 
 		sum := sha256.Sum256([]byte(cm.Data[gatewayConfigKey]))
 		assert.Equal(t, hex.EncodeToString(sum[:]), s.ConfigMapHash)
+	})
+
+	t.Run("resource attributes are rendered into the configmap", func(t *testing.T) {
+		dtp := newTestDTP("dtp", "dynatrace")
+		dk := &dynakube.DynaKube{}
+		dk.Spec.APIURL = "https://abc12345.live.dynatrace.com/api"
+		dk.Spec.ResourceAttributes = map[string]string{"region": "us-east"}
+		s := newTestScopeWithDynaKube(dtp, dk)
+		c := fake.NewClient()
+		r := &Reconciler{Client: c}
+
+		require.NoError(t, r.reconcileConfigMap(t.Context(), s))
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: s.Spec.GetStatefulSetName(), Namespace: dtp.Namespace}, cm))
+		assert.Contains(t, cm.Data[gatewayConfigKey], `set(attributes["region"], "us-east") where attributes["region"] == nil`)
+	})
+
+	t.Run("changing resource attributes changes the config hash, triggering a rollout", func(t *testing.T) {
+		dtp := newTestDTP("dtp", "dynatrace")
+		dk := &dynakube.DynaKube{}
+		dk.Spec.APIURL = "https://abc12345.live.dynatrace.com/api"
+		s := newTestScopeWithDynaKube(dtp, dk)
+		r := &Reconciler{Client: fake.NewClient()}
+
+		require.NoError(t, r.reconcileConfigMap(t.Context(), s))
+		hashBefore := s.ConfigMapHash
+
+		dk.Spec.ResourceAttributes = map[string]string{"region": "us-east"}
+		require.NoError(t, r.reconcileConfigMap(t.Context(), s))
+		hashAfter := s.ConfigMapHash
+
+		assert.NotEqual(t, hashBefore, hashAfter)
 	})
 
 	t.Run("merge labels", func(t *testing.T) {

--- a/pkg/controllers/dtprometheus/gateway/statefulset_test.go
+++ b/pkg/controllers/dtprometheus/gateway/statefulset_test.go
@@ -5,11 +5,13 @@ package gateway
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
+	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	imagemock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -87,7 +89,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 		sts := &appsv1.StatefulSet{}
 		require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: s.Spec.GetStatefulSetName(), Namespace: dtp.Namespace}, sts))
 
-		assertGolden(t, "statefulset.yaml", sts)
+		helpers.AssertGolden(t, filepath.Join("testdata", "statefulset.yaml"), sts)
 	})
 
 	t.Run("preserve existing replicas", func(t *testing.T) {

--- a/pkg/controllers/dtprometheus/gateway/testdata/configmap_with_resource_attributes.yaml
+++ b/pkg/controllers/dtprometheus/gateway/testdata/configmap_with_resource_attributes.yaml
@@ -1,0 +1,178 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/instance: otel-gateway
+    app.kubernetes.io/managed-by: dynatrace-operator
+    app.kubernetes.io/name: opentelemetry-gateway
+    internal.dynatrace.com/operator-version: snapshot
+  name: dtp-gateway
+  namespace: dynatrace
+  ownerReferences:
+  - apiVersion: dynatrace.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DTPrometheus
+    name: dtp
+    uid: dtp-uid
+data:
+  relay: |
+    connectors: {}
+    exporters:
+        otlphttp:
+            endpoint: https://abc12345.live.dynatrace.com/api/v2/otlp
+            headers:
+                Authorization: Api-Token ${env:DT_API_TOKEN}
+            sending_queue:
+                batch:
+                    flush_timeout: 10s
+                    max_size: 5000
+                    min_size: 500
+    extensions:
+        health_check:
+            endpoint: ${env:MY_POD_IP}:13133
+    processors:
+        cumulativetodelta:
+            initial_value: drop
+            max_staleness: 10m
+        k8sattributes:
+            extract:
+                annotations:
+                    - from: pod
+                      key_regex: metadata.dynatrace.com/(.*)
+                      tag_name: $$1
+                    - from: pod
+                      key: metadata.dynatrace.com
+                      tag_name: metadata.dynatrace.com
+                metadata:
+                    - k8s.pod.name
+                    - k8s.pod.uid
+                    - k8s.pod.ip
+                    - k8s.deployment.name
+                    - k8s.replicaset.name
+                    - k8s.statefulset.name
+                    - k8s.daemonset.name
+                    - k8s.job.name
+                    - k8s.cronjob.name
+                    - k8s.namespace.name
+                    - k8s.node.name
+                    - k8s.cluster.uid
+                    - k8s.container.name
+                    - k8s.deployment.uid
+                    - k8s.replicaset.uid
+                    - k8s.statefulset.uid
+                    - k8s.daemonset.uid
+                    - k8s.job.uid
+                    - k8s.cronjob.uid
+            pod_association:
+                - sources:
+                    - from: resource_attribute
+                      name: server.address
+                - sources:
+                    - from: resource_attribute
+                      name: k8s.pod.name
+                    - from: resource_attribute
+                      name: k8s.namespace.name
+                - sources:
+                    - from: resource_attribute
+                      name: k8s.pod.ip
+                - sources:
+                    - from: resource_attribute
+                      name: k8s.pod.uid
+                - sources:
+                    - from: connection
+        memory_limiter:
+            check_interval: 1s
+            limit_percentage: 95
+            spike_limit_percentage: 5
+        metric_start_time: null
+        transform:
+            metric_statements:
+                - context: datapoint
+                  statements:
+                    - set(attributes["http.request.method"], attributes["http_request_method"]) where attributes["http_request_method"] != nil
+                    - delete_key(attributes, "http_request_method")
+                    - set(attributes["http.response.status_code"], attributes["http_response_status_code"]) where attributes["http_response_status_code"] != nil
+                    - delete_key(attributes, "http_response_status_code")
+                    - set(attributes["network.protocol.name"], attributes["network_protocol_name"]) where attributes["network_protocol_name"] != nil
+                    - delete_key(attributes, "network_protocol_name")
+                    - set(attributes["network.protocol.version"], attributes["network_protocol_version"]) where attributes["network_protocol_version"] != nil
+                    - delete_key(attributes, "network_protocol_version")
+                    - set(attributes["rpc.method"], attributes["rpc_method"]) where attributes["rpc_method"] != nil
+                    - delete_key(attributes, "rpc_method")
+                    - set(attributes["rpc.response.status_code"], attributes["rpc_response_status_code"]) where attributes["rpc_response_status_code"] != nil
+                    - delete_key(attributes, "rpc_response_status_code")
+                    - set(attributes["rpc.system.name"], attributes["rpc_system_name"]) where attributes["rpc_system_name"] != nil
+                    - delete_key(attributes, "rpc_system_name")
+                    - set(attributes["server.address"], attributes["server_address"]) where attributes["server_address"] != nil
+                    - delete_key(attributes, "server_address")
+                    - set(attributes["server.port"], attributes["server_port"]) where attributes["server_port"] != nil
+                    - delete_key(attributes, "server_port")
+                    - set(attributes["url.scheme"], attributes["url_scheme"]) where attributes["url_scheme"] != nil
+                    - delete_key(attributes, "url_scheme")
+                - context: resource
+                  statements:
+                    - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where IsString(attributes["k8s.statefulset.name"])
+                    - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where IsString(attributes["k8s.replicaset.name"])
+                    - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where IsString(attributes["k8s.job.name"])
+                    - set(attributes["k8s.workload.name"], attributes["k8s.deployment.name"]) where IsString(attributes["k8s.deployment.name"])
+                    - set(attributes["k8s.workload.name"], attributes["k8s.daemonset.name"]) where IsString(attributes["k8s.daemonset.name"])
+                    - set(attributes["k8s.workload.name"], attributes["k8s.cronjob.name"]) where IsString(attributes["k8s.cronjob.name"])
+                    - set(attributes["k8s.workload.kind"], "statefulset") where IsString(attributes["k8s.statefulset.name"])
+                    - set(attributes["k8s.workload.kind"], "replicaset") where IsString(attributes["k8s.replicaset.name"])
+                    - set(attributes["k8s.workload.kind"], "job") where IsString(attributes["k8s.job.name"])
+                    - set(attributes["k8s.workload.kind"], "deployment") where IsString(attributes["k8s.deployment.name"])
+                    - set(attributes["k8s.workload.kind"], "daemonset") where IsString(attributes["k8s.daemonset.name"])
+                    - set(attributes["k8s.workload.kind"], "cronjob") where IsString(attributes["k8s.cronjob.name"])
+                    - set(attributes["k8s.workload.uid"], attributes["k8s.statefulset.uid"]) where IsString(attributes["k8s.statefulset.uid"])
+                    - set(attributes["k8s.workload.uid"], attributes["k8s.replicaset.uid"]) where IsString(attributes["k8s.replicaset.uid"])
+                    - set(attributes["k8s.workload.uid"], attributes["k8s.job.uid"]) where IsString(attributes["k8s.job.uid"])
+                    - set(attributes["k8s.workload.uid"], attributes["k8s.deployment.uid"]) where IsString(attributes["k8s.deployment.uid"])
+                    - set(attributes["k8s.workload.uid"], attributes["k8s.daemonset.uid"]) where IsString(attributes["k8s.daemonset.uid"])
+                    - set(attributes["k8s.workload.uid"], attributes["k8s.cronjob.uid"]) where IsString(attributes["k8s.cronjob.uid"])
+                    - delete_key(attributes, "k8s.statefulset.name")
+                    - delete_key(attributes, "k8s.replicaset.name")
+                    - delete_key(attributes, "k8s.job.name")
+                    - delete_key(attributes, "k8s.deployment.name")
+                    - delete_key(attributes, "k8s.daemonset.name")
+                    - delete_key(attributes, "k8s.cronjob.name")
+                    - delete_key(attributes, "k8s.statefulset.uid")
+                    - delete_key(attributes, "k8s.replicaset.uid")
+                    - delete_key(attributes, "k8s.deployment.uid")
+                    - delete_key(attributes, "k8s.daemonset.uid")
+                    - delete_key(attributes, "k8s.job.uid")
+                    - delete_key(attributes, "k8s.cronjob.uid")
+                - context: resource
+                  statements:
+                    - delete_key(attributes, "processor")
+                    - delete_key(attributes, "otel.signal")
+                    - delete_key(attributes, "otel.scope.name")
+                    - delete_key(attributes, "otel.scope.version")
+                - context: resource
+                  statements:
+                    - set(attributes["deploy.mood"], "yolo") where attributes["deploy.mood"] == nil
+                    - set(attributes["favorite.coffee"], "espresso") where attributes["favorite.coffee"] == nil
+                - context: resource
+                  statements:
+                    - merge_maps(attributes, ParseJSON(attributes["metadata.dynatrace.com"]), "upsert") where IsMatch(attributes["metadata.dynatrace.com"], "^\\{")
+                    - delete_key(attributes, "metadata.dynatrace.com")
+    receivers:
+        otlp:
+            protocols:
+                grpc:
+                    endpoint: ${env:MY_POD_IP}:4317
+    service:
+        extensions:
+            - health_check
+        pipelines:
+            metrics:
+                exporters:
+                    - otlphttp
+                processors:
+                    - memory_limiter
+                    - metric_start_time
+                    - cumulativetodelta
+                    - k8sattributes
+                    - transform
+                receivers:
+                    - otlp


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-8858

- adds `resourceAttributes` of the referenced `DynaKube` to the gateway `ConfigMap`
  - attributes are rendered as `set(attributes[%s], %s) where attributes[%s] == nil` to preserve precedence
  - I noticed a single `merge_maps(attributes, ParseJSON(...), "insert")` statement could replace the per-key `set()` calls and simplify the config, at the cost of readability (one packed JSON blob vs. one line per attribute), is this something we would want?
- annotations take precedence over `dk.resourceAttributes`
  - `JSON blob annotation > metadata.dynatrace.com/<key> > resourceAttributes`

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

`make go lint && make go test`

### In cluster
- Apply your `DynaKube` with `spec.resourceAttributes` set, e.g.:
```yaml
spec:
  resourceAttributes:
    favorite.coffee: espresso
    deploy.mood: yolo
```

- Apply `DtPrometheus`

```yaml
apiVersion: dynatrace.com/v1alpha1
kind: DTPrometheus
metadata:
  name: my-dtp
  namespace: dynatrace
spec:
  dynaKubeName: <your-dynakube-name>
  gateway:
    image: ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:0.51.0
```

- Check created `DtPrometheus`, `StatefulSet`, `ConfigMap`
- The `ConfigMap` should include one `set()` directive per `resourceAttribute` defined in the `DynaKube`
- Change  `spec.resourceAttributes`  on the `DynaKube`, reconcile, and confirm the `ConfigMap` content and  `ConfigMapHash`  annotation change, and the `StatefulSet `rolls out

- also verification of the generated ottl `transformer` with https://ottl.run/
<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->