### PR TITLE
Add SecurityContext and InitContainer to KubeMon AG

### DIFF
--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -95,6 +95,10 @@ const (
 
 	DockerImageUser  int64 = 1001
 	DockerImageGroup int64 = 1001
+
+	K8sCertificateFile        = "k8s-local.jks"
+	K8scrt2jksPath            = "/opt/dynatrace/gateway/k8scrt2jks.sh"
+	InitContainerTemplateName = "certificate-loader"
 )
 
 var (

--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -96,9 +96,9 @@ const (
 	DockerImageUser  int64 = 1001
 	DockerImageGroup int64 = 1001
 
-	K8sCertificateFile        = "k8s-local.jks"
-	K8scrt2jksPath            = "/opt/dynatrace/gateway/k8scrt2jks.sh"
-	InitContainerTemplateName = "certificate-loader"
+	K8sCertificateFile = "k8s-local.jks"
+	K8scrt2jksPath     = "/opt/dynatrace/gateway/k8scrt2jks.sh"
+	InitContainerName  = "certificate-loader"
 )
 
 var (

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -57,11 +57,11 @@ func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
 	}, mod.getReadOnlyInitVolumeMounts())
 
 	securityContext := GetSecurityContext(true)
-	securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(mod.dk.ActiveGate().Annotations, consts.InitContainerTemplateName)
+	securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(mod.dk.ActiveGate().Annotations, consts.InitContainerName)
 
 	return []corev1.Container{
 		{
-			Name:            consts.InitContainerTemplateName,
+			Name:            consts.InitContainerName,
 			Image:           mod.dk.ActiveGate().GetImage(),
 			ImagePullPolicy: mod.dk.ActiveGate().ImagePullPolicy,
 			WorkingDir:      consts.InitCertLoaderWorkDirMountPath,

--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kubemon.go
@@ -21,12 +21,6 @@ var _ volumeMountModifier = KubernetesMonitoringModifier{}
 var _ initContainerModifier = KubernetesMonitoringModifier{}
 var _ builder.Modifier = KubernetesMonitoringModifier{}
 
-const (
-	k8sCertificateFile        = "k8s-local.jks"
-	k8scrt2jksPath            = "/opt/dynatrace/gateway/k8scrt2jks.sh"
-	initContainerTemplateName = "certificate-loader"
-)
-
 func NewKubernetesMonitoringModifier(dk dynakube.DynaKube, capability capability.Capability) KubernetesMonitoringModifier {
 	return KubernetesMonitoringModifier{
 		dk:         dk,
@@ -63,16 +57,16 @@ func (mod KubernetesMonitoringModifier) getInitContainers() []corev1.Container {
 	}, mod.getReadOnlyInitVolumeMounts())
 
 	securityContext := GetSecurityContext(true)
-	securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(mod.dk.ActiveGate().Annotations, initContainerTemplateName)
+	securityContext.AppArmorProfile = k8ssecuritycontext.GetAppArmorProfile(mod.dk.ActiveGate().Annotations, consts.InitContainerTemplateName)
 
 	return []corev1.Container{
 		{
-			Name:            initContainerTemplateName,
+			Name:            consts.InitContainerTemplateName,
 			Image:           mod.dk.ActiveGate().GetImage(),
 			ImagePullPolicy: mod.dk.ActiveGate().ImagePullPolicy,
 			WorkingDir:      consts.InitCertLoaderWorkDirMountPath,
 			Command:         []string{"/bin/bash"},
-			Args:            []string{"-c", k8scrt2jksPath},
+			Args:            []string{"-c", consts.K8scrt2jksPath},
 			VolumeMounts:    volumeMounts,
 			Resources:       mod.capability.Properties().Resources,
 			SecurityContext: securityContext,
@@ -106,7 +100,7 @@ func (mod KubernetesMonitoringModifier) getVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 			Name:      consts.TrustStoreVolumeName,
 			MountPath: consts.TrustStoreCacertsMountPath,
-			SubPath:   k8sCertificateFile,
+			SubPath:   consts.K8sCertificateFile,
 		},
 	}
 }

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8ssecuritycontext"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sstatefulset"
 	maputil "github.com/Dynatrace/dynatrace-operator/pkg/util/map"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
@@ -206,6 +207,46 @@ func buildVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 			Name:         StorageVolumeName,
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		},
+		{
+			Name: agconsts.GatewayLibTempVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: agconsts.GatewayDataVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: agconsts.GatewayLogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: agconsts.GatewayConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: agconsts.TrustStoreVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: agconsts.GatewaySslVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name:         agconsts.InitCertLoaderWorkDirVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
 	}
 
 	if km.CustomProperties != nil {
@@ -265,6 +306,37 @@ func buildVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 			Name:      StorageVolumeName,
 			MountPath: agconsts.GatewayTmpMountPath,
 		},
+		{
+			ReadOnly:  false,
+			Name:      agconsts.GatewaySslVolumeName,
+			MountPath: agconsts.GatewaySslMountPath,
+		},
+		{
+			ReadOnly:  false,
+			Name:      agconsts.GatewayLibTempVolumeName,
+			MountPath: agconsts.GatewayLibTempMountPath,
+		},
+		{
+			ReadOnly:  false,
+			Name:      agconsts.GatewayDataVolumeName,
+			MountPath: agconsts.GatewayDataMountPath,
+		},
+		{
+			ReadOnly:  false,
+			Name:      agconsts.GatewayLogVolumeName,
+			MountPath: agconsts.GatewayLogMountPath,
+		},
+		{
+			ReadOnly:  false,
+			Name:      agconsts.GatewayConfigVolumeName,
+			MountPath: agconsts.GatewayConfigMountPath,
+		},
+		{
+			ReadOnly:  true,
+			Name:      agconsts.TrustStoreVolumeName,
+			MountPath: agconsts.TrustStoreCacertsMountPath,
+			SubPath:   agconsts.K8sCertificateFile,
+		},
 	}
 
 	if dk.KubernetesMonitoring().CustomProperties != nil {
@@ -292,6 +364,21 @@ func buildVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 	}
 
 	return mounts
