### PR TITLE
Fix mark-for-termination edge case

### DIFF
--- a/pkg/clients/dynatrace/hostevent/client_test.go
+++ b/pkg/clients/dynatrace/hostevent/client_test.go
@@ -57,6 +57,13 @@ func TestGetEntityIDForIP(t *testing.T) {
 		require.ErrorAs(t, err, new(EntityNotFoundError))
 	})
 
+	t.Run("no ip provided", func(t *testing.T) {
+		// deliberately not setupClient: no request is expected to be sent at all
+		coreClient := NewClient(coremock.NewClient(t), "")
+		_, err := coreClient.GetEntityIDForIP(t.Context(), "")
+		require.EqualError(t, err, "must provide IP")
+	})
+
 	t.Run("api error 404", func(t *testing.T) {
 		coreClient := setupClient(t, &core.HTTPError{StatusCode: 404, Message: "nope"})
 		_, err := coreClient.GetEntityIDForIP(t.Context(), "1.1.1.1")

--- a/pkg/controllers/nodes/nodes_controller.go
+++ b/pkg/controllers/nodes/nodes_controller.go
@@ -145,6 +145,10 @@ func (controller *Controller) reconcileNodeUpdate(ctx context.Context, dk *dynak
 
 	if cached, err := nodeCache.GetEntry(nodeName); err == nil {
 		cacheEntry.SetLastMarkedForTerminationTimestamp(cached.LastMarkedForTermination)
+
+		if cacheEntry.IPAddress == "" {
+			cacheEntry.IPAddress = cached.IPAddress
+		}
 	}
 
 	// Handle unschedulable Nodes, if they have a OneAgent instance
@@ -242,6 +246,12 @@ func (controller *Controller) sendMarkedForTermination(ctx context.Context, dk *
 
 func (controller *Controller) markForTermination(ctx context.Context, dk *dynakube.DynaKube, cacheEntry *cache.Entry) error {
 	log := logd.FromContext(ctx)
+
+	if cacheEntry.IPAddress == "" {
+		log.Info("skipping mark for termination event, no IP address known for node", "dynakube", dk.Name, "node", cacheEntry.NodeName)
+
+		return nil
+	}
 
 	if !cacheEntry.IsMarkableForTermination(controller.timeProvider.Now().UTC()) {
 		return nil

--- a/pkg/controllers/nodes/nodes_controller_test.go
+++ b/pkg/controllers/nodes/nodes_controller_test.go
@@ -5,6 +5,7 @@ package nodes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"testing"
@@ -310,6 +311,137 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, ctrl.pruneCache(ctx, nodesCache))
+	})
+
+	t.Run("Use cached IP when DynaKube status has no IP for node", func(t *testing.T) {
+		ctx := t.Context()
+		fakeClient := createDefaultFakeClient()
+
+		// the mark for termination event has to go out with the cached IP
+		dtClient := createDTMockClient(t, "1.2.3.4", "HOST-42")
+		ctrl := createDefaultReconciler(t, fakeClient, dtClient)
+
+		// warm up the cache, so node1 is known with 1.2.3.4
+		result, err := ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		// the OneAgent pod is evicted -> the instance is kept, but without an IP
+		var dk dynakube.DynaKube
+
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "oneagent1", Namespace: testNamespace}, &dk))
+
+		dk.Status.OneAgent.Instances = map[string]oneagent.Instance{"node1": {}}
+		require.NoError(t, fakeClient.Status().Update(ctx, &dk))
+
+		// the node gets cordoned
+		var node1 corev1.Node
+
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "node1"}, &node1))
+
+		node1.Spec.Unschedulable = true
+		require.NoError(t, fakeClient.Update(ctx, &node1))
+
+		result, err = ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		// the cached IP must survive the empty DynaKube status
+		c, err := ctrl.getCache(ctx)
+		require.NoError(t, err)
+
+		entry, err := c.GetEntry("node1")
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3.4", entry.IPAddress)
+		assert.False(t, entry.LastMarkedForTermination.IsZero())
+	})
+
+	t.Run("Skip mark for termination when no IP is known for the node", func(t *testing.T) {
+		fakeClient := fake.NewClient(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			},
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+				Status: dynakube.DynaKubeStatus{
+					OneAgent: oneagent.Status{
+						// instance is known, but the OneAgent pod never reported an IP
+						Instances: map[string]oneagent.Instance{"node1": {}},
+					},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oneagent1",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					token.APIKey: []byte(testAPIToken),
+				},
+			},
+		)
+
+		// no expectations -> any call to the Dynatrace API fails the test
+		hostClient := hostclientmock.NewClient(t)
+		ctrl := createDefaultReconciler(t, fakeClient, &dynatrace.Client{HostEvent: hostClient})
+
+		result, err := ctrl.Reconcile(t.Context(), createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+	})
+
+	t.Run("Remove cache entry on node deletion when no IP is known", func(t *testing.T) {
+		ctx := t.Context()
+
+		staleEntry, err := json.Marshal(cache.Entry{
+			LastSeen:     time.Now().UTC(),
+			IPAddress:    "",
+			DynaKubeName: "oneagent1",
+		})
+		require.NoError(t, err)
+
+		fakeClient := fake.NewClient(
+			// node1 is gone from the cluster, but still in the cache without an IP
+			&dynakube.DynaKube{
+				ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+				Status: dynakube.DynaKubeStatus{
+					OneAgent: oneagent.Status{
+						Instances: map[string]oneagent.Instance{"node1": {}},
+					},
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oneagent1",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					token.APIKey: []byte(testAPIToken),
+				},
+			},
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cache.ConfigMapName,
+					Namespace: testNamespace,
+				},
+				Data: map[string]string{"node1": string(staleEntry)},
+			},
+		)
+
+		// no expectations -> any call to the Dynatrace API fails the test
+		hostClient := hostclientmock.NewClient(t)
+		ctrl := createDefaultReconciler(t, fakeClient, &dynatrace.Client{HostEvent: hostClient})
+
+		result, err := ctrl.Reconcile(ctx, createReconcileRequest("node1"))
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		nodesCache, err := cache.New(ctx, fakeClient, testNamespace, nil)
+		require.NoError(t, err)
+
+		_, err = nodesCache.GetEntry("node1")
+		require.ErrorIs(t, err, cache.ErrEntryNotFound)
 	})
 
 	t.Run("Skip reconcile when platform token is detected", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR fixes an edge case for the mark-for-termination event in the nodes-controller.

In very rare circumstances (oneagent pod is in pending / can't schedule on the node anymore for some reason), it can happen that the ipaddress in the `status.oneagent.instances[]` is empty, causing the nodes controller to fail and retry until the node is fully removed from the dynakube status or an ip is provided.

This can be prevented by: 
- using the IP we anyway have in the cache from previous runs
- or not trying to send the mark-for-termination event if we don't have an IP address

https://dt-rnd.atlassian.net/browse/ICP-6725
<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

- create dynakube with old token
- wait till the instances field in the dynakube status is populated
- delete the ip of an instance there (simulating that a pending node was added to the list) 
- cordon the node
- the node reconciler should be able to send the mark for termination event

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->