### PR TITLE
 Fix missing CA bundles in UBI10 runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p /tmp/rootfs-dependency
 COPY --from=base / /tmp/rootfs-dependency
 RUN dnf install --installroot /tmp/rootfs-dependency \
       util-linux-core \
+      ca-certificates \
       --releasever 10 \
       --setopt install_weak_deps=false \
       --nodocs -y \


### PR DESCRIPTION
After switching to UBI10, the dependency stage no longer pulled CA trust packages transitively via util-linux-core. This change explicitly installs ca-certificates in Dockerfile so the final runtime image includes the expected CA bundle paths (e.g. /etc/ssl/certs/ca-bundle.crt).

Tracked in ICP-9040.

**Before the change:**
```sh
{"level":"error","ts":"2026-08-25T12:36:22.089Z","msg":"Reconciler error","controller":"dynakube-controller","controllerGroup":"[dynatrace.com](http://dynatrace.com/)","controllerKind":"DynaKube","DynaKube":{"name":"dev-dk","namespace":"dynatrace"},"namespace":"dynatrace","name":"dev-dk","reconcileID":"88ce56e2-a42e-4023-b9fb-a9c035fb2ee7","error":"get kubernetesClusterMEID: get k8s monitored entity: HTTP request: Get \"https://jaf3966d.dev.dynatracelabs.com/api/v2/settings/objects?fields=value%2Cscope&filter=value.clusterId%3D%27c5bd51d4-e414-4b67-871b-afbe81026a45%27&pageSize=500&schemaIds=builtin%3Acloud.kubernetes&validateOnly=true\": tls: failed to verify certificate: x509: certificate signed by unknown authority\nHTTP request: Get \"https://jaf3966d.dev.dynatracelabs.com/api/v1/deployment/installer/gateway/connectioninfo\": tls: failed to verify certificate: x509: certificate signed by unknown authority","stacktrace":"[sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler)\n\[tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494](http://tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494)\[nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem](http://nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem)\n\[tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437](http://tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437)\[nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1](http://nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1)\n\[tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312](http://tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312)"}
```
**After the change:**
```sh
{"level":"error","ts":"2026-08-25T14:47:30.893Z","msg":"Reconciler error","controller":"dynakube-controller","controllerGroup":"dynatrace.com","controllerKind":"DynaKube","DynaKube":{"name":"dev-dk","namespace":"dynatrace"},"namespace":"dynatrace","name":"dev-dk","reconcileID":"85445457-389d-4d98-aa00-584cc9f2fd43","error":"get kubernetesClusterMEID: get k8s monitored entity: HTTP 500: unknown server error\nHTTP 500: unknown server error","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312"}

```