### PR TITLE
rename pullPolicy -> imagePullPolicy in dtprometheus complete.yaml sample

### DIFF
--- a/assets/samples/dtprometheus/v1alpha1/complete.yaml
+++ b/assets/samples/dtprometheus/v1alpha1/complete.yaml
@@ -53,7 +53,7 @@ spec:
     # Overrides the default Target Allocator image (full reference including tag or digest).
     # When omitted the operator uses the image configured in the tenant.
     image: docker.io/dynatrace/otel-target-allocator:latest
-    pullPolicy: IfNotPresent
+    imagePullPolicy: IfNotPresent
 
     # Extra command-line flags for the Target Allocator.
     # The operator owns the config file mounted at /conf/targetallocator.yaml, and
@@ -138,7 +138,7 @@ spec:
     # Overrides the default scraper (OTel Collector) image (full reference including tag or digest).
     # When omitted the operator uses the image provided via the image endpoint.
     image: docker.io/dynatrace/dynatrace-otel-collector:latest
-    pullPolicy: IfNotPresent
+    imagePullPolicy: IfNotPresent
 
     # Extra command-line flags for the collector.
     # The only flags accepted are --config, --set and --feature-gates.
@@ -219,7 +219,7 @@ spec:
     # Overrides the default gateway (OTel Collector) image (full reference including tag or digest).
     # When omitted the operator uses the image provided via the image endpoint.
     image: docker.io/dynatrace/dynatrace-otel-collector:latest
-    pullPolicy: IfNotPresent
+    imagePullPolicy: IfNotPresent
 
     # Extra command-line flags for the collector.
     # The only flags accepted are --config, --set and --feature-gates.


### PR DESCRIPTION
## Description

when user apply complete.yaml it faces:
```
Error from server (BadRequest): error when creating "assets/samples/dtprometheus/v1alpha1/complete.yaml": DTPrometheus in version "v1alpha1" cannot be handled as a DTPrometheus: strict decoding error: unknown field "spec.gateway.pullPolicy", unknown field "spec.scraper.pullPolicy", unknown field "spec.targetAllocator.pullPolicy"
```

## How can this be tested?
`k apply -f assets/samples/dtprometheus/v1alpha1/complete.yaml `