### PR TITLE
Increase revive complexity limit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - gochecksumtype
     - gocognit
     - gocritic
-    - gocyclo
     - godot
     - goheader
     - gomoddirectives
@@ -175,7 +174,7 @@ linters:
             - 468
         - name: cyclomatic
           arguments:
-            - 13
+            - 30
         - name: banned-characters
           disabled: true
         - name: forbidden-call-in-wg-go

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -387,7 +387,6 @@ func (controller *Controller) setupTokensAndClient(ctx context.Context, dk *dyna
 	return dtClient, nil
 }
 
-//nolint:revive // complexity is above 13; this function needs refactoring.
 func (controller *Controller) reconcileComponents(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error {
 	log := logd.FromContext(ctx)
 

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -421,7 +421,7 @@ func (controller *Controller) reconcileEdgeConnectRegular(ctx context.Context, e
 	return nil
 }
 
-func (controller *Controller) reconcileEdgeConnectProvisioner(ctx context.Context, ec *edgeconnect.EdgeConnect) error { //nolint:revive
+func (controller *Controller) reconcileEdgeConnectProvisioner(ctx context.Context, ec *edgeconnect.EdgeConnect) error {
 	log := logd.FromContext(ctx)
 
 	log.Info("reconcileEdgeConnectProvisioner")

--- a/test/integrationtests/environment.go
+++ b/test/integrationtests/environment.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	latest "github.com/Dynatrace/dynatrace-operator/pkg/api/latest" //nolint:revive
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1beta5"


### PR DESCRIPTION
## Description

We have two linters that check cyclomatic complexity: revive an gocyclo. revive's limit was configured to 13, but gocyclo's default is 30.
Pick the larger default, but keep using revive.

Remove unused nolint directives
