### PR TITLE
support-archive: fix modification dates for saved files

### DIFF
--- a/cmd/supportarchive/archiver.go
+++ b/cmd/supportarchive/archiver.go
@@ -5,6 +5,7 @@ package supportarchive
 
 import (
 	"io"
+	"time"
 
 	"github.com/klauspost/compress/zip"
 	"github.com/pkg/errors"
@@ -32,7 +33,11 @@ type zipArchive struct {
 }
 
 func (z zipArchive) addFile(fileName string, reader io.Reader) error {
-	w, err := z.writer.Create(fileName)
+	w, err := z.writer.CreateHeader(&zip.FileHeader{
+		Name:     fileName,
+		Method:   zip.Deflate,
+		Modified: time.Now(),
+	})
 	if err != nil {
 		return errors.WithMessagef(err, "could not create file '%s' in zip archive", fileName)
 	}


### PR DESCRIPTION
## Description

Support-archive creates folders with right date, but files had dates  like `Jan 10 1980`.
<img width="443" height="81" alt="image" src="https://github.com/user-attachments/assets/c6cfac58-330a-4f61-899d-7809eb42e053" />
In this PR date is set explicitly to `time.Now()`
<img width="423" height="86" alt="image" src="https://github.com/user-attachments/assets/d40babc5-f9c0-4c70-aeb0-5d2c000b60aa" />

## How can this be tested?

Run support archive.