### PR TITLE
Handle malformed PCG ETag

### DIFF
--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
@@ -36,6 +36,7 @@ type ProcessGroupConfig struct {
 //   - On HTTP 200: *ProcessGroupConfig with ETag from response header and CBOR data, nil error.
 //   - On HTTP 304: *ProcessGroupConfig with the original ETag and nil Data, nil error.
 //   - On HTTP 404: *ProcessGroupConfig (empty), nil error. Endpoint not available.
+//   - On HTTP 400: *ProcessGroupConfig (empty), nil error. Clears a stale/rejected ETag instead of getting stuck retrying it forever.
 //   - On other errors: non-nil error.
 func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string) (*ProcessGroupConfig, error) {
 	ctx, log := logd.NewFromContext(ctx, loggerName)
@@ -66,6 +67,12 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 	if err != nil {
 		if core.IsNotFound(err) {
 			log.Info("process grouping config not available on cluster, skipping getting process grouping config")
+
+			return &ProcessGroupConfig{}, nil
+		}
+
+		if core.IsBadRequest(err) {
+			log.Info("process grouping config API rejected the cached ETag, clearing it", "error", err)
 
 			return &ProcessGroupConfig{}, nil
 		}

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
+	"regexp"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -87,6 +87,10 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 	return pgc, nil
 }
 
+var validETagRegex = regexp.MustCompile(`^"[0-9]+"$`)
+
+// IsMalformedETag reports whether etag is present but doesn't look like a real ETag from this API.
+// An empty etag means "none yet" and is not malformed.
 func IsMalformedETag(etag string) bool {
-	return strings.Contains(etag, ":dtagent")
+	return etag != "" && !validETagRegex.MatchString(etag)
 }

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/core"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
@@ -29,14 +30,13 @@ type ProcessGroupConfig struct {
 //
 // Parameters:
 //   - kubernetesClusterId: required Kubernetes cluster ID to scope the config. Empty string returns an error.
-//   - etag: optional ETag from a previous response. When non-empty, sent as If-None-Match header.
+//   - etag: optional ETag from a previous response. When non-empty, sent as If-None-Match header unless it is malformed.
 //     If the server responds with 304 Not Modified, returns a ProcessGroupConfig with the original ETag.
 //
 // Returns:
 //   - On HTTP 200: *ProcessGroupConfig with ETag from response header and CBOR data, nil error.
 //   - On HTTP 304: *ProcessGroupConfig with the original ETag and nil Data, nil error.
 //   - On HTTP 404: *ProcessGroupConfig (empty), nil error. Endpoint not available.
-//   - On HTTP 400: *ProcessGroupConfig (empty), nil error. Clears a stale/rejected ETag instead of getting stuck retrying it forever.
 //   - On other errors: non-nil error.
 func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClusterID string, etag string) (*ProcessGroupConfig, error) {
 	ctx, log := logd.NewFromContext(ctx, loggerName)
@@ -53,6 +53,11 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 		WithQueryParams(params).
 		WithHeader("Accept", "application/cbor")
 
+	if IsMalformedETag(etag) {
+		log.Info("ignoring malformed ETag", "etag", etag)
+		etag = ""
+	}
+
 	if etag != "" {
 		req = req.WithHeader(requestHeaderEtag, etag)
 	}
@@ -66,13 +71,7 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 
 	if err != nil {
 		if core.IsNotFound(err) {
-			log.Info("process grouping config not available on cluster, skipping getting process grouping config")
-
-			return &ProcessGroupConfig{}, nil
-		}
-
-		if core.IsBadRequest(err) {
-			log.Info("process grouping config API rejected the ETag, clearing it", "etag", etag, "error", err)
+			log.Info("process grouping config not available on cluster")
 
 			return &ProcessGroupConfig{}, nil
 		}
@@ -86,4 +85,8 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 	}
 
 	return pgc, nil
+}
+
+func IsMalformedETag(etag string) bool {
+	return strings.Contains(etag, ":dtagent")
 }

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig.go
@@ -72,7 +72,7 @@ func (c *ClientImpl) GetProcessGroupingConfig(ctx context.Context, kubernetesClu
 		}
 
 		if core.IsBadRequest(err) {
-			log.Info("process grouping config API rejected the cached ETag, clearing it", "error", err)
+			log.Info("process grouping config API rejected the ETag, clearing it", "etag", etag, "error", err)
 
 			return &ProcessGroupConfig{}, nil
 		}

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	testCBORData     = "\x81\x01" // minimal CBOR: array of one integer
-	testETag         = `"abc123"`
-	testResponseETag = `"def456"`
+	testETag         = `"5678"`
+	testResponseETag = `"1234"`
 	testClusterID    = "my-cluster"
 )
 