+}
+
+func buildInitVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			ReadOnly:  false,
+			Name:      agconsts.TrustStoreVolumeName,
+			MountPath: agconsts.GatewaySslMountPath,
+		},
+		{
+			ReadOnly:  false,
+			Name:      agconsts.InitCertLoaderWorkDirVolumeName,
+			MountPath: agconsts.InitCertLoaderWorkDirMountPath,
+		},
+	}
 }
 
 func (r *Reconciler) delete(ctx context.Context, dk *dynakube.DynaKube) error {
@@ -366,6 +453,18 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		return nil, err
 	}
 
+	initContainer := corev1.Container{
+		Name:            agconsts.InitContainerTemplateName,
+		Image:           imageURI,
+		ImagePullPolicy: dk.KubernetesMonitoring().ImagePullPolicy,
+		WorkingDir:      agconsts.InitCertLoaderWorkDirMountPath,
+		Command:         []string{"/bin/bash"},
+		Args:            []string{"-c", agconsts.K8scrt2jksPath},
+		VolumeMounts:    buildInitVolumeMounts(),
+		Resources:       dk.KubernetesMonitoring().Resources,
+		SecurityContext: buildSecurityContext(dk.KubernetesMonitoring().Annotations, agconsts.InitContainerTemplateName),
+	}
+
 	container := corev1.Container{
 		Name:            ContainerName,
 		Image:           imageURI,
@@ -379,9 +478,13 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 			{Name: agconsts.HTTPSServicePortName, ContainerPort: agconsts.HTTPSContainerPort},
 			{Name: agconsts.HTTPServicePortName, ContainerPort: agconsts.HTTPContainerPort},
 		},
+		SecurityContext: buildSecurityContext(dk.KubernetesMonitoring().Annotations, ContainerName),
 	}
 
 	km := dk.KubernetesMonitoring()
+
+	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, agconsts.InitContainerTemplateName)
+	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, ContainerName)
 
 	labels := k8slabel.New(k8slabel.KubeMonComponentLabel, dk.GetName(), "")
 
