### PR TITLE
dtprometheus fetch in support-archive

### DIFF
--- a/cmd/supportarchive/resource_query.go
+++ b/cmd/supportarchive/resource_query.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/dtprometheus"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
@@ -32,6 +34,17 @@ type resourceQueryGroup struct {
 type resourceQuery struct {
 	groupVersionKind schema.GroupVersionKind
 	filters          []client.ListOption
+}
+
+type customResourceSpec struct {
+	crdName          string
+	groupVersionKind schema.GroupVersionKind
+}
+
+var customResourceSpecs = []customResourceSpec{
+	{"dynakubes.dynatrace.com", toGroupVersionKind(latest.GroupVersion, dynakube.DynaKube{})},
+	{"edgeconnects.dynatrace.com", toGroupVersionKind(v1alpha2.GroupVersion, edgeconnect.EdgeConnect{})},
+	{"dtprometheuses.dynatrace.com", toGroupVersionKind(v1alpha1.GroupVersion, dtprometheus.DTPrometheus{})},
 }
 
 func getQueries(namespace string, appName string) []resourceQuery {
@@ -93,11 +106,13 @@ func getComponentsQueryGroup(namespace string, appName string, labelKey string) 
 }
 
 func getCustomResourcesQueryGroup(namespace string) resourceQueryGroup {
+	gvks := make([]schema.GroupVersionKind, 0, len(customResourceSpecs))
+	for _, spec := range customResourceSpecs {
+		gvks = append(gvks, spec.groupVersionKind)
+	}
+
 	return resourceQueryGroup{
-		resources: []schema.GroupVersionKind{
-			toGroupVersionKind(latest.GroupVersion, dynakube.DynaKube{}),
-			toGroupVersionKind(v1alpha2.GroupVersion, edgeconnect.EdgeConnect{}),
-		},
+		resources: gvks,
 		filters: []client.ListOption{
 			client.InNamespace(namespace),
 		},

--- a/cmd/supportarchive/resource_query.go
+++ b/cmd/supportarchive/resource_query.go
@@ -36,17 +36,6 @@ type resourceQuery struct {
 	filters          []client.ListOption
 }
 
-type customResourceSpec struct {
-	crdName          string
-	groupVersionKind schema.GroupVersionKind
-}
-
-var customResourceSpecs = []customResourceSpec{
-	{"dynakubes.dynatrace.com", toGroupVersionKind(latest.GroupVersion, dynakube.DynaKube{})},
-	{"edgeconnects.dynatrace.com", toGroupVersionKind(v1alpha2.GroupVersion, edgeconnect.EdgeConnect{})},
-	{"dtprometheuses.dynatrace.com", toGroupVersionKind(v1alpha1.GroupVersion, dtprometheus.DTPrometheus{})},
-}
-
 func getQueries(namespace string, appName string) []resourceQuery {
 	return slices.Concat(
 		getInjectedNamespaceQueryGroup().getQueries(),
@@ -106,13 +95,12 @@ func getComponentsQueryGroup(namespace string, appName string, labelKey string) 
 }
 
 func getCustomResourcesQueryGroup(namespace string) resourceQueryGroup {
-	gvks := make([]schema.GroupVersionKind, 0, len(customResourceSpecs))
-	for _, spec := range customResourceSpecs {
-		gvks = append(gvks, spec.groupVersionKind)
-	}
-
 	return resourceQueryGroup{
-		resources: gvks,
+		resources: []schema.GroupVersionKind{
+			toGroupVersionKind(latest.GroupVersion, dynakube.DynaKube{}),
+			toGroupVersionKind(v1alpha2.GroupVersion, edgeconnect.EdgeConnect{}),
+			toGroupVersionKind(v1alpha1.GroupVersion, dtprometheus.DTPrometheus{}),
+		},
 		filters: []client.ListOption{
 			client.InNamespace(namespace),
 		},

--- a/cmd/supportarchive/resource_query_test.go
+++ b/cmd/supportarchive/resource_query_test.go
@@ -13,7 +13,7 @@ const namespace = "dynatrace"
 
 func TestObjectQuerySyntax(t *testing.T) {
 	queries := getQueries(namespace, defaultOperatorAppName)
-	assert.Len(t, queries, 20)
+	assert.Len(t, queries, 21)
 
 	for _, query := range queries {
 		assert.NotEmpty(t, query.groupVersionKind.Kind)

--- a/cmd/supportarchive/resources.go
+++ b/cmd/supportarchive/resources.go
@@ -147,22 +147,21 @@ func (collector k8sResourceCollector) readCustomResourceDefinitions() (*unstruct
 	resourceList := &unstructured.UnstructuredList{}
 	resourceList.SetGroupVersionKind(toGroupVersionKind(apiextensionsv1.SchemeGroupVersion, apiextensionsv1.CustomResourceDefinition{}))
 
-	for _, spec := range customResourceSpecs {
-		var crd apiextensionsv1.CustomResourceDefinition
-		if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: spec.crdName}, &crd); err != nil {
-			switch {
-			case k8serrors.IsForbidden(err):
-				logInfof(collector.log, "no permission to get CRD %s, skipping", spec.crdName)
-			case k8serrors.IsNotFound(err):
-				logInfof(collector.log, "CRD %s not installed, skipping", spec.crdName)
-			default:
-				return nil, err
-			}
+	var dynaKube apiextensionsv1.CustomResourceDefinition
+	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "dynakubes.dynatrace.com"}, &dynaKube); err != nil {
+		return nil, err
+	}
 
-			continue
-		}
+	var edgeConnect apiextensionsv1.CustomResourceDefinition
+	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "edgeconnects.dynatrace.com"}, &edgeConnect); err != nil {
+		return nil, err
+	}
 
-		resourceList.Items = append(resourceList.Items, collector.getCRD(crd))
+	resourceList.Items = append(resourceList.Items, collector.getCRD(dynaKube), collector.getCRD(edgeConnect))
+
+	var dtPrometheus apiextensionsv1.CustomResourceDefinition
+	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "dtprometheuses.dynatrace.com"}, &dtPrometheus); err == nil {
+		resourceList.Items = append(resourceList.Items, collector.getCRD(dtPrometheus))
 	}
 
 	return resourceList, nil

--- a/cmd/supportarchive/resources.go
+++ b/cmd/supportarchive/resources.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -56,8 +55,6 @@ func (collector k8sResourceCollector) Do() error {
 		resourceList, err := collector.readObjectsList(query.groupVersionKind, query.filters)
 		if err != nil {
 			switch {
-			case k8serrors.IsForbidden(err):
-				logInfof(collector.log, "no permission to list %s, skipping", query.groupVersionKind.String())
 			case k8smeta.IsNoMatchError(err):
 				logInfof(collector.log, "CRD not installed, skipping %s", query.groupVersionKind.String())
 			default:

--- a/cmd/supportarchive/resources.go
+++ b/cmd/supportarchive/resources.go
@@ -163,6 +163,7 @@ func (collector k8sResourceCollector) readCustomResourceDefinitions() (*unstruct
 		if !k8serrors.IsForbidden(err) && !k8serrors.IsNotFound(err) {
 			return nil, err
 		}
+
 		logInfof(collector.log, "skipping dtprometheuses.dynatrace.com CRD")
 	} else {
 		resourceList.Items = append(resourceList.Items, collector.getCRD(dtPrometheus))

--- a/cmd/supportarchive/resources.go
+++ b/cmd/supportarchive/resources.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,7 +24,6 @@ import (
 const (
 	k8sResourceCollectorName = "k8sResourceCollector"
 	webhookValidatorName     = "dynatrace-webhook"
-	crdNameSuffix            = "dynatrace.com"
 )
 
 type k8sResourceCollector struct {
@@ -54,7 +55,14 @@ func (collector k8sResourceCollector) Do() error {
 	for _, query := range getQueries(collector.namespace, collector.appName) {
 		resourceList, err := collector.readObjectsList(query.groupVersionKind, query.filters)
 		if err != nil {
-			logErrorf(collector.log, err, "could not get manifest for %s", query.groupVersionKind.String())
+			switch {
+			case k8serrors.IsForbidden(err):
+				logInfof(collector.log, "no permission to list %s, skipping", query.groupVersionKind.String())
+			case k8smeta.IsNoMatchError(err):
+				logInfof(collector.log, "CRD not installed, skipping %s", query.groupVersionKind.String())
+			default:
+				logErrorf(collector.log, err, "could not get manifest for %s", query.groupVersionKind.String())
+			}
 
 			continue
 		}
@@ -139,17 +147,23 @@ func (collector k8sResourceCollector) readCustomResourceDefinitions() (*unstruct
 	resourceList := &unstructured.UnstructuredList{}
 	resourceList.SetGroupVersionKind(toGroupVersionKind(apiextensionsv1.SchemeGroupVersion, apiextensionsv1.CustomResourceDefinition{}))
 
-	var dynaKube apiextensionsv1.CustomResourceDefinition
-	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "dynakubes.dynatrace.com"}, &dynaKube); err != nil {
-		return nil, err
-	}
+	for _, spec := range customResourceSpecs {
+		var crd apiextensionsv1.CustomResourceDefinition
+		if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: spec.crdName}, &crd); err != nil {
+			switch {
+			case k8serrors.IsForbidden(err):
+				logInfof(collector.log, "no permission to get CRD %s, skipping", spec.crdName)
+			case k8serrors.IsNotFound(err):
+				logInfof(collector.log, "CRD %s not installed, skipping", spec.crdName)
+			default:
+				return nil, err
+			}
 
-	var edgeConnect apiextensionsv1.CustomResourceDefinition
-	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "edgeconnects.dynatrace.com"}, &edgeConnect); err != nil {
-		return nil, err
-	}
+			continue
+		}
 
-	resourceList.Items = append(resourceList.Items, collector.getCRD(dynaKube), collector.getCRD(edgeConnect))
+		resourceList.Items = append(resourceList.Items, collector.getCRD(crd))
+	}
 
 	return resourceList, nil
 }

--- a/cmd/supportarchive/resources.go
+++ b/cmd/supportarchive/resources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -56,7 +57,8 @@ func (collector k8sResourceCollector) Do() error {
 		if err != nil {
 			switch {
 			case k8smeta.IsNoMatchError(err):
-				logInfof(collector.log, "CRD not installed, skipping %s", query.groupVersionKind.String())
+				// CRD not installed, skip
+				continue
 			default:
 				logErrorf(collector.log, err, "could not get manifest for %s", query.groupVersionKind.String())
 			}
@@ -157,7 +159,12 @@ func (collector k8sResourceCollector) readCustomResourceDefinitions() (*unstruct
 	resourceList.Items = append(resourceList.Items, collector.getCRD(dynaKube), collector.getCRD(edgeConnect))
 
 	var dtPrometheus apiextensionsv1.CustomResourceDefinition
-	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "dtprometheuses.dynatrace.com"}, &dtPrometheus); err == nil {
+	if err := collector.apiReader.Get(collector.context, client.ObjectKey{Name: "dtprometheuses.dynatrace.com"}, &dtPrometheus); err != nil {
+		if !k8serrors.IsForbidden(err) && !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+		logInfof(collector.log, "skipping dtprometheuses.dynatrace.com CRD: %s", err)
+	} else {
 		resourceList.Items = append(resourceList.Items, collector.getCRD(dtPrometheus))
 	}
 

--- a/cmd/supportarchive/resources.go
+++ b/cmd/supportarchive/resources.go
@@ -163,7 +163,7 @@ func (collector k8sResourceCollector) readCustomResourceDefinitions() (*unstruct
 		if !k8serrors.IsForbidden(err) && !k8serrors.IsNotFound(err) {
 			return nil, err
 		}
-		logInfof(collector.log, "skipping dtprometheuses.dynatrace.com CRD: %s", err)
+		logInfof(collector.log, "skipping dtprometheuses.dynatrace.com CRD")
 	} else {
 		resourceList.Items = append(resourceList.Items, collector.getCRD(dtPrometheus))
 	}

--- a/cmd/supportarchive/resources_test.go
+++ b/cmd/supportarchive/resources_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/dtprometheus"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	webhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
@@ -100,6 +101,10 @@ func TestManifestCollector_Success(t *testing.T) {
 			TypeMeta:   typeMeta("EdgeConnect"),
 			ObjectMeta: objectMeta("edgeconnect1"),
 		},
+		&dtprometheus.DTPrometheus{
+			TypeMeta:   typeMeta("DTPrometheus"),
+			ObjectMeta: objectMeta("dtprometheus1"),
+		},
 		&admissionregistrationv1.MutatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "admissionregistration.k8s.io/v1",
@@ -130,6 +135,12 @@ func TestManifestCollector_Success(t *testing.T) {
 				Name: "edgeconnects.dynatrace.com",
 			},
 		},
+		&apiextensionsv1.CustomResourceDefinition{
+			TypeMeta: typeMeta("CustomResourceDefinition"),
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dtprometheuses.dynatrace.com",
+			},
+		},
 	)
 
 	buffer := bytes.Buffer{}
@@ -148,10 +159,12 @@ func TestManifestCollector_Success(t *testing.T) {
 		fmt.Sprintf("%s/job/crd-storage-migration%s", testOperatorNamespace, manifestExtension),
 		fmt.Sprintf("%s/dynakube/dynakube1%s", testOperatorNamespace, manifestExtension),
 		fmt.Sprintf("%s/edgeconnect/edgeconnect1%s", testOperatorNamespace, manifestExtension),
+		fmt.Sprintf("%s/dtprometheus/dtprometheus1%s", testOperatorNamespace, manifestExtension),
 		fmt.Sprintf("%s/mutatingwebhookconfiguration%s", "webhook_configurations", manifestExtension),
 		fmt.Sprintf("%s/validatingwebhookconfiguration%s", "webhook_configurations", manifestExtension),
 		fmt.Sprintf("%s/customresourcedefinition-dynakubes%s", "crds", manifestExtension),
 		fmt.Sprintf("%s/customresourcedefinition-edgeconnects%s", "crds", manifestExtension),
+		fmt.Sprintf("%s/customresourcedefinition-dtprometheuses%s", "crds", manifestExtension),
 	}
 
 	slices.Sort(expectedFiles)
@@ -197,7 +210,7 @@ func TestManifestCollector_PartialCollectionOnMissingResources(t *testing.T) {
 	log := newSupportArchiveLogger(&logBuffer)
 
 	queries := getQueries(testOperatorNamespace, defaultOperatorAppName)
-	require.Len(t, queries, 20)
+	require.Len(t, queries, 21)
 
 	clt := fake.NewClientWithIndex(
 		&appsv1.StatefulSet{


### PR DESCRIPTION
## Description

https://dt-rnd.atlassian.net/browse/ICP-8197


What was already there about Gateway, TargetAllocator, Scraper:

- configmaps because we fetch all configmaps in dynatrace namespace
- logs (`--managed-logs=true` by default, so all pods with `app.kubernetes.io/managed-by=dynatrace-operator`)
- manifests - fetched also through `app.kubernetes.io/managed-by=dynatrace-operator`

### What was added
- fetching dtprometheus CRD
- fetching dtprometheus CRs

## How can this be tested?

Deploy operator with and without experimental FF and fetch support-archive zip.
- Deployed with by `make deploy`
- Deploy dtprometheus with `kubectl apply -f assets/samples/dtprometheus/v1alpha1/complete.yaml` and right dynakube name
- fetched support-archive
- Deleted dtprometheus
- turned off the feature flag `helm upgrade dynatrace-operator -n dynatrace config/helm/chart/default --reuse-values --set experimental.enablePrometheus=false`
- fetched support-archive again

~logs without FF~
```
...
[support-archive]	CRD not installed, skipping dynatrace.com/v1alpha1, Kind=DTPrometheus
...
[support-archive]	no permission to get CRD dtprometheuses.dynatrace.com, skipping
[support-archive]	Collected manifest for manifests/crds/customresourcedefinition-dynakubes.yaml
[support-archive]	Collected manifest for manifests/crds/customresourcedefinition-edgeconnects.yaml
```

~When we deploy operator without feature flag - we don't have permissions to query dtprometheus crds.~ 
~That's the first error that surface while getting the object.~ 


Simplified the flow - only successful CRD fetches are logged.
CR fetch logs one message that:
```
[support-archive]	CRD not installed, skipping dynatrace.com/v1alpha1, Kind=DTPrometheus
```
