### PR TITLE
Add TLS cert to kubemon AG if KSPM is enabled

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -6662,6 +6662,8 @@ spec:
                     type: object
                   image:
                     type: string
+                  tlsSecretHash:
+                    type: string
                 type: object
               metadataEnrichment:
                 properties:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -6678,6 +6678,8 @@ spec:
                     type: object
                   image:
                     type: string
+                  tlsSecretHash:
+                    type: string
                 type: object
               metadataEnrichment:
                 properties:

--- a/pkg/api/latest/dynakube/certs.go
+++ b/pkg/api/latest/dynakube/certs.go
@@ -7,15 +7,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	TrustedCAKey  = "certs"
-	ServerCertKey = "server.crt"
-	TLSCertKey    = "tls.crt"
+	TrustedCAKey = "certs"
 )
 
 func (dk *DynaKube) TrustedCAs(ctx context.Context, kubeReader client.Reader) ([]byte, error) {
@@ -46,12 +45,12 @@ func (dk *DynaKube) ActiveGateTLSCert(ctx context.Context, kubeReader client.Rea
 		}
 
 		// first check if the tls.crt key is available
-		if tlsCertKey, ok := tlsSecret.Data[TLSCertKey]; ok {
+		if tlsCertKey, ok := tlsSecret.Data[consts.TLSCrtDataName]; ok {
 			return tlsCertKey, nil
 		}
 
 		// use server.crt as fallback for older secrets
-		if tlsCertKey, ok := tlsSecret.Data[ServerCertKey]; ok {
+		if tlsCertKey, ok := tlsSecret.Data[consts.TLSServerCrtDataName]; ok {
 			return tlsCertKey, nil
 		}
 	}

--- a/pkg/api/latest/dynakube/certs_test.go
+++ b/pkg/api/latest/dynakube/certs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -104,15 +105,15 @@ func activeGateTLSCertificate(t *testing.T) {
 
 	t.Run("get tls certificates from server.crt", func(t *testing.T) {
 		testFunc(t, map[string][]byte{
-			dynakube.ServerCertKey: []byte(testSecretValue),
+			consts.TLSServerCrtDataName: []byte(testSecretValue),
 		})
 	})
 
 	t.Run("get tls certificates from tls.crt", func(t *testing.T) {
 		testFunc(t, map[string][]byte{
 			// prioritize tls.crt over server.crt
-			dynakube.TLSCertKey:    []byte(testSecretValue),
-			dynakube.ServerCertKey: []byte(testSecretValueNew),
+			consts.TLSCrtDataName:       []byte(testSecretValue),
+			consts.TLSServerCrtDataName: []byte(testSecretValueNew),
 		})
 	})
 }

--- a/pkg/api/latest/dynakube/kubemon/props.go
+++ b/pkg/api/latest/dynakube/kubemon/props.go
@@ -66,6 +66,20 @@ func (km *KubeMon) GetCustomPropertiesSecretName() string {
 	return km.name + NameSuffix + "-custom-properties"
 }
 
+// GetTLSSecretName returns the name of the KubeMon TLS secret.
+func (km *KubeMon) GetTLSSecretName() string {
+	if km.TLSCertsRef != nil && km.TLSCertsRef.SecretName != "" {
+		return km.TLSCertsRef.SecretName
+	}
+
+	return km.GetAutoTLSSecretName()
+}
+
+// GetAutoTLSSecretName returns the name of the automatically created KubeMon TLS secret.
+func (km *KubeMon) GetAutoTLSSecretName() string {
+	return km.name + NameSuffix + "-tls-secret"
+}
+
 // GetCustomImage returns the user-provided image override, or "" if unset.
 func (km *Spec) GetCustomImage() string {
 	if km == nil {

--- a/pkg/api/latest/dynakube/kubemon/status.go
+++ b/pkg/api/latest/dynakube/kubemon/status.go
@@ -18,7 +18,7 @@ type Status struct {
 	// +kubebuilder:validation:Optional
 	ConnectionInfo communication.ConnectionInfo `json:"connectionInfo,omitzero"`
 
-	// TLSSecretHash contains the hash of the TLS certificate and key that is passed to both the Kubeernetes Monitoring ActiveGate and Node-Configuration-Collector.
+	// TLSSecretHash contains the hash of the TLS certificate and key that is passed to both the Kubernetes Monitoring ActiveGate and Node-Configuration-Collector.
 	// Meant to keep the two in sync.
 	TLSSecretHash string `json:"tlsSecretHash,omitempty"`
 }

--- a/pkg/api/latest/dynakube/kubemon/status.go
+++ b/pkg/api/latest/dynakube/kubemon/status.go
@@ -17,4 +17,8 @@ type Status struct {
 	// Information about KubernetesMonitoring's connections.
 	// +kubebuilder:validation:Optional
 	ConnectionInfo communication.ConnectionInfo `json:"connectionInfo,omitzero"`
+
+	// TLSSecretHash contains the hash of the TLS certificate and key that is passed to both the Kubeernetes Monitoring ActiveGate and Node-Configuration-Collector.
+	// Meant to keep the two in sync.
+	TLSSecretHash string `json:"tlsSecretHash,omitempty"`
 }

--- a/pkg/consts/tls.go
+++ b/pkg/consts/tls.go
@@ -10,4 +10,6 @@ const (
 
 	// TLSCrtDataName is the key used to store a TLS certificate in the secret's data field.
 	TLSCrtDataName = "tls.crt"
+
+	TLSServerCrtDataName = "server.crt"
 )

--- a/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/tls/reconciler.go
@@ -28,8 +28,6 @@ import (
 const (
 	activeGateSelfSignedTLSCommonNameSuffix = "activegate"
 
-	tlsCrtDataName = "server.crt"
-
 	conditionType = "TLSSecret"
 )
 
@@ -131,9 +129,9 @@ func (r *Reconciler) createSelfSignedTLSSecret(ctx context.Context, dk *dynakube
 
 	coreLabels := k8slabel.NewCoreLabels(dk.Name, k8slabel.ActiveGateComponentLabel)
 	secretData := map[string][]byte{
-		consts.TLSCrtDataName: pemCert,
-		consts.TLSKeyDataName: pemPk,
-		tlsCrtDataName:        pemCert,
+		consts.TLSCrtDataName:       pemCert,
+		consts.TLSKeyDataName:       pemPk,
+		consts.TLSServerCrtDataName: pemCert,
 	}
 
 	secret, err := k8ssecret.Build(dk, dk.ActiveGate().GetTLSSecretName(), secretData, k8ssecret.SetLabels(coreLabels.BuildLabels()))

--- a/pkg/controllers/dynakube/extension/eec/reconciler_test.go
+++ b/pkg/controllers/dynakube/extension/eec/reconciler_test.go
@@ -1193,8 +1193,8 @@ func TestLegacyVolumes(t *testing.T) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},
@@ -1307,8 +1307,8 @@ func TestLegacyVolumes(t *testing.T) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},
@@ -1443,8 +1443,8 @@ func TestLegacyVolumes(t *testing.T) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},
@@ -1537,8 +1537,8 @@ func TestVolumes(t *testing.T) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},
@@ -1629,8 +1629,8 @@ func TestVolumes(t *testing.T) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},
@@ -1743,8 +1743,8 @@ func TestVolumes(t *testing.T) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},
@@ -1817,8 +1817,8 @@ func TestActiveGateVolumes(t *testing.T) {
 				SecretName:  tlsSecretName,
 				Items: []corev1.KeyToPath{
 					{
-						Key:  activeGateTrustedCertSecretKeyPath,
-						Path: activeGateTrustedCertSecretKeyPath,
+						Key:  consts.TLSServerCrtDataName,
+						Path: consts.TLSServerCrtDataName,
 					},
 				},
 			},