@@ -400,6 +503,8 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		k8sstatefulset.SetTerminationGracePeriodSeconds(km.TerminationGracePeriodSeconds),
 		k8sstatefulset.SetImagePullSecrets(dk.ImagePullSecretReferences()),
 		k8sstatefulset.SetAutomountServiceAccountToken(true),
+		k8sstatefulset.SetSecurityContext(buildPodSecurityContext()),
+		k8sstatefulset.SetInitContainer(initContainer),
 	}
 
 	return k8sstatefulset.Build(dk, km.GetStatefulSetName(), container, opts...)
@@ -468,4 +573,36 @@ func (r *Reconciler) getCustomPropertiesHash(ctx context.Context, dk *dynakube.D
 	}
 
 	return hash, nil
+}
+
+func buildSecurityContext(annotations map[string]string, containerName string) *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Privileged:               new(false),
+		AllowPrivilegeEscalation: new(false),
+		RunAsNonRoot:             new(true),
+		RunAsUser:                new(agconsts.DockerImageUser),
+		RunAsGroup:               new(agconsts.DockerImageGroup),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		ReadOnlyRootFilesystem: new(true),
+		AppArmorProfile:        k8ssecuritycontext.GetAppArmorProfile(annotations, containerName),
+	}
+}
+
+func buildPodSecurityContext() *corev1.PodSecurityContext {
+	sc := corev1.PodSecurityContext{
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	sc.FSGroup = new(agconsts.DockerImageGroup)
+
+	return &sc
 }

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -453,6 +453,8 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		return nil, err
 	}
 
+	km := dk.KubernetesMonitoring()
+
 	initContainer := corev1.Container{
 		Name:            agconsts.InitContainerTemplateName,
 		Image:           imageURI,
@@ -462,7 +464,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		Args:            []string{"-c", agconsts.K8scrt2jksPath},
 		VolumeMounts:    buildInitVolumeMounts(),
 		Resources:       dk.KubernetesMonitoring().Resources,
-		SecurityContext: buildSecurityContext(dk.KubernetesMonitoring().Annotations, agconsts.InitContainerTemplateName),
+		SecurityContext: buildSecurityContext(km.Annotations, agconsts.InitContainerTemplateName),
 	}
 
 	container := corev1.Container{
@@ -478,13 +480,10 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 			{Name: agconsts.HTTPSServicePortName, ContainerPort: agconsts.HTTPSContainerPort},
 			{Name: agconsts.HTTPServicePortName, ContainerPort: agconsts.HTTPContainerPort},
 		},
-		SecurityContext: buildSecurityContext(dk.KubernetesMonitoring().Annotations, ContainerName),
+		SecurityContext: buildSecurityContext(km.Annotations, ContainerName),
 	}
 
-	km := dk.KubernetesMonitoring()
-
-	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, agconsts.InitContainerTemplateName)
-	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, ContainerName)
+	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, agconsts.InitContainerTemplateName, ContainerName)
 
 	labels := k8slabel.New(k8slabel.KubeMonComponentLabel, dk.GetName(), "")
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -456,7 +456,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 	km := dk.KubernetesMonitoring()
 
 	initContainer := corev1.Container{
-		Name:            agconsts.InitContainerTemplateName,
+		Name:            agconsts.InitContainerName,
 		Image:           imageURI,
 		ImagePullPolicy: dk.KubernetesMonitoring().ImagePullPolicy,
 		WorkingDir:      agconsts.InitCertLoaderWorkDirMountPath,
@@ -464,7 +464,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		Args:            []string{"-c", agconsts.K8scrt2jksPath},
 		VolumeMounts:    buildInitVolumeMounts(),
 		Resources:       dk.KubernetesMonitoring().Resources,
-		SecurityContext: buildSecurityContext(km.Annotations, agconsts.InitContainerTemplateName),
+		SecurityContext: buildSecurityContext(km.Annotations, agconsts.InitContainerName),
 	}
 
 	container := corev1.Container{
@@ -483,7 +483,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		SecurityContext: buildSecurityContext(km.Annotations, ContainerName),
 	}
 
