### PR TITLE
Prevent controller-runtime warning log

### DIFF
--- a/pkg/controllers/csi/provisioner/controller.go
+++ b/pkg/controllers/csi/provisioner/controller.go
@@ -104,13 +104,21 @@ func (provisioner *OneAgentProvisioner) Reconcile(ctx context.Context, request r
 	if !installconfig.GetModules().CSIDriver {
 		log.Info("CSI driver migration mode active, running cleanup only")
 
-		return reconcile.Result{RequeueAfter: longRequeueDuration}, provisioner.cleaner.Run(ctx)
+		if err := provisioner.cleaner.Run(ctx); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{RequeueAfter: longRequeueDuration}, nil
 	}
 
 	if !isProvisionerNeeded(&dk) {
 		log.Info("CSI driver provisioner not needed")
 
-		return reconcile.Result{RequeueAfter: longRequeueDuration}, provisioner.cleaner.Run(ctx)
+		if err := provisioner.cleaner.Run(ctx); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{RequeueAfter: longRequeueDuration}, nil
 	}
 
 	err = provisioner.setupFileSystem(&dk)

--- a/pkg/controllers/edgeconnect/controller.go
+++ b/pkg/controllers/edgeconnect/controller.go
@@ -242,7 +242,7 @@ func (controller *Controller) reconcileEdgeConnect(ctx context.Context, ec *edge
 
 			log.Debug("reconcileEdgeConnect status update error")
 
-			return reconcile.Result{RequeueAfter: fastRequeueInterval}, retErr
+			return reconcile.Result{}, retErr
 		}
 	}
 


### PR DESCRIPTION
## Description

Controller-runtime logs a warning if a Reconcile function returns a non-zero result with a non-zero error. Previously, the result was silently dropped but this was not the intended use of the interface so they made this error explicit.