@@ -1832,8 +1832,8 @@ func TestActiveGateVolumes(t *testing.T) {
 				SecretName:  testDynakubeName + activegate.TLSSecretSuffix,
 				Items: []corev1.KeyToPath{
 					{
-						Key:  activeGateTrustedCertSecretKeyPath,
-						Path: activeGateTrustedCertSecretKeyPath,
+						Key:  consts.TLSServerCrtDataName,
+						Path: consts.TLSServerCrtDataName,
 					},
 				},
 			},

--- a/pkg/controllers/dynakube/extension/eec/statefulset.go
+++ b/pkg/controllers/dynakube/extension/eec/statefulset.go
@@ -55,24 +55,23 @@ const (
 	// Env variable values
 	envExtensionsModuleExecPath = "/opt/dynatrace/remotepluginmodule/agent/lib64/extensionsmodule"
 	envDsInstallDir             = "/opt/dynatrace/remotepluginmodule/agent/datasources"
-	envActiveGateTrustedCert    = activeGateTrustedCertMountPath + "/" + activeGateTrustedCertSecretKeyPath
+	envActiveGateTrustedCert    = activeGateTrustedCertMountPath + "/" + consts.TLSServerCrtDataName
 	envEECHTTPSCertPathPem      = httpsCertMountPath + "/" + consts.TLSCrtDataName
 	envEECHTTPSPrivKeyPathPem   = httpsCertMountPath + "/" + consts.TLSKeyDataName
 	// Volume names and paths
-	eecTokenMountPath                  = "/secrets/tokens"
-	customCertificateMountPath         = "/secrets/extensions"
-	customCertificateVolumeName        = "extension-custom-certs"
-	runtimeVolumeName                  = "agent-runtime"
-	runtimeMountPath                   = "/var/lib/dynatrace/remotepluginmodule"
-	customConfigVolumeName             = "custom-config"
-	customConfigMountPath              = "/secrets/config"
-	activeGateTrustedCertVolumeName    = "server-certs"
-	activeGateTrustedCertMountPath     = "/secrets/ag"
-	activeGateTrustedCertSecretKeyPath = "server.crt"
-	httpsCertVolumeName                = "https-certs"
-	httpsCertMountPath                 = "/secrets/https"
-	runtimeConfigurationFilename       = "runtimeConfiguration"
-	serviceURLScheme                   = "https://"
+	eecTokenMountPath               = "/secrets/tokens"
+	customCertificateMountPath      = "/secrets/extensions"
+	customCertificateVolumeName     = "extension-custom-certs"
+	runtimeVolumeName               = "agent-runtime"
+	runtimeMountPath                = "/var/lib/dynatrace/remotepluginmodule"
+	customConfigVolumeName          = "custom-config"
+	customConfigMountPath           = "/secrets/config"
+	activeGateTrustedCertVolumeName = "server-certs"
+	activeGateTrustedCertMountPath  = "/secrets/ag"
+	httpsCertVolumeName             = "https-certs"
+	httpsCertMountPath              = "/secrets/https"
+	runtimeConfigurationFilename    = "runtimeConfiguration"
+	serviceURLScheme                = "https://"
 
 	legacyConfigurationVolumeName = "runtime-configuration"
 	legacyConfigurationMountPath  = "/var/lib/dynatrace/remotepluginmodule/agent/conf"
@@ -462,8 +461,8 @@ func setVolumes(dk *dynakube.DynaKube) func(o *appsv1.StatefulSet) {
 						SecretName:  dk.ActiveGate().GetTLSSecretName(),
 						Items: []corev1.KeyToPath{
 							{
-								Key:  activeGateTrustedCertSecretKeyPath,
-								Path: activeGateTrustedCertSecretKeyPath,
+								Key:  consts.TLSServerCrtDataName,
+								Path: consts.TLSServerCrtDataName,
 							},
 						},
 					},

--- a/pkg/controllers/dynakube/injection/reconciler_test.go
+++ b/pkg/controllers/dynakube/injection/reconciler_test.go
@@ -613,7 +613,7 @@ func TestGenerateCorrectCertInitSecret(t *testing.T) {
 	})
 
 	autoTLSSecret := clientSecret(dkBase.ActiveGate().GetTLSSecretName(), dkBase.Namespace, map[string][]byte{
-		dynakube.TLSCertKey: []byte("certificate"),
+		consts.TLSCrtDataName: []byte("certificate"),
 	})
 
 	t.Run("create new cert secret and delete it if not needed", func(t *testing.T) {
@@ -704,7 +704,7 @@ func TestGenerateCorrectOTLPCertInitSecret(t *testing.T) {
 	})
 
 	autoTLSSecret := clientSecret(dkBase.ActiveGate().GetTLSSecretName(), dkBase.Namespace, map[string][]byte{
-		dynakube.TLSCertKey: []byte("certificate"),
+		consts.TLSCrtDataName: []byte("certificate"),
 	})
 
 	t.Run("create new cert secret and delete it if not needed", func(t *testing.T) {

--- a/pkg/controllers/dynakube/kspm/daemonset/certs.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/certs.go
@@ -5,6 +5,7 @@ package daemonset
 
 import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -35,7 +36,7 @@ func getCertMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      certVolumeName,
 		MountPath: certFolderPath,
-		SubPath:   dynakube.ServerCertKey,
+		SubPath:   consts.TLSServerCrtDataName,
 	}
 }
 

--- a/pkg/controllers/dynakube/kspm/daemonset/certs.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/certs.go
@@ -15,11 +15,16 @@ const (
 )
 
 func getCertVolume(dk dynakube.DynaKube) corev1.Volume {
+	secretName := dk.ActiveGate().GetTLSSecretName()
+	if dk.IsKubemonEnabled() {
+		secretName = dk.KubernetesMonitoring().GetTLSSecretName()
+	}
+
 	return corev1.Volume{
 		Name: certVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  dk.ActiveGate().GetTLSSecretName(),
+				SecretName:  secretName,
 				DefaultMode: new(int32(0o640)),
 			},
 		},

--- a/pkg/controllers/dynakube/kspm/daemonset/certs_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/certs_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 )
 
 func getDynaKubeWithCerts(t *testing.T) dynakube.DynaKube {
@@ -25,6 +27,38 @@ func getDynaKubeWithAutomaticCerts(t *testing.T) dynakube.DynaKube {
 
 	dk := dynakube.DynaKube{}
 	dk.ActiveGate().Capabilities = []activegate.CapabilityDisplayName{activegate.KubeMonCapability.DisplayName}
+
+	return dk
+}
+
+func getDynaKubeWithKubemonCerts(t *testing.T) dynakube.DynaKube {
+	t.Helper()
+
+	t.Setenv(k8senv.ExperimentalEnableKubemonOperand, "true")
+
+	dk := dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			KubernetesMonitoring: &kubemon.Spec{
+				TLSCertsRef: &kubemon.TLSCertsRef{
+					SecretName: "test",
+				},
+			},
+		},
+	}
+
+	return dk
+}
+
+func getDynaKubeWithKubemonAutomaticCerts(t *testing.T) dynakube.DynaKube {
+	t.Helper()
+
+	t.Setenv(k8senv.ExperimentalEnableKubemonOperand, "true")
+
+	dk := dynakube.DynaKube{
+		Spec: dynakube.DynaKubeSpec{
+			KubernetesMonitoring: &kubemon.Spec{},
+		},
+	}
 
 	return dk
 }

