### PR TITLE
fixup e2e: refactor createOrUpdateHandler to patch with apply.

### DIFF
--- a/test/e2e/helpers/kubernetes/manifests/installation.go
+++ b/test/e2e/helpers/kubernetes/manifests/installation.go
@@ -21,6 +21,13 @@ func createOrUpdateHandler(r *resources.Resources) decoder.HandlerFunc {
 	return func(ctx context.Context, obj k8s.Object) error {
 		err := r.Create(ctx, obj)
 		if k8serrors.IsAlreadyExists(err) {
+			existing := obj.DeepCopyObject().(k8s.Object)
+			if getErr := r.Get(ctx, obj.GetName(), obj.GetNamespace(), existing); getErr != nil {
+				return getErr
+			}
+
+			obj.SetResourceVersion(existing.GetResourceVersion())
+
 			return r.Update(ctx, obj)
 		}
 

--- a/test/e2e/helpers/kubernetes/manifests/installation.go
+++ b/test/e2e/helpers/kubernetes/manifests/installation.go
@@ -7,9 +7,12 @@ package manifests
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -17,21 +20,19 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-func createOrUpdateHandler(r *resources.Resources) decoder.HandlerFunc {
+func applyHandler(r *resources.Resources) decoder.HandlerFunc {
 	return func(ctx context.Context, obj k8s.Object) error {
-		err := r.Create(ctx, obj)
-		if k8serrors.IsAlreadyExists(err) {
-			existing := obj.DeepCopyObject().(k8s.Object)
-			if getErr := r.Get(ctx, obj.GetName(), obj.GetNamespace(), existing); getErr != nil {
-				return getErr
-			}
-
-			obj.SetResourceVersion(existing.GetResourceVersion())
-
-			return r.Update(ctx, obj)
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return err
 		}
-
-		return err
+		return r.Patch(ctx, obj, k8s.Patch{
+			PatchType: types.ApplyPatchType,
+			Data:      data,
+		}, func(opts *metav1.PatchOptions) {
+			opts.FieldManager = "e2e-test"
+			opts.Force = new(true)
+		})
 	}
 }
 
@@ -45,7 +46,7 @@ func InstallFromFile(path string, options ...decoder.DecodeOption) env.Func {
 
 		resources := envConfig.Client().Resources()
 
-		return ctx, decoder.DecodeEach(ctx, kubernetesManifest, createOrUpdateHandler(resources), options...)
+		return ctx, decoder.DecodeEach(ctx, kubernetesManifest, applyHandler(resources), options...)
 	}
 }
 

--- a/test/e2e/helpers/kubernetes/manifests/installation.go
+++ b/test/e2e/helpers/kubernetes/manifests/installation.go
@@ -26,6 +26,7 @@ func applyHandler(r *resources.Resources) decoder.HandlerFunc {
 		if err != nil {
 			return err
 		}
+
 		return r.Patch(ctx, obj, k8s.Patch{
 			PatchType: types.ApplyPatchType,
 			Data:      data,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

This PR fixes related to https://dt-rnd.atlassian.net/browse/ICP-9139

> === RUN   TestNoCSI_edgeconnect_proxy_https/edgeconnect-proxy-https/install_proxy
      feature.go:34:
                  Error Trace:    /Users/andrii.soldatenko/work/dynatrace-operator/test/e2e/helpers/feature.go:34
                                                          /Users/andrii.soldatenko/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.7.0/pkg/env/env.go:479
                                                          /Users/andrii.soldatenko/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.7.0/pkg/env/env.go:523
                  Error:          Received unexpected error:
                                  serviceentries.networking.istio.io "squid" is invalid: metadata.resourceVersion: Invalid value: 0: must be specified for an update
                  Test:           TestNoCSI_edgeconnect_proxy_https/edgeconnect-proxy-https/install_proxy

## How can this be tested?

```
go test -v -count 1 -tags e2e -timeout 20m ./test/e2e/scenarios/nocsi -run "TestNoCSI_edgeconnect_proxy_https"
```
run all
```
make test/e2e/edgeconnect
```