### PR TITLE
[release-1.10] fix: use golang version from Dockerfile for actions/setup-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
       is_snyk_authorized: ${{ steps.is-snyk-authorized.outputs.is_authorized == 'true' && 'true' || '' }}
       is_docker_authorized: ${{ steps.is-docker-authorized.outputs.is_authorized == 'true' && 'true' || '' }}
       markdown_changed: ${{ steps.markdown.outputs.any_changed == 'true' && 'true' || '' }}
+      go_version: ${{ steps.go-version.outputs.go_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -43,6 +44,9 @@ jobs:
           fetch-depth: ${{ github.event_name == 'merge_group' && '0' || '2' }}
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Check if it is a protected branch
         id: is-protected-branch
         run: |
@@ -172,7 +176,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ needs.detect-changes.outputs.go_version }}
           cache: false
       - name: Run Unit tests and Integration tests
         id: unittest
@@ -196,7 +200,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ needs.detect-changes.outputs.go_version }}
           cache: false
       - name: Get golangci-lint version
         id: linter-version
@@ -222,7 +226,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ needs.detect-changes.outputs.go_version }}
           cache: false
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -58,10 +58,13 @@ jobs:
           # renovate datasource=github-releases depName=kubernetes-sigs/kind
           version: v0.32.0
           install_only: true
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Set up go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
       - name: Set up helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -125,10 +125,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Setup Golang
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
       - name: Build helm packages
         uses: ./.github/actions/build-helm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,10 +249,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Setup Golang
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
       - name: Generate release notes
         shell: bash

--- a/.github/workflows/sync-openapi-schema.yaml
+++ b/.github/workflows/sync-openapi-schema.yaml
@@ -60,9 +60,12 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y make
 
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable'
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Description

we used `'stable'` version in setup-go actions. 
This cause misalignment between golang version in ci and code causing errors in linting and generating files like:

```
  Error: ../../../../../opt/hostedtoolcache/go/1.27.0/x64/src/crypto/internal/randutil/randutil.go:11:2: could not import math/rand/v2 (/opt/hostedtoolcache/go/1.27.0/x64/src/math/rand/v2/rand.go:213:17: method must have no type parameters) (typecheck)
```


## How can this be tested?
CI runs