### PR TITLE
Add publicRegistryOverride to EdgeConnect

### DIFF
--- a/config/crd/bases/dynatrace.com_edgeconnects.yaml
+++ b/config/crd/bases/dynatrace.com_edgeconnects.yaml
@@ -1025,6 +1025,10 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              publicRegistryOverride:
+                description: Overrides the default public registry from which the
+                  EdgeConnect image is pulled.
+                type: string
               replicas:
                 description: 'Amount of replicas for your EdgeConnect (the default
                   value is: 1)'

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -7791,6 +7791,10 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              publicRegistryOverride:
+                description: Overrides the default public registry from which the
+                  EdgeConnect image is pulled.
+                type: string
               replicas:
                 description: 'Amount of replicas for your EdgeConnect (the default
                   value is: 1)'

--- a/doc/api/edgeconnect-api-ref.md
+++ b/doc/api/edgeconnect-api-ref.md
@@ -14,6 +14,7 @@
 |`hostRestrictions`|Restrict outgoing HTTP requests to your internal resources to specified hosts|-|array|
 |`labels`|Adds additional labels to the EdgeConnect pods|-|object|
 |`nodeSelector`|Node selector to control the selection of nodes for the EdgeConnect pods|-|object|
+|`publicRegistryOverride`|Overrides the default public registry from which the EdgeConnect image is pulled.|-|string|
 |`replicas`|Amount of replicas for your EdgeConnect (the default value is: 1)|-|integer|
 |`resources`|Defines resources requests and limits for single pods|-|object|
 |`serviceAccountName`|ServiceAccountName that allows EdgeConnect to access the Kubernetes API|-|string|

--- a/pkg/api/v1alpha2/edgeconnect/edgeconnect_types.go
+++ b/pkg/api/v1alpha2/edgeconnect/edgeconnect_types.go
@@ -47,6 +47,10 @@ type EdgeConnectSpec struct { //nolint:revive
 	// Enables automatic restarts of EdgeConnect pods in case a new version is available (the default value is: true)
 	AutoUpdate *bool `json:"autoUpdate,omitempty"`
 
+	// Overrides the default public registry from which the EdgeConnect image is pulled.
+	// +kubebuilder:validation:Optional
+	PublicRegistryOverride string `json:"publicRegistryOverride,omitempty"`
+
 	// Overrides the default image
 	// +kubebuilder:validation:Optional
 	ImageRef image.Ref `json:"imageRef,omitzero"`

--- a/pkg/api/validation/edgeconnect/public_registry.go
+++ b/pkg/api/validation/edgeconnect/public_registry.go
@@ -1,0 +1,22 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"context"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+)
+
+const (
+	errorPublicRegistryOverrideWithCustomImage = `The publicRegistryOverride field and a custom image (spec.imageRef.repository) are mutually exclusive. Remove one of them.`
+)
+
+func publicRegistryOverrideWithCustomImage(_ context.Context, _ *Validator, ec *edgeconnect.EdgeConnect) string {
+	if ec.Spec.PublicRegistryOverride != "" && ec.IsCustomImage() {
+		return errorPublicRegistryOverrideWithCustomImage
+	}
+
+	return ""
+}

--- a/pkg/api/validation/edgeconnect/public_registry_test.go
+++ b/pkg/api/validation/edgeconnect/public_registry_test.go
@@ -1,0 +1,50 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha2/edgeconnect"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_publicRegistryOverrideWithCustomImage(t *testing.T) {
+	t.Run("accept when neither field is set", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{},
+		}
+		require.Empty(t, publicRegistryOverrideWithCustomImage(t.Context(), nil, ec))
+	})
+	t.Run("accept when only publicRegistryOverride is set", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				PublicRegistryOverride: "my.registry.example.com",
+			},
+		}
+		require.Empty(t, publicRegistryOverrideWithCustomImage(t.Context(), nil, ec))
+	})
+	t.Run("accept when only custom imageRef is set", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				ImageRef: image.Ref{
+					Repository: "my.registry.example.com/edgeconnect",
+				},
+			},
+		}
+		require.Empty(t, publicRegistryOverrideWithCustomImage(t.Context(), nil, ec))
+	})
+	t.Run("reject when both publicRegistryOverride and custom imageRef are set", func(t *testing.T) {
+		ec := &edgeconnect.EdgeConnect{
+			Spec: edgeconnect.EdgeConnectSpec{
+				PublicRegistryOverride: "my.registry.example.com",
+				ImageRef: image.Ref{
+					Repository: "my.registry.example.com/edgeconnect",
+				},
+			},
+		}
+		require.Equal(t, errorPublicRegistryOverrideWithCustomImage, publicRegistryOverrideWithCustomImage(t.Context(), nil, ec))
+	})
+}

--- a/pkg/api/validation/edgeconnect/validation.go
+++ b/pkg/api/validation/edgeconnect/validation.go
@@ -38,6 +38,7 @@ var validatorErrorFuncs = []validatorFunc{
 	isValidSSOServerURL,
 	checkSSOServerProtocol,
 	isAllowedSSOServer,
+	publicRegistryOverrideWithCustomImage,
 }
 
 func New(apiReader client.Reader, cfg *rest.Config) admission.Validator[runtime.Object] {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-8198](https://dt-rnd.atlassian.net/browse/ICP-8198)

With this we add the `publicRegistryOverride` field to the EdgeConnect as a preparation for the auto-update public registry story.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->

Apply a EdgeConnect and test if the field is accepted.

[ICP-8198]: https://dt-rnd.atlassian.net/browse/ICP-8198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