--- a/pkg/controllers/dynakube/kspm/daemonset/env.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/env.go
@@ -39,7 +39,7 @@ func getEnvs(dk dynakube.DynaKube, tenantUUID string) []corev1.EnvVar {
 		},
 	}
 
-	if dk.ActiveGate().HasCaCert() {
+	if dk.IsKubemonEnabled() || dk.ActiveGate().HasCaCert() {
 		envs = append(envs, getCertEnv())
 	}
 

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -83,7 +83,10 @@ func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube) (*appsv1.DaemonSet
 	}
 
 	labels := k8slabel.NewAppLabels(k8slabel.KSPMComponentLabel, dk.Name, k8slabel.KSPMComponentLabel, dk.Spec.Templates.KSPMNodeConfigurationCollector.ImageRef.Tag)
-	templateAnnotations := map[string]string{tokenSecretHashAnnotation: dk.KSPM().TokenSecretHash}
+	templateAnnotations := map[string]string{
+		tokenSecretHashAnnotation: dk.KSPM().TokenSecretHash,
+		tlsSecretHashAnnotation:   dk.KubernetesMonitoring().TLSSecretHash,
+	}
 	maps.Copy(templateAnnotations, k8ssecuritycontext.RemoveAppArmorAnnotation(dk.KSPM().Annotations, containerName))
 
 	affinity := k8saffinity.NewAMDOnlyNodeAffinity()

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
@@ -129,7 +129,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		assert.NotEmpty(t, daemonset.Spec.Template.Spec.Affinity)
 		assert.Subset(t, daemonset.Spec.Template.Labels, daemonset.Spec.Selector.MatchLabels)
 		require.Empty(t, daemonset.Annotations)
-		require.Len(t, daemonset.Spec.Template.Annotations, 1)
+		require.Len(t, daemonset.Spec.Template.Annotations, 2)
 		assert.Contains(t, daemonset.Spec.Template.Annotations, tokenSecretHashAnnotation)
 		assert.Equal(t, serviceAccountName, daemonset.Spec.Template.Spec.ServiceAccountName)
 		assert.Empty(t, daemonset.Spec.Template.Spec.DNSPolicy)

--- a/pkg/controllers/dynakube/kspm/daemonset/volumes.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/volumes.go
@@ -18,6 +18,7 @@ const (
 	tokenVolumeName           = "kspm-token"
 	tokenMountPath            = consts.DTComponentsSecretsRootDir + "/tokens/kspm/node-configuration-collector"
 	tokenSecretHashAnnotation = api.InternalFlagPrefix + "kspm-token-secret-hash"
+	tlsSecretHashAnnotation   = api.InternalFlagPrefix + "kubemon-tls-secret-hash"
 
 	nodeRootMountPath = "/node_root"
 )
@@ -28,7 +29,7 @@ func getVolumes(dk dynakube.DynaKube) []corev1.Volume {
 	volumes = append(volumes, getNodeVolumes(dk.KSPM().GetUniqueMappedHostPaths())...)
 	volumes = append(volumes, getTokenVolume(dk))
 
-	if dk.ActiveGate().HasCaCert() {
+	if dk.IsKubemonEnabled() || dk.ActiveGate().HasCaCert() {
 		volumes = append(volumes, getCertVolume(dk))
 	}
 
@@ -41,7 +42,7 @@ func getMounts(dk dynakube.DynaKube) []corev1.VolumeMount {
 	mounts = append(mounts, getNodeVolumeMounts(dk.KSPM().GetUniqueMappedHostPaths())...)
 	mounts = append(mounts, getTokenVolumeMount())
 
-	if dk.ActiveGate().HasCaCert() {
+	if dk.IsKubemonEnabled() || dk.ActiveGate().HasCaCert() {
 		mounts = append(mounts, getCertMount())
 	}
 

--- a/pkg/controllers/dynakube/kspm/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/volumes_test.go
@@ -121,6 +121,34 @@ func TestGetMounts(t *testing.T) {
 			assert.NotEmpty(t, mount.MountPath)
 		}
 	})
+
+	t.Run("get cert mount with custom KubeMon cert", func(t *testing.T) {
+		dk := getDynaKubeWithKubemonCerts(t)
+		dk.Spec.KSPM = &kspm.Spec{}
+		mounts := getMounts(dk)
+
+		require.NotEmpty(t, mounts)
+		assert.Len(t, mounts, expectedMountLen+1)
+
+		for _, mount := range mounts {
+			assert.NotEmpty(t, mount.Name)
+			assert.NotEmpty(t, mount.MountPath)
+		}
+	})
+
+	t.Run("get cert mount with automatic KubeMon cert", func(t *testing.T) {
+		dk := getDynaKubeWithKubemonAutomaticCerts(t)
+		dk.Spec.KSPM = &kspm.Spec{}
+		mounts := getMounts(dk)
+
+		require.NotEmpty(t, mounts)
+		assert.Len(t, mounts, expectedMountLen+1)
+
+		for _, mount := range mounts {
+			assert.NotEmpty(t, mount.Name)
+			assert.NotEmpty(t, mount.MountPath)
+		}
+	})
 }
 
 func TestGetVolumes(t *testing.T) {
@@ -203,7 +231,9 @@ func TestGetVolumes(t *testing.T) {
 
 		testMappedVolumes(volumes)
 	})
+}
 