@@ -180,19 +180,18 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 	})
 
 	t.Run("bad request", func(t *testing.T) {
-		const badETag = "bad_etag"
 		serverErr := &core.HTTPError{StatusCode: http.StatusBadRequest, Message: "bad request"}
 
 		client := setupMockedProcessGroupingClient(
 			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
-			map[string]string{"If-None-Match": badETag},
+			map[string]string{"If-None-Match": testETag},
 			nil,
 			nil,
 			serverErr,
 		)
 
-		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, badETag)
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, testETag)
 		require.ErrorIs(t, err, serverErr)
 		assert.Nil(t, pgc)
 	})
@@ -226,4 +225,23 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "1234567890:dtagent1234567890ABC")
 		assertEmpty(t, pgc, err)
 	})
+}
+
+func TestIsMalformedETag(t *testing.T) {
+	tests := []struct {
+		name string
+		etag string
+		want bool
+	}{
+		{"empty etag is not malformed", "", false},
+		{"valid quoted numeric etag", `"12345"`, false},
+		{"known malformed pattern", `"0:dtagent10348260901170245Pkr0"`, true},
+		{"unquoted numeric etag", "12345", true},
+		{"quoted non-numeric etag", `"abc123"`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsMalformedETag(tt.etag))
+		})
+	}
 }

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -166,7 +166,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Nil(t, pgc)
 	})
 
