### PR TITLE
[release-1.8] fix: use golang version from Dockerfile for actions/setup-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,12 +33,16 @@ jobs:
       is_snyk_authorized: ${{ steps.is-snyk-authorized.outputs.is_authorized == 'true' && 'true' || '' }}
       is_docker_authorized: ${{ steps.is-docker-authorized.outputs.is_authorized == 'true' && 'true' || '' }}
       markdown_changed: ${{ steps.markdown.outputs.any_changed == 'true' && 'true' || '' }}
+      go_version: ${{ steps.go-version.outputs.go_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Check if it is a protected branch
         id: is-protected-branch
         run: |
@@ -155,7 +159,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ needs.detect-changes.outputs.go_version }}
           cache: false
       - name: Run Unit tests and Integration tests
         id: unittest
@@ -177,7 +181,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ needs.detect-changes.outputs.go_version }}
           cache: false
       - name: Run lint
         run: |
@@ -193,7 +197,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ needs.detect-changes.outputs.go_version }}
           cache: false
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -55,10 +55,13 @@ jobs:
           # renovate datasource=github-releases depName=kubernetes-sigs/kind
           version: v0.31.0
           install_only: true
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Set up go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version-file: "./go.mod"
+          go-version: ${{ steps.go-version.outputs.go_version }}
       - name: Set up helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -116,10 +116,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Setup Golang
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
       - name: Build helm packages
         uses: ./.github/actions/build-helm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,10 +192,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Setup Golang
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: "${{ github.workspace }}/go.mod"
+          go-version: ${{ steps.go-version.outputs.go_version }}
+          cache: false
       - name: Generate release notes
         shell: bash
         env:

--- a/hack/make/prerequisites.mk
+++ b/hack/make/prerequisites.mk
@@ -29,7 +29,7 @@ CYCLONEDX_GOMOD_VERSION ?= v1.9.0
 # renovate depName=github.com/mikefarah/yq/v4
 YQ_VERSION ?= v4.49.2
 # renovate depName=github.com/vladopajic/go-test-coverage/v2
-GO_TEST_COVERAGE_VERSION ?= v2.18.9
+GO_TEST_COVERAGE_VERSION ?= v2.18.3
 
 # Enable renovate once project is migrated to newer structure
 OPERATOR_SDK_VERSION ?= v1.36.0


### PR DESCRIPTION
## Description

Same as #7341  but for release-1.8

> [!IMPORTANT]
> I had to downgrade GO_TEST_COVERAGE_VERSION to 2.18.3 cause we had too new version that requires go 1.26 (we have 1.25.10)

we used `'stable'` version in setup-go actions. 
This cause misalignment between golang version in ci and code causing errors in linting and generating files like:

```
  Error: ../../../../../opt/hostedtoolcache/go/1.27.0/x64/src/crypto/internal/randutil/randutil.go:11:2: could not import math/rand/v2 (/opt/hostedtoolcache/go/1.27.0/x64/src/math/rand/v2/rand.go:213:17: method must have no type parameters) (typecheck)
```


## How can this be tested?
CI runs