+func TestGetVolumesForCerts(t *testing.T) {
 	t.Run("add cert volume", func(t *testing.T) {
 		dk := getDynaKubeWithCerts(t)
 		dk.Spec.KSPM = &kspm.Spec{}
@@ -224,6 +254,42 @@ func TestGetVolumes(t *testing.T) {
 
 	t.Run("add cert volume with automatic AG cert", func(t *testing.T) {
 		dk := getDynaKubeWithAutomaticCerts(t)
+		dk.Spec.KSPM = &kspm.Spec{}
+		volumes := getVolumes(dk)
+
+		require.NotEmpty(t, volumes)
+		assert.Len(t, volumes, expectedMountLen+1)
+
+		for _, volume := range volumes {
+			assert.NotEmpty(t, volume.Name)
+			require.NotEmpty(t, volume.VolumeSource)
+
+			if volume.Name == certVolumeName {
+				assert.NotEmpty(t, volume.Secret.SecretName)
+			}
+		}
+	})
+
+	t.Run("add cert volume with KubeMon cert", func(t *testing.T) {
+		dk := getDynaKubeWithCerts(t)
+		dk.Spec.KSPM = &kspm.Spec{}
+		volumes := getVolumes(dk)
+
+		require.NotEmpty(t, volumes)
+		assert.Len(t, volumes, expectedMountLen+1)
+
+		for _, volume := range volumes {
+			assert.NotEmpty(t, volume.Name)
+			require.NotEmpty(t, volume.VolumeSource)
+
+			if volume.Name == certVolumeName {
+				assert.NotEmpty(t, volume.Secret.SecretName)
+			}
+		}
+	})
+
+	t.Run("add cert volume with automatic KubeMon cert", func(t *testing.T) {
+		dk := getDynaKubeWithKubemonAutomaticCerts(t)
 		dk.Spec.KSPM = &kspm.Spec{}
 		volumes := getVolumes(dk)
 

--- a/pkg/controllers/dynakube/kspm/daemonset/volumes_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/volumes_test.go
@@ -51,8 +51,7 @@ func TestGetMounts(t *testing.T) {
 		}
 		mounts := getMounts(dk)
 
-		require.NotEmpty(t, mounts)
-		assert.Len(t, mounts, expectedMountLen)
+		require.Len(t, mounts, expectedMountLen)
 
 		for _, mount := range mounts {
 			assert.NotEmpty(t, mount.Name)
@@ -99,8 +98,7 @@ func TestGetMounts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		mounts := getMounts(dk)
 
-		require.NotEmpty(t, mounts)
-		assert.Len(t, mounts, expectedMountLen+1)
+		require.Len(t, mounts, expectedMountLen+1)
 
 		for _, mount := range mounts {
 			assert.NotEmpty(t, mount.Name)
@@ -113,8 +111,7 @@ func TestGetMounts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		mounts := getMounts(dk)
 
-		require.NotEmpty(t, mounts)
-		assert.Len(t, mounts, expectedMountLen+1)
+		require.Len(t, mounts, expectedMountLen+1)
 
 		for _, mount := range mounts {
 			assert.NotEmpty(t, mount.Name)
@@ -127,8 +124,7 @@ func TestGetMounts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		mounts := getMounts(dk)
 
-		require.NotEmpty(t, mounts)
-		assert.Len(t, mounts, expectedMountLen+1)
+		require.Len(t, mounts, expectedMountLen+1)
 
 		for _, mount := range mounts {
 			assert.NotEmpty(t, mount.Name)
@@ -141,8 +137,7 @@ func TestGetMounts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		mounts := getMounts(dk)
 
-		require.NotEmpty(t, mounts)
-		assert.Len(t, mounts, expectedMountLen+1)
+		require.Len(t, mounts, expectedMountLen+1)
 
 		for _, mount := range mounts {
 			assert.NotEmpty(t, mount.Name)
@@ -189,8 +184,7 @@ func TestGetVolumes(t *testing.T) {
 		}
 		volumes := getVolumes(dk)
 
-		require.NotEmpty(t, volumes)
-		assert.Len(t, volumes, expectedMountLen)
+		require.Len(t, volumes, expectedMountLen)
 
 		for _, volume := range volumes {
 			assert.NotEmpty(t, volume.Name)
@@ -239,8 +233,7 @@ func TestGetVolumesForCerts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		volumes := getVolumes(dk)
 
-		require.NotEmpty(t, volumes)
-		assert.Len(t, volumes, expectedMountLen+1)
+		require.Len(t, volumes, expectedMountLen+1)
 
 		for _, volume := range volumes {
 			assert.NotEmpty(t, volume.Name)
@@ -257,8 +250,7 @@ func TestGetVolumesForCerts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		volumes := getVolumes(dk)
 
-		require.NotEmpty(t, volumes)
-		assert.Len(t, volumes, expectedMountLen+1)
+		require.Len(t, volumes, expectedMountLen+1)
 
 		for _, volume := range volumes {
 			assert.NotEmpty(t, volume.Name)
@@ -275,8 +267,7 @@ func TestGetVolumesForCerts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		volumes := getVolumes(dk)
 
-		require.NotEmpty(t, volumes)
-		assert.Len(t, volumes, expectedMountLen+1)
+		require.Len(t, volumes, expectedMountLen+1)
 
 		for _, volume := range volumes {
 			assert.NotEmpty(t, volume.Name)
@@ -293,8 +284,7 @@ func TestGetVolumesForCerts(t *testing.T) {
 		dk.Spec.KSPM = &kspm.Spec{}
 		volumes := getVolumes(dk)
 
-		require.NotEmpty(t, volumes)
-		assert.Len(t, volumes, expectedMountLen+1)
+		require.Len(t, volumes, expectedMountLen+1)
 
 		for _, volume := range volumes {
 			assert.NotEmpty(t, volume.Name)

--- a/pkg/controllers/dynakube/kubemon/gateway/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/gateway/reconciler.go
@@ -27,8 +27,7 @@ import (
 )
 
 type Reconciler struct {
-	client       client.Client
-	timeProvider *timeprovider.Provider
+	client client.Client
 }
 
 const (
@@ -37,8 +36,7 @@ const (
 
 func NewReconciler(kubeClient client.Client) *Reconciler {
 	return &Reconciler{
-		client:       kubeClient,
-		timeProvider: timeprovider.New(),
+		client: kubeClient,
 	}
 }
 
@@ -162,7 +160,7 @@ func (r *Reconciler) createTLSSecret(ctx context.Context, dk *dynakube.DynaKube)
 }
 
 func (r *Reconciler) tlsCertificateData(dk *dynakube.DynaKube) (map[string][]byte, error) {
-	cert, err := certificates.New(r.timeProvider)
+	cert, err := certificates.New(timeprovider.New())
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/controllers/dynakube/kubemon/gateway/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/gateway/reconciler.go
@@ -5,26 +5,40 @@ package gateway
 
 import (
 	"context"
+	"crypto/x509"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	tlsconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/certificates"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	k8sobject "github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type Reconciler struct {
-	client client.Client
+	client       client.Client
+	timeProvider *timeprovider.Provider
 }
+
+const (
+	kubemonSelfSignedTLSCommonNameSuffix = "kubemon"
+)
 
 func NewReconciler(kubeClient client.Client) *Reconciler {
 	return &Reconciler{
-		client: kubeClient,
+		client:       kubeClient,
+		timeProvider: timeprovider.New(),
 	}
 }
 
@@ -32,14 +46,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error
 	ctx, _ = logd.NewFromContext(ctx, "gateway")
 
 	if !dk.KubernetesMonitoring().IsEnabled() || !dk.KSPM().IsEnabled() {
-		return client.IgnoreNotFound(r.client.Delete(ctx, kubemonService(dk)))
+		dk.KubernetesMonitoring().TLSSecretHash = ""
+
+		if err := client.IgnoreNotFound(r.client.Delete(ctx, kubemonService(dk))); err != nil {
+			return err
+		}
+
+		return client.IgnoreNotFound(r.client.Delete(ctx, tlsSecretSpec(dk, nil)))
 	}
 
 	if err := r.createService(ctx, dk); err != nil {
 		return err
 	}
 
-	return nil
+	if dk.KubernetesMonitoring().TLSCertsRef == nil || dk.KubernetesMonitoring().TLSCertsRef.SecretName == "" {
+		if err := r.createTLSSecret(ctx, dk); err != nil {
+			return err
+		}
+	} else {
+		// automatically created TLS secret is not used, delete it if exists
+		_ = r.client.Delete(ctx, tlsSecretSpec(dk, nil))
+	}
+
+	return r.setStatusTLSSecretHash(ctx, dk)
 }
 
 func (r *Reconciler) createService(ctx context.Context, dk *dynakube.DynaKube) error {
@@ -95,4 +124,113 @@ func kubemonService(dk *dynakube.DynaKube) *corev1.Service {
 			Ports:    ports,
 		},
 	}
+}
+
+func (r *Reconciler) createTLSSecret(ctx context.Context, dk *dynakube.DynaKube) error {
+	certificateData, err := r.tlsCertificateData(dk)
+	if err != nil {
+		return err
+	}
+
+	desired := tlsSecretSpec(dk, certificateData)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	return k8sobject.RetryCreateOrUpdate(ctx, r.client, secret, func() error {
+		secret.Labels = desired.Labels
+		secret.Type = desired.Type
+
+		// desired key/certificate always have unique values so they are used only when
+		// secret.Data is empty -> the secret doesn't exist yet
+		// secret.Data is "broken"
+
+		_, okTLSCrtDataName := secret.Data[tlsconsts.TLSCrtDataName]
+		_, okTLSKeyDataName := secret.Data[tlsconsts.TLSKeyDataName]
+		_, okTLSServerCrtDataName := secret.Data[tlsconsts.TLSServerCrtDataName]
+
+		if !okTLSCrtDataName || !okTLSKeyDataName || !okTLSServerCrtDataName {
+			secret.Data = desired.Data
+		}
+
+		return controllerutil.SetControllerReference(dk, secret, r.client.Scheme())
+	})
+}
+
+func (r *Reconciler) tlsCertificateData(dk *dynakube.DynaKube) (map[string][]byte, error) {
+	cert, err := certificates.New(r.timeProvider)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	cert.Cert.DNSNames = certificates.AltNames(dk.Name, dk.Namespace, kubemonSelfSignedTLSCommonNameSuffix)
+	cert.Cert.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment
+	cert.Cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	cert.Cert.Subject.CommonName = certificates.CommonName(dk.Name, dk.Namespace, kubemonSelfSignedTLSCommonNameSuffix)
+
+	if err := cert.SelfSign(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	pemCert, pemPk, err := cert.ToPEM()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return map[string][]byte{
+		tlsconsts.TLSCrtDataName:       pemCert,
+		tlsconsts.TLSKeyDataName:       pemPk,
+		tlsconsts.TLSServerCrtDataName: pemCert,
+	}, nil
+}
+
+func tlsSecretSpec(dk *dynakube.DynaKube, data map[string][]byte) *corev1.Secret {
+	labels := k8slabel.New(k8slabel.KubeMonComponentLabel, dk.Name, "")
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dk.KubernetesMonitoring().GetAutoTLSSecretName(),
+			Namespace: dk.Namespace,
+			Labels:    labels.AsMap(),
+		},
+		Data: data,
+		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+func (r *Reconciler) setStatusTLSSecretHash(ctx context.Context, dk *dynakube.DynaKube) error {
+	var secret corev1.Secret
+
+	// retry because a Secret created by the preceding createOrUpdate call may not be immediately visible in the API.
+	err := retry.OnError(retry.DefaultBackoff, k8serrors.IsNotFound, func() error {
+		err := r.client.Get(ctx, client.ObjectKey{Name: dk.KubernetesMonitoring().GetTLSSecretName(), Namespace: dk.Namespace}, &secret)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if len(secret.Data) == 0 {
+		dk.KubernetesMonitoring().TLSSecretHash = ""
+
+		return nil
+	}
+
+	// custom secret may contain server.p12 field or tls.crt, tls.key fields
+	hash, err := hasher.GenerateSecureHash(secret.Data)
+	if err != nil {
+		return errors.Wrap(err, "failed to hash TLS secret")
+	}
+
+	dk.KubernetesMonitoring().TLSSecretHash = hash
+
+	return nil
 }

--- a/pkg/controllers/dynakube/kubemon/gateway/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/gateway/reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
 	kubemonapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	tlsconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/gateway"
 	"github.com/Dynatrace/dynatrace-operator/test/helpers"
 	"github.com/pkg/errors"
@@ -24,7 +25,7 @@ import (
 )
 
 func TestKubemonDisabled(t *testing.T) {
-	t.Run("no existing service, reconcile completes without error", func(t *testing.T) {
+	t.Run("no existing service/cert, reconcile completes without error", func(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dk",
@@ -36,7 +37,7 @@ func TestKubemonDisabled(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("existing service is removed from the cluster", func(t *testing.T) {
+	t.Run("existing service/cert are removed from the cluster", func(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dk",
@@ -50,7 +51,13 @@ func TestKubemonDisabled(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 		}
-		fakeClient := fake.NewClient(dk, existingSvc)
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.KubernetesMonitoring().GetAutoTLSSecretName(),
+				Namespace: dk.Namespace,
+			},
+		}
+		fakeClient := fake.NewClient(dk, existingSvc, existingSecret)
 
 		err := gateway.NewReconciler(fakeClient).Reconcile(t.Context(), dk)
 		require.NoError(t, err)
@@ -58,11 +65,15 @@ func TestKubemonDisabled(t *testing.T) {
 		svc := &corev1.Service{}
 		getErr := fakeClient.Get(t.Context(), client.ObjectKey{Name: gateway.ServiceName(dk.Name), Namespace: dk.Namespace}, svc)
 		assert.True(t, k8serrors.IsNotFound(getErr), "service should have been removed from the cluster")
+
+		secret := &corev1.Secret{}
+		getErr = fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.KubernetesMonitoring().GetAutoTLSSecretName(), Namespace: dk.Namespace}, secret)
+		assert.True(t, k8serrors.IsNotFound(getErr), "secret should have been removed from the cluster")
 	})
 }
 
 func TestKubemonEnabled(t *testing.T) {
-	t.Run("no service is created when KSPM is disabled", func(t *testing.T) {
+	t.Run("no service/cert is created when KSPM is disabled", func(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dk",
@@ -79,9 +90,13 @@ func TestKubemonEnabled(t *testing.T) {
 		svc := &corev1.Service{}
 		svcMissing := k8serrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKey{Name: gateway.ServiceName(dk.Name), Namespace: dk.Namespace}, svc))
 		assert.True(t, svcMissing, "service should not have been created")
+
+		secret := &corev1.Secret{}
+		secretMissing := k8serrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.KubernetesMonitoring().GetAutoTLSSecretName(), Namespace: dk.Namespace}, secret))
+		assert.True(t, secretMissing, "secret should not have been created")
 	})
 
-	t.Run("existing service is removed when KSPM is disabled", func(t *testing.T) {
+	t.Run("existing service/cert are removed when KSPM is disabled", func(t *testing.T) {
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dk",
@@ -97,13 +112,23 @@ func TestKubemonEnabled(t *testing.T) {
 				Namespace: dk.Namespace,
 			},
 		}
-		fakeClient := fake.NewClient(dk, existingSvc)
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.KubernetesMonitoring().GetAutoTLSSecretName(),
+				Namespace: dk.Namespace,
+			},
+		}
+		fakeClient := fake.NewClient(dk, existingSvc, existingSecret)
 
 		require.NoError(t, gateway.NewReconciler(fakeClient).Reconcile(t.Context(), dk))
 
 		svc := &corev1.Service{}
 		svcMissing := k8serrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKey{Name: gateway.ServiceName(dk.Name), Namespace: dk.Namespace}, svc))
 		assert.True(t, svcMissing, "service should have been removed from the cluster")
+
+		secret := &corev1.Secret{}
+		secretMissing := k8serrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.KubernetesMonitoring().GetAutoTLSSecretName(), Namespace: dk.Namespace}, secret))
+		assert.True(t, secretMissing, "secret should have been removed from the cluster")
 	})
 
 	t.Run("service has expected configuration", func(t *testing.T) {
@@ -151,5 +176,90 @@ func TestKubemonEnabled(t *testing.T) {
 
 		err := gateway.NewReconciler(fakeClient).Reconcile(t.Context(), dk)
 		require.ErrorIs(t, err, createErr)
+	})
+
+	t.Run("automatic TLS secret is not created if custom secret is specified", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dk",
+				Namespace: "dynatrace",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				KubernetesMonitoring: &kubemonapi.Spec{
+					TLSCertsRef: &kubemonapi.TLSCertsRef{
+						SecretName: "custom-secret",
+					},
+				},
+			},
+		}
+		fakeClient := fake.NewClient(dk)
+
+		err := gateway.NewReconciler(fakeClient).Reconcile(t.Context(), dk)
+		require.NoError(t, err)
+
+		secret := &corev1.Secret{}
+		secretMissing := k8serrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.KubernetesMonitoring().GetAutoTLSSecretName(), Namespace: dk.Namespace}, secret))
+		assert.True(t, secretMissing, "secret should not have been created")
+	})
+
+	t.Run("existing automatic TLS secret is removed from the cluster if custom secret is specified", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dk",
+				Namespace: "dynatrace",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				KubernetesMonitoring: &kubemonapi.Spec{
+					TLSCertsRef: &kubemonapi.TLSCertsRef{
+						SecretName: "custom-secret",
+					},
+				},
+				KSPM: &kspm.Spec{},
+			},
+		}
+		customSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-secret",
+				Namespace: dk.Namespace,
+			},
+		}
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.KubernetesMonitoring().GetAutoTLSSecretName(),
+				Namespace: dk.Namespace,
+			},
+		}
+		fakeClient := fake.NewClient(dk, existingSecret, customSecret)
+
+		err := gateway.NewReconciler(fakeClient).Reconcile(t.Context(), dk)
+		require.NoError(t, err)
+
+		secret := &corev1.Secret{}
+		secretMissing := k8serrors.IsNotFound(fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.KubernetesMonitoring().GetAutoTLSSecretName(), Namespace: dk.Namespace}, secret))
+		assert.True(t, secretMissing, "secret should have been removed from the cluster")
+	})
+
+	t.Run("automatic TLS secret has expected configuration", func(t *testing.T) {
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dk",
+				Namespace: "dynatrace",
+			},
+			Spec: dynakube.DynaKubeSpec{
+				KubernetesMonitoring: &kubemonapi.Spec{},
+				KSPM:                 &kspm.Spec{},
+			},
+		}
+		fakeClient := fake.NewClient(dk)
+
+		err := gateway.NewReconciler(fakeClient).Reconcile(t.Context(), dk)
+		require.NoError(t, err)
+
+		secret := &corev1.Secret{}
+		require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: dk.KubernetesMonitoring().GetAutoTLSSecretName(), Namespace: dk.Namespace}, secret))
+
+		assert.Contains(t, secret.Data, tlsconsts.TLSCrtDataName, "secret should contain "+tlsconsts.TLSCrtDataName+" field")
+		assert.Contains(t, secret.Data, tlsconsts.TLSKeyDataName, "secret should contain "+tlsconsts.TLSKeyDataName+" field")
+		assert.Contains(t, secret.Data, tlsconsts.TLSServerCrtDataName, "secret should contain "+tlsconsts.TLSServerCrtDataName+" field")
 	})
 }

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -40,6 +40,7 @@ const (
 	AnnotationAuthTokenHash        = api.InternalFlagPrefix + "kubemon-authtoken-hash"
 	AnnotationCustomPropertiesHash = api.InternalFlagPrefix + "kubemon-customproperties-hash"
 	AnnotationKSPMTokenHash        = api.InternalFlagPrefix + "kubemon-kspm-token-hash"
+	AnnotationTLSSecretHash        = api.InternalFlagPrefix + "kubemon-tls-secret-hash"
 	StorageVolumeName              = "kubemon-storage"
 	AuthTokenVolumeName            = "kubemon-authtoken-secret"
 	kspmTokenVolumeName            = "kspm-token"
@@ -113,6 +114,7 @@ func buildPodAnnotations(dk *dynakube.DynaKube, tokenHash, authTokenHash, custom
 
 	if dk.KSPM().IsEnabled() {
 		annotations[AnnotationKSPMTokenHash] = dk.KSPM().TokenSecretHash
+		annotations[AnnotationTLSSecretHash] = dk.KubernetesMonitoring().TLSSecretHash
 	}
 
 	return annotations
@@ -220,15 +222,25 @@ func buildVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 	}
 
 	if dk.KSPM().IsEnabled() {
-		volumes = append(volumes, corev1.Volume{
-			Name: kspmTokenVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName:  dk.KSPM().GetTokenSecretName(),
-					DefaultMode: new(int32(0o640)),
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: kspmTokenVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  dk.KSPM().GetTokenSecretName(),
+						DefaultMode: new(int32(0o640)),
+					},
 				},
 			},
-		})
+			corev1.Volume{
+				Name: agconsts.CertsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  dk.KubernetesMonitoring().GetTLSSecretName(),
+						DefaultMode: new(int32(0o640)),
+					},
+				},
+			})
 	}
 
 	return volumes