-	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, agconsts.InitContainerTemplateName, ContainerName)
+	km.Annotations = k8ssecuritycontext.RemoveAppArmorAnnotation(km.Annotations, agconsts.InitContainerName, ContainerName)
 
 	labels := k8slabel.New(k8slabel.KubeMonComponentLabel, dk.GetName(), "")
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_integration_test.go
@@ -306,14 +306,14 @@ func assertStatefulSetShape(t *testing.T, sts *appsv1.StatefulSet, dk *dynakube.
 	assert.NotNil(t, k8senv.Find(container.Env, connectioninfo.EnvDTTenant))
 	assert.NotNil(t, k8senv.Find(container.Env, connectioninfo.EnvDTServer))
 
-	require.Len(t, container.VolumeMounts, 3)
+	require.Len(t, container.VolumeMounts, 9)
 	assert.Equal(t, connectioninfo.TenantSecretVolumeName, container.VolumeMounts[0].Name)
 	assert.Equal(t, statefulset.AuthTokenVolumeName, container.VolumeMounts[1].Name)
 	assert.Equal(t, kubemonauthtoken.SecretKey, container.VolumeMounts[1].SubPath)
 	assert.Equal(t, statefulset.StorageVolumeName, container.VolumeMounts[2].Name)
 	assert.Equal(t, dk.KubernetesMonitoring().GetServiceAccountName(), sts.Spec.Template.Spec.ServiceAccountName)
 
-	require.Len(t, sts.Spec.Template.Spec.Volumes, 3)
+	require.Len(t, sts.Spec.Template.Spec.Volumes, 10)
 	assert.Equal(t, connectioninfo.TenantSecretVolumeName, sts.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(t, statefulset.AuthTokenVolumeName, sts.Spec.Template.Spec.Volumes[1].Name)
 	assert.Equal(t, statefulset.StorageVolumeName, sts.Spec.Template.Spec.Volumes[2].Name)

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8smount"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8svolume"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sstatefulset"
+	k8sversion "github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/version"
 	operatorversion "github.com/Dynatrace/dynatrace-operator/pkg/version"
 	"github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	imageclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
@@ -253,7 +254,7 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 		container := sts.Spec.Template.Spec.Containers[0]
 
-		require.Len(t, container.VolumeMounts, 3)
+		require.Len(t, container.VolumeMounts, 9)
 		assert.Equal(t, connectioninfo.TenantSecretVolumeName, container.VolumeMounts[0].Name)
 		assert.Equal(t, connectioninfo.TenantTokenMountPoint, container.VolumeMounts[0].MountPath)
 		assert.Equal(t, connectioninfo.TenantTokenKey, container.VolumeMounts[0].SubPath)
@@ -269,7 +270,7 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 		container := sts.Spec.Template.Spec.Containers[0]
 
-		require.Len(t, container.VolumeMounts, 3)
+		require.Len(t, container.VolumeMounts, 9)
 		assert.Equal(t, statefulset.AuthTokenVolumeName, container.VolumeMounts[1].Name)
 		assert.Equal(t, agconsts.AuthTokenMountPoint, container.VolumeMounts[1].MountPath)
 		assert.Equal(t, kubemonauthtoken.SecretKey, container.VolumeMounts[1].SubPath)
@@ -294,11 +295,11 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		require.Len(t, sts.Spec.Template.Spec.Containers, 1)
 		container := sts.Spec.Template.Spec.Containers[0]
 
-		require.Len(t, container.VolumeMounts, 4)
-		assert.Equal(t, kubemoncustomproperties.VolumeName, container.VolumeMounts[3].Name)
-		assert.Equal(t, kubemoncustomproperties.MountPath, container.VolumeMounts[3].MountPath)
-		assert.Equal(t, kubemoncustomproperties.DataKey, container.VolumeMounts[3].SubPath)
-		assert.True(t, container.VolumeMounts[3].ReadOnly)
+		require.Len(t, container.VolumeMounts, 10)
+		assert.Equal(t, kubemoncustomproperties.VolumeName, container.VolumeMounts[9].Name)
+		assert.Equal(t, kubemoncustomproperties.MountPath, container.VolumeMounts[9].MountPath)
+		assert.Equal(t, kubemoncustomproperties.DataKey, container.VolumeMounts[9].SubPath)
+		assert.True(t, container.VolumeMounts[9].ReadOnly)
 		assert.True(t, hasCustomPropertiesVolume(sts, dk))
 	})
 