-	t.Run("bad_request", func(t *testing.T) {
+	t.Run("bad_request_clears_etag", func(t *testing.T) {
 		const badETag = "bad_etag"
 		serverErr := &core.HTTPError{StatusCode: http.StatusBadRequest, Message: "bad request"}
 
@@ -179,9 +179,10 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		)
 
 		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, badETag)
-		require.Error(t, err)
-		require.True(t, core.HasStatusCode(err, http.StatusBadRequest))
-		assert.Nil(t, pgc)
+		require.NoError(t, err)
+		assert.NotNil(t, pgc)
+		assert.Empty(t, pgc.Data)
+		assert.Empty(t, pgc.ETag)
 	})
 
 	t.Run("not_found_404_endpoint_unavailable", func(t *testing.T) {

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -69,7 +69,7 @@ func setupMockedProcessGroupingClient(
 }
 
 func TestGetProcessGroupingConfig(t *testing.T) {
-	t.Run("success_200_with_etag", func(t *testing.T) {
+	t.Run("success 200 with etag", func(t *testing.T) {
 		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
@@ -88,7 +88,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.NotEqual(t, testETag, pgc.ETag)
 	})
 
-	t.Run("success_200_without_etag", func(t *testing.T) {
+	t.Run("success 200 without etag", func(t *testing.T) {
 		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
@@ -105,7 +105,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Equal(t, testResponseETag, pgc.ETag)
 	})
 
-	t.Run("not_modified_304", func(t *testing.T) {
+	t.Run("not modified 304", func(t *testing.T) {
 		httpErr := &core.HTTPError{StatusCode: 304}
 
 		client := setupMockedProcessGroupingClient(t,
@@ -123,7 +123,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Equal(t, testETag, pgc.ETag)
 	})
 
-	t.Run("with_kubernetes_cluster_id", func(t *testing.T) {
+	t.Run("with kubernetes cluster id", func(t *testing.T) {
 		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
 		client := setupMockedProcessGroupingClient(t,
@@ -139,7 +139,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Equal(t, testResponseETag, pgc.ETag)
 	})
 
-	t.Run("empty_kubernetes_cluster_id_returns_error", func(t *testing.T) {
+	t.Run("empty kubernetes cluster id returns error", func(t *testing.T) {
 		// Create a client directly without mock setup since we expect early return
 		coreClient := coremock.NewClient(t)
 		client := NewClient(coreClient, "", "")
@@ -149,7 +149,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Nil(t, pgc)
 	})
 
-	t.Run("server_error", func(t *testing.T) {
+	t.Run("server error", func(t *testing.T) {
 		serverErr := &core.HTTPError{StatusCode: http.StatusInternalServerError, Message: "internal server error"}
 
 		client := setupMockedProcessGroupingClient(t,
@@ -166,7 +166,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Nil(t, pgc)
 	})
 
-	t.Run("bad_request_clears_etag", func(t *testing.T) {
+	t.Run("bad request clears etag", func(t *testing.T) {
 		const badETag = "bad_etag"
 		serverErr := &core.HTTPError{StatusCode: http.StatusBadRequest, Message: "bad request"}
 
@@ -185,7 +185,7 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Empty(t, pgc.ETag)
 	})
 
-	t.Run("not_found_404_endpoint_unavailable", func(t *testing.T) {
+	t.Run("not found 404 endpoint unavailable", func(t *testing.T) {
 		httpErr := &core.HTTPError{StatusCode: http.StatusNotFound, Message: "endpoint not available"}
 
 		client := setupMockedProcessGroupingClient(t,

--- a/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
+++ b/pkg/clients/dynatrace/oneagent/processgroupingconfig_test.go
@@ -69,10 +69,19 @@ func setupMockedProcessGroupingClient(
 }
 
 func TestGetProcessGroupingConfig(t *testing.T) {
+	assertEmpty := func(t *testing.T, pgc *ProcessGroupConfig, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		assert.NotNil(t, pgc)
+		assert.Empty(t, pgc.Data)
+		assert.Empty(t, pgc.ETag)
+	}
+
 	t.Run("success 200 with etag", func(t *testing.T) {
 		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			map[string]string{"If-None-Match": testETag},
 			respHeaders,
@@ -91,7 +100,8 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 	t.Run("success 200 without etag", func(t *testing.T) {
 		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			nil,
 			respHeaders,
@@ -108,7 +118,8 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 	t.Run("not modified 304", func(t *testing.T) {
 		httpErr := &core.HTTPError{StatusCode: 304}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			map[string]string{"If-None-Match": testETag},
 			nil,
@@ -126,7 +137,8 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 	t.Run("with kubernetes cluster id", func(t *testing.T) {
 		respHeaders := http.Header{"Etag": []string{testResponseETag}}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			nil,
 			respHeaders,
@@ -152,7 +164,8 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 	t.Run("server error", func(t *testing.T) {
 		serverErr := &core.HTTPError{StatusCode: http.StatusInternalServerError, Message: "internal server error"}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			nil,
 			nil,
@@ -166,11 +179,12 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		assert.Nil(t, pgc)
 	})
 
-	t.Run("bad request clears etag", func(t *testing.T) {
+	t.Run("bad request", func(t *testing.T) {
 		const badETag = "bad_etag"
 		serverErr := &core.HTTPError{StatusCode: http.StatusBadRequest, Message: "bad request"}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			map[string]string{"If-None-Match": badETag},
 			nil,
@@ -179,16 +193,15 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		)
 
 		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, badETag)
-		require.NoError(t, err)
-		assert.NotNil(t, pgc)
-		assert.Empty(t, pgc.Data)
-		assert.Empty(t, pgc.ETag)
+		require.ErrorIs(t, err, serverErr)
+		assert.Nil(t, pgc)
 	})
 
 	t.Run("not found 404 endpoint unavailable", func(t *testing.T) {
 		httpErr := &core.HTTPError{StatusCode: http.StatusNotFound, Message: "endpoint not available"}
 
-		client := setupMockedProcessGroupingClient(t,
+		client := setupMockedProcessGroupingClient(
+			t,
 			map[string]string{"kubernetesClusterId": testClusterID},
 			nil,
 			nil,
@@ -197,9 +210,20 @@ func TestGetProcessGroupingConfig(t *testing.T) {
 		)
 
 		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "")
-		require.NoError(t, err)
-		assert.NotNil(t, pgc)
-		assert.Empty(t, pgc.Data)
-		assert.Empty(t, pgc.ETag)
+		assertEmpty(t, pgc, err)
+	})
+
+	t.Run("clear malformed etag", func(t *testing.T) {
+		client := setupMockedProcessGroupingClient(
+			t,
+			map[string]string{"kubernetesClusterId": testClusterID},
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		pgc, err := client.GetProcessGroupingConfig(t.Context(), testClusterID, "1234567890:dtagent1234567890ABC")
+		assertEmpty(t, pgc, err)
 	})
 }

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
@@ -161,6 +161,7 @@ func Cleanup(ctx context.Context, client client.Client, apiReader client.Reader,
 
 func cleanupConfig(ctx context.Context, client client.Client, apiReader client.Reader, namespaces []corev1.Namespace, dk *dynakube.DynaKube) error {
 	log := logd.FromContext(ctx)
+
 	clearMalformedETagLookup(dk)
 
 	defer meta.RemoveStatusCondition(dk.Conditions(), ConfigConditionType)

--- a/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
+++ b/pkg/injection/namespace/bootstrapperconfig/bootstrapperconfig.go
@@ -161,6 +161,7 @@ func Cleanup(ctx context.Context, client client.Client, apiReader client.Reader,
 
 func cleanupConfig(ctx context.Context, client client.Client, apiReader client.Reader, namespaces []corev1.Namespace, dk *dynakube.DynaKube) error {
 	log := logd.FromContext(ctx)
+	clearMalformedETagLookup(dk)
 
 	defer meta.RemoveStatusCondition(dk.Conditions(), ConfigConditionType)
 

--- a/pkg/injection/namespace/bootstrapperconfig/pgc.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pgc.go
@@ -5,6 +5,7 @@ package bootstrapperconfig
 
 import (
 	"context"
+	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -52,6 +53,11 @@ func (s *SecretGenerator) preparePGC(ctx context.Context, dk *dynakube.DynaKube)
 	}
 
 	cachedPGC := s.readCachedPGC(ctx, dk)
+	if oneagent.IsMalformedETag(cachedPGC.ETag) && !shouldLookupWithMalformedETag(dk) {
+		log.Debug("throttled API request with malformed cached etag", "etag", cachedPGC.ETag)
+
+		return cachedPGC, nil
+	}
 
 	pgc, err := s.dtClient.GetProcessGroupingConfig(ctx, dk.Status.KubernetesClusterMEID, cachedPGC.ETag)
 	if err != nil {
@@ -63,6 +69,8 @@ func (s *SecretGenerator) preparePGC(ctx context.Context, dk *dynakube.DynaKube)
 	if pgc == nil {
 		return &oneagent.ProcessGroupConfig{}, nil
 	}
+
+	registerMalformedETagLookup(dk, pgc.ETag)
 
 	if pgc.ETag == cachedPGC.ETag && pgc.ETag != "" {
 		return cachedPGC, nil
@@ -96,4 +104,28 @@ func (s *SecretGenerator) readCachedPGC(ctx context.Context, dk *dynakube.DynaKu
 		ETag: secret.Annotations[annotationPGCETag],
 		Data: secret.Data[DeclarativeInputFileName],
 	}
+}
+
+// In-memory throttling for API lookups with malformed ETag, so we don't spam the API.
+// The implementation is purposefully kept simple:
+// * No thread-safety: The whole DynaKube controller is not thread-safe, so this requires a bigger effort
+// * Use DynaKube names as key: We only process DynaKubes in a single namespace, so there won't be any collisions
+var malformedETagLastLookup = make(map[string]time.Time)
+
+func shouldLookupWithMalformedETag(dk *dynakube.DynaKube) bool {
+	lastLookup := malformedETagLastLookup[dk.Name]
+
+	return lastLookup.IsZero() || time.Since(lastLookup) > dk.APIRequestThreshold()
+}
+
+func registerMalformedETagLookup(dk *dynakube.DynaKube, etag string) {
+	if oneagent.IsMalformedETag(etag) {
+		malformedETagLastLookup[dk.Name] = time.Now()
+	} else {
+		delete(malformedETagLastLookup, dk.Name)
+	}
+}
+
+func clearMalformedETagLookup(dk *dynakube.DynaKube) {
+	delete(malformedETagLastLookup, dk.Name)
 }

--- a/pkg/injection/namespace/bootstrapperconfig/pgc_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pgc_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
@@ -19,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const invalidTestETag = "1234567890:dtagent1234567890ABC"
 
 func Test_SecretGenerator_preparePGC(t *testing.T) {
 	const (
@@ -215,4 +218,102 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		require.NotNil(t, pgc)
 		assert.Equal(t, responseETag, pgc.ETag)
 	})
+
+	t.Run("throttle malformed etag lookup", func(t *testing.T) {
+		dk := newDK()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        GetSourceConfigSecretName(dk.Name),
+				Namespace:   dk.Namespace,
+				Annotations: map[string]string{annotationPGCETag: invalidTestETag},
+			},
+		}
+
+		t.Cleanup(func() { clear(malformedETagLastLookup) })
+		malformedETagLastLookup[dk.Name] = time.Now().Add(-1 * time.Minute)
+
+		clt := fake.NewClient(dk, secret)
+		mockDTClient := oneagentclientmock.NewClient(t)
+
+		sg := NewSecretGenerator(clt, clt, mockDTClient)
+		pgc, err := sg.preparePGC(t.Context(), dk)
+
+		require.NoError(t, err)
+		require.NotNil(t, pgc)
+		assert.Equal(t, invalidTestETag, pgc.ETag)
+	})
+
+	t.Run("clear malformed etag", func(t *testing.T) {
+		dk := newDK()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        GetSourceConfigSecretName(dk.Name),
+				Namespace:   dk.Namespace,
+				Annotations: map[string]string{annotationPGCETag: invalidTestETag},
+			},
+		}
+
+		t.Cleanup(func() { clear(malformedETagLastLookup) })
+		malformedETagLastLookup[dk.Name] = time.Now().Add(-15 * time.Minute)
+
+		clt := fake.NewClient(dk, secret)
+		mockDTClient := oneagentclientmock.NewClient(t)
+
+		payload := []byte("pgc-data")
+		responseETag := "new-etag-xyz"
+
+		mockDTClient.EXPECT().
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, invalidTestETag).
+			Return(&oneagent.ProcessGroupConfig{
+				ETag: responseETag,
+				Data: payload,
+			}, nil)
+
+		sg := NewSecretGenerator(clt, clt, mockDTClient)
+		pgc, err := sg.preparePGC(t.Context(), dk)
+
+		require.NoError(t, err)
+		require.NotNil(t, pgc)
+		assert.Equal(t, responseETag, pgc.ETag)
+	})
+}
+
+func Test_shouldLookupWithMalformedETag(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiThreshold uint16
+		preseed      time.Time
+		expect       bool
+	}{
+		{"no entry", 15, time.Time{}, true},
+		{"zero threshold", 0, time.Now().Add(-1 * time.Hour), true},
+		{"below threshold", 15, time.Now().Add(-14 * time.Minute), false},
+		{"above threshold", 15, time.Now().Add(-15 * time.Minute), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dk := &dynakube.DynaKube{}
+			dk.Name = "test"
+			dk.Spec.DynatraceAPIRequestThreshold = new(tt.apiThreshold)
+
+			t.Cleanup(func() { clear(malformedETagLastLookup) })
+			malformedETagLastLookup[dk.Name] = tt.preseed
+
+			got := shouldLookupWithMalformedETag(dk)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func Test_registerMalformedETagLookup(t *testing.T) {
+	dk := &dynakube.DynaKube{}
+	dk.Name = "test"
+
+	t.Cleanup(func() { clear(malformedETagLastLookup) })
+
+	assert.NotContains(t, malformedETagLastLookup, dk.Name)
+	registerMalformedETagLookup(dk, invalidTestETag)
+	assert.Contains(t, malformedETagLastLookup, dk.Name)
+	registerMalformedETagLookup(dk, "1234:1234")
+	assert.NotContains(t, malformedETagLastLookup, dk.Name)
 }

--- a/pkg/injection/namespace/bootstrapperconfig/pgc_test.go
+++ b/pkg/injection/namespace/bootstrapperconfig/pgc_test.go
@@ -21,7 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const invalidTestETag = "1234567890:dtagent1234567890ABC"
+const (
+	testETag        = `"1234657890"`
+	invalidTestETag = `"1234567890:dtagent1234567890ABC"`
+)
 
 func Test_SecretGenerator_preparePGC(t *testing.T) {
 	const (
@@ -53,7 +56,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient.EXPECT().
 			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
 			Return(&oneagent.ProcessGroupConfig{
-				ETag: "etag123",
+				ETag: testETag,
 				Data: payload,
 			}, nil)
 
@@ -63,7 +66,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, pgc)
 		assert.Equal(t, payload, pgc.Data)
-		assert.Equal(t, "etag123", pgc.ETag)
+		assert.Equal(t, testETag, pgc.ETag)
 	})
 
 	t.Run("success - response between 800 KiB and 900 KiB triggers warning", func(t *testing.T) {
@@ -75,7 +78,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient.EXPECT().
 			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
 			Return(&oneagent.ProcessGroupConfig{
-				ETag: "etag123",
+				ETag: testETag,
 				Data: payload,
 			}, nil)
 
@@ -96,7 +99,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient.EXPECT().
 			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
 			Return(&oneagent.ProcessGroupConfig{
-				ETag: "etag123",
+				ETag: testETag,
 				Data: payload,
 			}, nil)
 
@@ -150,14 +153,13 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 	t.Run("304 not modified uses cached data", func(t *testing.T) {
 		dk := newDK()
 		cachedData := []byte("cached-pgc-data")
-		cachedETag := "etag-abc"
 
 		sourceSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      GetSourceConfigSecretName(testDynakube),
 				Namespace: testNamespace,
 				Annotations: map[string]string{
-					annotationPGCETag: cachedETag,
+					annotationPGCETag: testETag,
 				},
 			},
 			Data: map[string][]byte{
@@ -169,8 +171,8 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient := oneagentclientmock.NewClient(t)
 
 		mockDTClient.EXPECT().
-			GetProcessGroupingConfig(mock.Anything, testClusterMEID, cachedETag).
-			Return(&oneagent.ProcessGroupConfig{ETag: cachedETag}, nil)
+			GetProcessGroupingConfig(mock.Anything, testClusterMEID, testETag).
+			Return(&oneagent.ProcessGroupConfig{ETag: testETag}, nil)
 
 		sg := NewSecretGenerator(clt, clt, mockDTClient)
 		pgc, err := sg.preparePGC(t.Context(), dk)
@@ -178,7 +180,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, pgc)
 		assert.Equal(t, cachedData, pgc.Data)
-		assert.Equal(t, cachedETag, pgc.ETag)
+		assert.Equal(t, testETag, pgc.ETag)
 	})
 
 	t.Run("empty MEID skips without error", func(t *testing.T) {
@@ -202,12 +204,11 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient := oneagentclientmock.NewClient(t)
 
 		payload := []byte("pgc-data")
-		responseETag := "new-etag-xyz"
 
 		mockDTClient.EXPECT().
 			GetProcessGroupingConfig(mock.Anything, testClusterMEID, "").
 			Return(&oneagent.ProcessGroupConfig{
-				ETag: responseETag,
+				ETag: testETag,
 				Data: payload,
 			}, nil)
 
@@ -216,7 +217,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, pgc)
-		assert.Equal(t, responseETag, pgc.ETag)
+		assert.Equal(t, testETag, pgc.ETag)
 	})
 
 	t.Run("throttle malformed etag lookup", func(t *testing.T) {
@@ -260,12 +261,11 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 		mockDTClient := oneagentclientmock.NewClient(t)
 
 		payload := []byte("pgc-data")
-		responseETag := "new-etag-xyz"
 
 		mockDTClient.EXPECT().
 			GetProcessGroupingConfig(mock.Anything, testClusterMEID, invalidTestETag).
 			Return(&oneagent.ProcessGroupConfig{
-				ETag: responseETag,
+				ETag: testETag,
 				Data: payload,
 			}, nil)
 
@@ -274,7 +274,7 @@ func Test_SecretGenerator_preparePGC(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, pgc)
-		assert.Equal(t, responseETag, pgc.ETag)
+		assert.Equal(t, testETag, pgc.ETag)
 	})
 }
 
@@ -314,6 +314,6 @@ func Test_registerMalformedETagLookup(t *testing.T) {
 	assert.NotContains(t, malformedETagLastLookup, dk.Name)
 	registerMalformedETagLookup(dk, invalidTestETag)
 	assert.Contains(t, malformedETagLastLookup, dk.Name)
-	registerMalformedETagLookup(dk, "1234:1234")
+	registerMalformedETagLookup(dk, testETag)
 	assert.NotContains(t, malformedETagLastLookup, dk.Name)
 }


### PR DESCRIPTION
## Description

Some tenant configurations return a malformed ETag when requesting the ProcessGroupingConfig. This feature is optional, so it should not block deployment.

Add an in-memory cache based on the API request threshold.

ICP-9284

## How can this be tested?

Deploy a AG+CNFS DynaKube and check the bootstrapper secret and logs.