@@ -265,12 +277,18 @@ func buildVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 	}
 
 	if dk.KSPM().IsEnabled() {
-		mounts = append(mounts, corev1.VolumeMount{
-			Name:      kspmTokenVolumeName,
-			ReadOnly:  true,
-			MountPath: kspmTokenMountPath,
-			SubPath:   kspm.TokenSecretKey,
-		})
+		mounts = append(mounts,
+			corev1.VolumeMount{
+				Name:      kspmTokenVolumeName,
+				ReadOnly:  true,
+				MountPath: kspmTokenMountPath,
+				SubPath:   kspm.TokenSecretKey,
+			},
+			corev1.VolumeMount{
+				Name:      agconsts.CertsVolumeName,
+				ReadOnly:  true,
+				MountPath: agconsts.CertsMountPath,
+			})
 	}
 
 	return mounts

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
@@ -421,6 +421,69 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		assert.Contains(t, names, dk.TenantRegistryPullSecretName())
 		assert.Contains(t, names, "my-custom-pull-secret")
 	})
+
+	t.Run("KSPM disabled, no automatic TLS secret", func(t *testing.T) {
+		dk := newTestDynaKube()
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		assert.False(t, slices.ContainsFunc(sts.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+			return v.Secret != nil && v.Secret.SecretName == dk.KubernetesMonitoring().GetAutoTLSSecretName()
+		}))
+	})
+
+	t.Run("KSPM disabled, neither custom nor automatic TLS secret is created", func(t *testing.T) {
+		dk := newTestDynaKube()
+		dk.Spec.KubernetesMonitoring.TLSCertsRef = &kubemonapi.TLSCertsRef{
+			SecretName: "custom-tls-secret",
+		}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		assert.False(t, slices.ContainsFunc(sts.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+			return v.Secret != nil && (v.Secret.SecretName == "custom-tls-secret" || v.Secret.SecretName == dk.KubernetesMonitoring().GetAutoTLSSecretName())
+		}))
+	})
+
+	t.Run("KSPM enabled, automatic TLS certificate volume and mount are added", func(t *testing.T) {
+		dk := newTestDynaKube()
+		dk.Spec.KSPM = &kspmapi.Spec{}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		certVolume := k8svolume.FindByName(sts.Spec.Template.Spec.Volumes, agconsts.CertsVolumeName)
+		require.NotNil(t, certVolume, agconsts.CertsVolumeName+" volume not found")
+		require.NotNil(t, certVolume.Secret)
+		require.NotNil(t, certVolume.Secret.DefaultMode)
+		assert.Equal(t, dk.KubernetesMonitoring().GetAutoTLSSecretName(), certVolume.Secret.SecretName)
+		assert.EqualValues(t, 0o640, *certVolume.Secret.DefaultMode)
+
+		container := sts.Spec.Template.Spec.Containers[0]
+		certMount, err := k8smount.Find(container.VolumeMounts, agconsts.CertsVolumeName)
+		require.NoError(t, err)
+		assert.True(t, certMount.ReadOnly)
+		assert.Equal(t, agconsts.CertsMountPath, certMount.MountPath)
+	})
+
+	t.Run("KSPM enabled, custom TLS certificate volume and mount are added", func(t *testing.T) {
+		dk := newTestDynaKube()
+		dk.Spec.KubernetesMonitoring.TLSCertsRef = &kubemonapi.TLSCertsRef{
+			SecretName: "custom-tls-secret",
+		}
+		dk.Spec.KSPM = &kspmapi.Spec{}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		certVolume := k8svolume.FindByName(sts.Spec.Template.Spec.Volumes, agconsts.CertsVolumeName)
+		require.NotNil(t, certVolume, agconsts.CertsVolumeName+" volume not found")
+		require.NotNil(t, certVolume.Secret)
+		require.NotNil(t, certVolume.Secret.DefaultMode)
+		// dk.KubernetesMonitoring().GetTLSSecretName() not called to make sure custom secret has higher priority
+		assert.Equal(t, "custom-tls-secret", certVolume.Secret.SecretName)
+		assert.EqualValues(t, 0o640, *certVolume.Secret.DefaultMode)
+
+		container := sts.Spec.Template.Spec.Containers[0]
+		certMount, err := k8smount.Find(container.VolumeMounts, agconsts.CertsVolumeName)
+		require.NoError(t, err)
+		assert.True(t, certMount.ReadOnly)
+		assert.Equal(t, agconsts.CertsMountPath, certMount.MountPath)
+	})
 }
 
 func TestReconcileMetadata(t *testing.T) {

--- a/pkg/controllers/dynakube/otelc/statefulset/volumes.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/volumes.go
@@ -54,7 +54,7 @@ func setVolumes(dk *dynakube.DynaKube) func(o *appsv1.StatefulSet) {
 					SecretName: dk.ActiveGate().GetTLSSecretName(),
 					Items: []corev1.KeyToPath{
 						{
-							Key:  dynakube.ServerCertKey,
+							Key:  consts.TLSServerCrtDataName,
 							Path: otelcconsts.ActiveGateCertFile,
 						},
 					},

--- a/pkg/controllers/dynakube/otelc/statefulset/volumes_test.go
+++ b/pkg/controllers/dynakube/otelc/statefulset/volumes_test.go
@@ -275,7 +275,7 @@ func agCertVolume(dk *dynakube.DynaKube) corev1.Volume {
 				SecretName: dk.ActiveGate().GetTLSSecretName(),
 				Items: []corev1.KeyToPath{
 					{
-						Key:  dynakube.ServerCertKey,
+						Key:  consts.TLSServerCrtDataName,
 						Path: otelcconsts.ActiveGateCertFile,
 					},
 				},

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig_test.go
@@ -169,7 +169,7 @@ func TestGenerateForDynakube(t *testing.T) {
 				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
-				dynakube.ServerCertKey: []byte("test-cert-value"),
+				consts.TLSServerCrtDataName: []byte("test-cert-value"),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),
@@ -271,7 +271,7 @@ func TestGenerateForDynakube(t *testing.T) {
 				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
-				dynakube.ServerCertKey: []byte("test-cert-value"),
+				consts.TLSServerCrtDataName: []byte("test-cert-value"),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),
@@ -405,7 +405,7 @@ func TestGenerateForDynakube(t *testing.T) {
 				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
-				dynakube.ServerCertKey: []byte("test-cert-value"),
+				consts.TLSServerCrtDataName: []byte("test-cert-value"),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),
@@ -472,7 +472,7 @@ func TestGenerateForDynakube(t *testing.T) {
 				token.PaaSKey: []byte(testPaasToken),
 			}),
 			clientSecret(dk.ActiveGate().TLSSecretName, testNamespaceDynatrace, map[string][]byte{
-				dynakube.ServerCertKey: []byte("test-cert-value"),
+				consts.TLSServerCrtDataName: []byte("test-cert-value"),
 			}),
 			clientSecret(dk.OneAgent().GetTenantSecret(), testNamespaceDynatrace, map[string][]byte{
 				"tenant-token": []byte(testTenantToken),

--- a/pkg/injection/otlp/exporterconfig/secret_generator_test.go
+++ b/pkg/injection/otlp/exporterconfig/secret_generator_test.go
@@ -126,7 +126,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
-				dynakube.TLSCertKey: []byte(testCrt),
+				consts.TLSCrtDataName: []byte(testCrt),
 			}),
 		)
 
@@ -192,7 +192,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 				token.DataIngestKey: []byte(testDataIngestToken),
 			}),
 			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{
-				dynakube.TLSCertKey: []byte(testCrt),
+				consts.TLSCrtDataName: []byte(testCrt),
 			}),
 			clientSecret(consts.OTLPExporterSecretName, testNamespace, map[string][]byte{
 				token.DataIngestKey: []byte(oldDataIngestToken),
@@ -295,7 +295,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			namespace2,
 			terminatingNS,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
-			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
+			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{consts.TLSCrtDataName: []byte(testCrt)}),
 		)
 
 		secretGenerator := NewSecretGenerator(clt, clt)