@@ -380,7 +381,7 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
 
 		assert.Empty(t, sts.Spec.VolumeClaimTemplates)
-		require.Len(t, sts.Spec.Template.Spec.Volumes, 3)
+		require.Len(t, sts.Spec.Template.Spec.Volumes, 10)
 		assert.Equal(t, statefulset.StorageVolumeName, sts.Spec.Template.Spec.Volumes[2].Name)
 		assert.NotNil(t, sts.Spec.Template.Spec.Volumes[2].EmptyDir)
 	})
@@ -483,6 +484,274 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, certMount.ReadOnly)
 		assert.Equal(t, agconsts.CertsMountPath, certMount.MountPath)
+	})
+
+	t.Run("securityContext present", func(t *testing.T) {
+		dk := newTestDynaKube()
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+		require.NotNil(t, sts.Spec.Template.Spec.SecurityContext)
+		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+		require.NotNil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext)
+
+		checkSecurityContext := func(t *testing.T, sc *corev1.SecurityContext) {
+			require.NotNil(t, sc.Privileged)
+			assert.False(t, *sc.Privileged)
+
+			require.NotNil(t, sc.AllowPrivilegeEscalation)
+			assert.False(t, *sc.AllowPrivilegeEscalation)
+
+			require.NotNil(t, sc.RunAsNonRoot)
+			assert.True(t, *sc.RunAsNonRoot)
+
+			require.NotNil(t, sc.RunAsUser)
+			assert.Equal(t, agconsts.DockerImageUser, *sc.RunAsUser)
+
+			require.NotNil(t, sc.RunAsGroup)
+			assert.Equal(t, agconsts.DockerImageUser, *sc.RunAsGroup)
+
+			require.NotNil(t, sc.Capabilities)
+			assert.Empty(t, sc.Capabilities.Add)
+			require.Len(t, sc.Capabilities.Drop, 1)
+			assert.Contains(t, sc.Capabilities.Drop, corev1.Capability("ALL"))
+
+			require.NotNil(t, sc.SeccompProfile)
+			assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type)
+
+			require.NotNil(t, sc.ReadOnlyRootFilesystem)
+			assert.True(t, *sc.ReadOnlyRootFilesystem)
+		}
+
+		checkSecurityContext(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+		checkSecurityContext(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext)
+	})
+
+	t.Run("securityContext.AppArmorProfile is not set on cluster 1.30", func(t *testing.T) {
+		t.Cleanup(k8sversion.DisableCacheForTest(30))
+
+		dk := newTestDynaKube()
+		dk.Spec.KubernetesMonitoring.Annotations = map[string]string{
+			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + "kubemon": "runtime/default",
+		}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		require.NotNil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext)
+		assert.Nil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext.AppArmorProfile)
+
+		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+		require.Nil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+
+		assert.Contains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+"kubemon")
+	})
+
+	t.Run("securityContext.AppArmorProfile is set on cluster 1.31 for given container", func(t *testing.T) {
+		t.Cleanup(k8sversion.DisableCacheForTest(31))
+
+		dk := newTestDynaKube()
+		dk.Spec.KubernetesMonitoring.Annotations = map[string]string{
+			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + statefulset.ContainerName: "runtime/default",
+		}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		require.NotNil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext)
+		assert.Nil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext.AppArmorProfile)
+
+		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
+
+		assert.NotContains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+statefulset.ContainerName)
+	})
+
+	t.Run("securityContext.AppArmorProfile is set on cluster 1.31 for both containers", func(t *testing.T) {
+		t.Cleanup(k8sversion.DisableCacheForTest(31))
+
+		dk := newTestDynaKube()
+		dk.Spec.KubernetesMonitoring.Annotations = map[string]string{
+			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + statefulset.ContainerName:          "runtime/default",
+			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + agconsts.InitContainerTemplateName: "unconfined",
+		}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		require.NotNil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext)
+		assert.NotNil(t, sts.Spec.Template.Spec.InitContainers[0].SecurityContext.AppArmorProfile)
+		assert.Equal(t, corev1.AppArmorProfileTypeUnconfined, sts.Spec.Template.Spec.InitContainers[0].SecurityContext.AppArmorProfile.Type)
+
+		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
+		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
+		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
+
+		assert.NotContains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+statefulset.ContainerName)
+		assert.NotContains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+agconsts.InitContainerTemplateName)
+	})
+}
+
+func TestReconcileBuildsStatefulSetVolumes(t *testing.T) {
+	t.Run("basic container volume mounts", func(t *testing.T) {
+		dk := newTestDynaKube()
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+		container := sts.Spec.Template.Spec.Containers[0]
+		require.Len(t, container.VolumeMounts, 9)
+
+		mounts := []corev1.VolumeMount{
+			{
+				Name:      connectioninfo.TenantSecretVolumeName,
+				ReadOnly:  true,
+				MountPath: connectioninfo.TenantTokenMountPoint,
+				SubPath:   connectioninfo.TenantTokenKey,
+			},
+			{
+				Name:      statefulset.AuthTokenVolumeName,
+				ReadOnly:  true,
+				MountPath: agconsts.AuthTokenMountPoint,
+				SubPath:   kubemonauthtoken.SecretKey,
+			},
+			{
+				Name:      statefulset.StorageVolumeName,
+				MountPath: agconsts.GatewayTmpMountPath,
+			},
+			{
+				ReadOnly:  false,
+				Name:      agconsts.GatewaySslVolumeName,
+				MountPath: agconsts.GatewaySslMountPath,
+			},
+			{
+				ReadOnly:  false,
+				Name:      agconsts.GatewayLibTempVolumeName,
+				MountPath: agconsts.GatewayLibTempMountPath,
+			},
+			{
+				ReadOnly:  false,
+				Name:      agconsts.GatewayDataVolumeName,
+				MountPath: agconsts.GatewayDataMountPath,
+			},
+			{
+				ReadOnly:  false,
+				Name:      agconsts.GatewayLogVolumeName,
+				MountPath: agconsts.GatewayLogMountPath,
+			},
+			{
+				ReadOnly:  false,
+				Name:      agconsts.GatewayConfigVolumeName,
+				MountPath: agconsts.GatewayConfigMountPath,
+			},
+			{
+				ReadOnly:  true,
+				Name:      agconsts.TrustStoreVolumeName,
+				MountPath: agconsts.TrustStoreCacertsMountPath,
+				SubPath:   agconsts.K8sCertificateFile,
+			},
+		}
+
+		for _, mount := range mounts {
+			assert.Contains(t, container.VolumeMounts, mount, "valid %s volumeMount not found", mount.Name)
+		}
+	})
+
+	t.Run("initContainer volume mounts", func(t *testing.T) {
+		dk := newTestDynaKube()
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		require.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
+		container := sts.Spec.Template.Spec.InitContainers[0]
+		require.Len(t, container.VolumeMounts, 2)
+
+		mounts := []corev1.VolumeMount{
+			{
+				ReadOnly:  false,
+				Name:      agconsts.TrustStoreVolumeName,
+				MountPath: agconsts.GatewaySslMountPath,
+			},
+			{
+				ReadOnly:  false,
+				Name:      agconsts.InitCertLoaderWorkDirVolumeName,
+				MountPath: agconsts.InitCertLoaderWorkDirMountPath,
+			},
+		}
+
+		for _, mount := range mounts {
+			assert.Contains(t, container.VolumeMounts, mount, "valid %s volumeMount not found", mount.Name)
+		}
+	})
+
+	t.Run("basic volumes", func(t *testing.T) {
+		dk := newTestDynaKube()
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		require.Len(t, sts.Spec.Template.Spec.Volumes, 10)
+
+		km := dk.KubernetesMonitoring()
+		volumes := []corev1.Volume{
+			{
+				Name: connectioninfo.TenantSecretVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  km.GetTenantSecretName(),
+						DefaultMode: new(int32(0o640)),
+						Optional:    new(false),
+					},
+				},
+			},
+			{
+				Name: statefulset.AuthTokenVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  km.GetAuthTokenSecretName(),
+						DefaultMode: new(int32(0o640)),
+						Optional:    new(false),
+					},
+				},
+			},
+			{
+				Name:         statefulset.StorageVolumeName,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			},
+			{
+				Name: agconsts.GatewayLibTempVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: agconsts.GatewayDataVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: agconsts.GatewayLogVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: agconsts.GatewayConfigVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: agconsts.TrustStoreVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: agconsts.GatewaySslVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name:         agconsts.InitCertLoaderWorkDirVolumeName,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			},
+		}
+
+		for _, volume := range volumes {
+			assert.Contains(t, sts.Spec.Template.Spec.Volumes, volume, "valid %s volume not found", volume.Name)
+		}
 	})
 }
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
@@ -567,8 +567,8 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 
 		dk := newTestDynaKube()
 		dk.Spec.KubernetesMonitoring.Annotations = map[string]string{
-			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + statefulset.ContainerName:          "runtime/default",
-			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + agconsts.InitContainerTemplateName: "unconfined",
+			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + statefulset.ContainerName:  "runtime/default",
+			corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + agconsts.InitContainerName: "unconfined",
 		}
 		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
 