@@ -355,7 +355,7 @@ func TestSecretGenerator_GenerateForDynakube(t *testing.T) {
 			dk,
 			nonInjected,
 			clientSecret(testDynakube, testNamespaceDynatrace, map[string][]byte{token.DataIngestKey: []byte(testDataIngestToken)}),
-			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{dynakube.TLSCertKey: []byte(testCrt)}),
+			clientSecret(tlsSecretName, testNamespaceDynatrace, map[string][]byte{consts.TLSCrtDataName: []byte(testCrt)}),
 		)
 
 		secretGenerator := NewSecretGenerator(clt, clt)

--- a/pkg/webhook/mutation/pod/webhook_integration_test.go
+++ b/pkg/webhook/mutation/pod/webhook_integration_test.go
@@ -1233,7 +1233,7 @@ func TestOTLPWebhook(t *testing.T) { //nolint:revive
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				dynakube.TLSCertKey: []byte(agCertData),
+				consts.TLSCrtDataName: []byte(agCertData),
 			},
 		}
 		integrationtests.CreateKubernetesObject(t, clt, agCertSecret)
@@ -1632,7 +1632,7 @@ func getOTLPExporterCertsSecret(namespace string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			dynakube.TLSCertKey: []byte("ag-cert-data"),
+			consts.TLSCrtDataName: []byte("ag-cert-data"),
 		},
 	}
 }

--- a/test/e2e/features/cloudnative/codemodules/codemodules.go
+++ b/test/e2e/features/cloudnative/codemodules/codemodules.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
+	opconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	dtcsi "github.com/Dynatrace/dynatrace-operator/pkg/controllers/csi"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	oacommon "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator/oneagent"
@@ -192,7 +193,7 @@ func getAgTLSSecret(secret *corev1.Secret) features.Func {
 		err := envConfig.Client().Resources().Get(ctx, secret.Name, secret.Namespace, secret)
 		require.NoError(t, err)
 
-		_, ok := secret.Data[dynakube.ServerCertKey]
+		_, ok := secret.Data[opconsts.TLSServerCrtDataName]
 		require.True(t, ok)
 
 		return ctx
@@ -229,7 +230,7 @@ func WithProxyAndAGCert(t *testing.T, proxySpec *value.Source) features.Feature 
 	agP12, _ := os.ReadFile(filepath.Join(project.TestDataDir(), agCertificateAndPrivateKey))
 	agSecret := k8ssecret.New(agSecretName, cloudNativeDynakube.Namespace,
 		map[string][]byte{
-			dynakube.ServerCertKey:          agCrt,
+			opconsts.TLSServerCrtDataName:   agCrt,
 			agCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", k8ssecret.Create(agSecret))
@@ -312,8 +313,8 @@ func WithProxyAndAutomaticAGCert(t *testing.T, proxySpec *value.Source) features
 	}
 	builder.Assess("read AG TLS secret", getAgTLSSecret(&agTLSSecret))
 
-	cloudnative.AssessSampleContainer(builder, sampleApp, func() []byte { return agTLSSecret.Data[dynakube.ServerCertKey] }, nil)
-	cloudnative.AssessOneAgentContainer(builder, func() []byte { return agTLSSecret.Data[dynakube.ServerCertKey] }, nil)
+	cloudnative.AssessSampleContainer(builder, sampleApp, func() []byte { return agTLSSecret.Data[opconsts.TLSServerCrtDataName] }, nil)
+	cloudnative.AssessOneAgentContainer(builder, func() []byte { return agTLSSecret.Data[opconsts.TLSServerCrtDataName] }, nil)
 	cloudnative.AssessActiveGateContainer(builder, &cloudNativeDynakube, nil)
 
 	// Register sample, dynakubeComponents and operator uninstall
@@ -353,7 +354,7 @@ func WithProxyCAAndAGCert(t *testing.T, proxySpec *value.Source) features.Featur
 	agP12, _ := os.ReadFile(filepath.Join(project.TestDataDir(), agCertificateAndPrivateKey))
 	agSecret := k8ssecret.New(agSecretName, cloudNativeDynakube.Namespace,
 		map[string][]byte{
-			dynakube.ServerCertKey:          agCrt,
+			opconsts.TLSServerCrtDataName:   agCrt,
 			agCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", k8ssecret.Create(agSecret))
@@ -454,8 +455,8 @@ func WithProxyCAAndAutomaticAGCert(t *testing.T, proxySpec *value.Source) featur
 	}
 	builder.Assess("read AG TLS secret", getAgTLSSecret(&agTLSSecret))
 
-	cloudnative.AssessSampleContainer(builder, sampleApp, func() []byte { return agTLSSecret.Data[dynakube.ServerCertKey] }, trustedCa)
-	cloudnative.AssessOneAgentContainer(builder, func() []byte { return agTLSSecret.Data[dynakube.ServerCertKey] }, trustedCa)
+	cloudnative.AssessSampleContainer(builder, sampleApp, func() []byte { return agTLSSecret.Data[opconsts.TLSServerCrtDataName] }, trustedCa)
+	cloudnative.AssessOneAgentContainer(builder, func() []byte { return agTLSSecret.Data[opconsts.TLSServerCrtDataName] }, trustedCa)
 	cloudnative.AssessActiveGateContainer(builder, &cloudNativeDynakube, trustedCa)
 
 	// Register sample, dynakubeComponents and operator uninstall

--- a/test/e2e/features/logmonitoring/logmonitoring.go
+++ b/test/e2e/features/logmonitoring/logmonitoring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/token"
+	opconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/configsecret"
 	lmdaemonset "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/logmonitoring/logmonsettings"
@@ -70,7 +71,7 @@ func Feature(t *testing.T) features.Feature {
 
 	agSecret := k8ssecret.New(consts.AgSecretName, testDynakube.Namespace,
 		map[string][]byte{
-			dynakube.ServerCertKey:                 agCrt,
+			opconsts.TLSServerCrtDataName:          agCrt,
 			consts.AgCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", k8ssecret.Create(agSecret))

--- a/test/e2e/features/supportarchive/support_archive.go
+++ b/test/e2e/features/supportarchive/support_archive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/extensions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	opconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/consts"
 	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/dynakube"
@@ -106,7 +107,7 @@ func Feature(t *testing.T) features.Feature {
 
 	agSecret := k8ssecret.New(consts.AgSecretName, testDynakube.Namespace,
 		map[string][]byte{
-			dynakube.ServerCertKey:                 agCrt,
+			opconsts.TLSServerCrtDataName:          agCrt,
 			consts.AgCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", k8ssecret.Create(agSecret))

--- a/test/e2e/features/telemetryingest/telemetryingest.go
+++ b/test/e2e/features/telemetryingest/telemetryingest.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
+	opconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	otelcconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/otelc/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/consts"
 	componentActiveGate "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
@@ -408,7 +409,7 @@ func createAgTLSSecret(namespace string) (corev1.Secret, error) {
 
 	return k8ssecret.New(consts.AgSecretName, namespace,
 		map[string][]byte{
-			dynakube.ServerCertKey:                 agCrt,
+			opconsts.TLSServerCrtDataName:          agCrt,
 			consts.AgCertificateAndPrivateKeyField: agP12,
 		}), nil
 }

--- a/test/e2e/features/usepublicregistry/deploy.go
+++ b/test/e2e/features/usepublicregistry/deploy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
+	opconsts "github.com/Dynatrace/dynatrace-operator/pkg/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/cloudnative"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/consts"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
@@ -400,7 +401,7 @@ func logMonFeature(t *testing.T, featureName, dkName, override string) features.
 
 	agSecret := k8ssecret.New(consts.AgSecretName, testDynakube.Namespace,
 		map[string][]byte{
-			dynakube.ServerCertKey:                 agCrt,
+			opconsts.TLSServerCrtDataName:          agCrt,
 			consts.AgCertificateAndPrivateKeyField: agP12,
 		})
 	builder.Assess("create AG TLS secret", k8ssecret.Create(agSecret))


### PR DESCRIPTION
[JIRA](https://dt-rnd.atlassian.net/browse/ICP-7552)

## Description

TLS connection is always established between KubeMon and KSPM components.
Self-signed TLS certificate for KubeMon AG is created by the operator or custom secret is used.
KubeMon POD and KSPM POD are restarted if hash value of the TLS secret.Data is changed:
- automatic TLS secret is not rotated but can be deleted by a user
- custom secret can be changed
- the kubemon spec can be changed

## How can this be tested?

unittests

deploy
- dk with KSPM+AG-KubeMon
- dk with KSPM+AG+"feature.dynatrace.com/"automatic-tls-certificate:false" -KubeMon
- dk with KSPM+KubeMon+AG (KSPM connected to KubeMon AG)
- dk with KSPM+KubeMon-AG

expected KSPM messages:
```
 Info: Collection uploaded to "https://dynakube-activegate.dynatrace/e/<tenant>/api/v2/kubernetes/node-config/ingest?node=...".

 Info: Collection uploaded to "https://dynakube-kubemon.dynatrace/e/<tenant>/api/v2/kubernetes/node-config/ingest?node=...".  
```