@@ -581,7 +581,7 @@ func TestReconcileBuildsStatefulSet(t *testing.T) {
 		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile.Type)
 
 		assert.NotContains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+statefulset.ContainerName)
-		assert.NotContains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+agconsts.InitContainerTemplateName)
+		assert.NotContains(t, sts.Spec.Template.Annotations, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+agconsts.InitContainerName)
 	})
 }
 

--- a/pkg/util/kubernetes/objects/k8sstatefulset/builder.go
+++ b/pkg/util/kubernetes/objects/k8sstatefulset/builder.go
@@ -108,6 +108,12 @@ func SetContainer(container corev1.Container) Option {
 	}
 }
 
+func SetInitContainer(container corev1.Container) Option {
+	return func(s *appsv1.StatefulSet) {
+		s.Spec.Template.Spec.InitContainers = append(s.Spec.Template.Spec.InitContainers, container)
+	}
+}
+
 func SetServiceAccount(serviceAccountName string) Option {
 	return func(s *appsv1.StatefulSet) {
 		s.Spec.Template.Spec.ServiceAccountName = serviceAccountName


### PR DESCRIPTION
[ICP-7803](https://dt-rnd.atlassian.net/browse/ICP-7803)

## Description

Adds initContainer that imports K8S API certificate to java certificate storage.
Adds security context to both containers. 
Migrates apparmor annotation into security context if possible.
Additionally adds RW volumes because the filesystem is RO now.

## How can this be tested?

1) unittests
2) deploy dk with KubeMon enabled and check size of the  java certs storage :
```
kubectl -n dynatrace exec -t pod/dynakube-kubemon-0 -- bash -c "ls -l /opt/dynatrace/gateway/jre/lib/security/cacerts"
```
without initContainer (`main` branch):
```
-rw-r--r-- 1 root root 167880 Apr 21 21:27 /opt/dynatrace/gateway/jre/lib/security/cacerts
```
with initContainer:
```
-rw-r--r-- 1 1001 1001 168992 Sep  1 09:34 /opt/dynatrace/gateway/jre/lib/security/cacerts
```
Sizes are the same in case of AG w/o `kubernetes-monitoring` capability and AG with `kubernetes-monitoring` capability.

[ICP-7803]: https://dt-rnd.atlassian.net/browse/ICP-7803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