### PR TITLE
Reconcile DTPrometheus when relevant DynaKube fields changed

### DIFF
--- a/pkg/controllers/dtprometheus/reconciler.go
+++ b/pkg/controllers/dtprometheus/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
@@ -255,7 +256,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Map requests from DynaKube to DTPrometheus
 			handler.EnqueueRequestsFromMapFunc(newDTPrometheusFromDynaKubeMapper(mgr.GetClient())),
 			// Filter out any DynaKube changes that are not relevant for DTPrometheus
-			builder.WithPredicates(predicate.Or(newDynaKubePhaseChangedPredicate(), newDynaKubeTokenNameChangedPredicate())),
+			builder.WithPredicates(newDynaKubeChangedPredicate()),
 		).
 		Named("dtprometheus").
 		Complete(r)
@@ -289,8 +290,12 @@ func newDTPrometheusFromDynaKubeMapper(c client.Client) handler.MapFunc {
 	}
 }
 
-// Create [predicate.Funcs] that only return true when the DynaKube phase changed.
-func newDynaKubePhaseChangedPredicate() predicate.Funcs {
+// Create [predicate.Funcs] that return true when DynaKube changed in a way that's relevant for a DTPrometheus.
+//   - status.phase changed
+//   - spec.token changed
+//   - spec.resourceAttributes changed
+//   - object deleted
+func newDynaKubeChangedPredicate() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(event.TypedCreateEvent[client.Object]) bool {
 			return false
@@ -309,35 +314,9 @@ func newDynaKubePhaseChangedPredicate() predicate.Funcs {
 				return false
 			}
 
-			return oldDK.Status.Phase != newDK.Status.Phase
-		},
-		GenericFunc: func(event.TypedGenericEvent[client.Object]) bool {
-			return false
-		},
-	}
-}
-
-// Create [predicate.Funcs] that only return true when the DK token secret name changes
-func newDynaKubeTokenNameChangedPredicate() predicate.Funcs {
-	return predicate.Funcs{
-		CreateFunc: func(event.TypedCreateEvent[client.Object]) bool {
-			return false
-		},
-		DeleteFunc: func(event.TypedDeleteEvent[client.Object]) bool {
-			return false
-		},
-		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
-			oldDK, _ := e.ObjectOld.(*dynakube.DynaKube)
-			newDK, _ := e.ObjectNew.(*dynakube.DynaKube)
-
-			if oldDK == nil || newDK == nil {
-				// Don't need to drag a context or logger variable into this closure for this unexpected case.
-				logd.Get().WithName("dtprometheus-predicate").Error(nil, fmt.Sprintf("expected DynaKube, but got old:%T, new:%T", e.ObjectOld, e.ObjectNew))
-
-				return false
-			}
-
-			return oldDK.Tokens() != newDK.Tokens()
+			return oldDK.Status.Phase != newDK.Status.Phase ||
+				oldDK.Tokens() != newDK.Tokens() ||
+				!maps.Equal(oldDK.Spec.ResourceAttributes, newDK.Spec.ResourceAttributes)
 		},
 		GenericFunc: func(event.TypedGenericEvent[client.Object]) bool {
 			return false

--- a/pkg/controllers/dtprometheus/reconciler.go
+++ b/pkg/controllers/dtprometheus/reconciler.go
@@ -316,10 +316,25 @@ func newDynaKubeChangedPredicate() predicate.Funcs {
 
 			return oldDK.Status.Phase != newDK.Status.Phase ||
 				oldDK.Tokens() != newDK.Tokens() ||
+				oldDK.Spec.TrustedCAs != newDK.Spec.TrustedCAs ||
+				oldDK.GetDynatraceAPIRequestThreshold() != newDK.GetDynatraceAPIRequestThreshold() ||
+				dynaKubeProxyChanged(oldDK, newDK) ||
 				!maps.Equal(oldDK.Spec.ResourceAttributes, newDK.Spec.ResourceAttributes)
 		},
 		GenericFunc: func(event.TypedGenericEvent[client.Object]) bool {
 			return false
 		},
 	}
+}
+
+func dynaKubeProxyChanged(oldDK, newDK *dynakube.DynaKube) bool {
+	if (oldDK.Spec.Proxy != nil) != (newDK.Spec.Proxy != nil) {
+		return true
+	}
+
+	if oldDK.Spec.Proxy != nil {
+		return *oldDK.Spec.Proxy != *newDK.Spec.Proxy
+	}
+
+	return false
 }

--- a/pkg/controllers/dtprometheus/reconciler.go
+++ b/pkg/controllers/dtprometheus/reconciler.go
@@ -291,10 +291,6 @@ func newDTPrometheusFromDynaKubeMapper(c client.Client) handler.MapFunc {
 }
 
 // Create [predicate.Funcs] that return true when DynaKube changed in a way that's relevant for a DTPrometheus.
-//   - status.phase changed
-//   - spec.token changed
-//   - spec.resourceAttributes changed
-//   - object deleted
 func newDynaKubeChangedPredicate() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(event.TypedCreateEvent[client.Object]) bool {

--- a/pkg/controllers/dtprometheus/reconciler_integration_test.go
+++ b/pkg/controllers/dtprometheus/reconciler_integration_test.go
@@ -199,6 +199,21 @@ func TestSetupWithManager(t *testing.T) {
 		})
 	})
 
+	t.Run("DynaKube resource attributes change triggers reconcile", func(t *testing.T) {
+		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-resource-attributes", "dk-tokens")
+
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: "https://dummy.dynatrace.com/api"},
+		}
+		integrationtests.CreateDynakube(t, clt, dk)
+
+		assertReconcileTriggered(t, key, func() {
+			dk.Spec.ResourceAttributes = map[string]string{"foo": "bar"}
+			require.NoError(t, clt.Update(t.Context(), dk))
+		})
+	})
+
 	t.Run("DynaKube update without a phase change does not trigger reconcile", func(t *testing.T) {
 		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-nophase", "dk-nophase")
 

--- a/pkg/controllers/dtprometheus/reconciler_integration_test.go
+++ b/pkg/controllers/dtprometheus/reconciler_integration_test.go
@@ -84,14 +84,14 @@ func TestSetupWithManager(t *testing.T) {
 	// for the initial reconcile triggered by the primary "For" watch. Waiting here
 	// means later assertions can attribute any *additional* reconcile to the
 	// specific watch under test, rather than to this setup step.
-	createDTPrometheus := func(t *testing.T, name, dynaKubeName string) (*dtprometheus.DTPrometheus, client.ObjectKey) {
+	createDTPrometheus := func(t *testing.T) (*dtprometheus.DTPrometheus, client.ObjectKey) {
 		t.Helper()
 
 		dtprom := &dtprometheus.DTPrometheus{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
-			Spec:       dtprometheus.DTPrometheusSpec{DynaKubeName: dynaKubeName},
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "dtprometheus", Namespace: metav1.NamespaceDefault},
+			Spec:       dtprometheus.DTPrometheusSpec{DynaKubeName: "dynakube"},
 		}
-		require.NoError(t, clt.Create(t.Context(), dtprom))
+		integrationtests.CreateKubernetesObject(t, clt, dtprom)
 
 		key := client.ObjectKeyFromObject(dtprom)
 		require.Eventually(t, func() bool { return recorder.count(key) > 0 }, eventuallyTimeout, eventuallyInterval)
@@ -123,7 +123,7 @@ func TestSetupWithManager(t *testing.T) {
 	}
 
 	t.Run("update to an owned ConfigMap triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-configmap", "dk")
+		dtprom, key := createDTPrometheus(t)
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owned-configmap", Namespace: dtprom.Namespace}}
 		require.NoError(t, controllerutil.SetControllerReference(dtprom, cm, scheme.Scheme))
@@ -134,7 +134,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("update to an owned Deployment triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-deployment", "dk")
+		dtprom, key := createDTPrometheus(t)
 
 		dep := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "owned-deployment", Namespace: dtprom.Namespace},
@@ -156,7 +156,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("update to an owned Service triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-service", "dk")
+		dtprom, key := createDTPrometheus(t)
 
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: "owned-service", Namespace: dtprom.Namespace},
@@ -170,7 +170,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube phase change triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube", "dk")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -186,7 +186,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube tokens change triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-tokens", "dk-tokens")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -201,7 +201,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube resource attributes change triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-resource-attributes", "dk-tokens")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -216,7 +216,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube trusted CAs change triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-trusted-cas", "dynakube")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -231,7 +231,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube proxy change triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-proxy", "dynakube")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -246,7 +246,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube API request threshold triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-api-request-threshold", "dynakube")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -261,7 +261,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube update without a phase change does not trigger reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-nophase", "dk-nophase")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
@@ -279,7 +279,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("phase change on a DynaKube not referenced by any DTPrometheus does not trigger reconcile", func(t *testing.T) {
-		_, key := createDTPrometheus(t, "dtprom-dynakube-unreferenced", "dk-referenced")
+		_, key := createDTPrometheus(t)
 
 		unreferencedDK := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: "dk-unreferenced", Namespace: metav1.NamespaceDefault},
@@ -293,7 +293,7 @@ func TestSetupWithManager(t *testing.T) {
 	})
 
 	t.Run("DynaKube deletion triggers reconcile", func(t *testing.T) {
-		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-delete", "dk-delete")
+		dtprom, key := createDTPrometheus(t)
 
 		dk := &dynakube.DynaKube{
 			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},

--- a/pkg/controllers/dtprometheus/reconciler_integration_test.go
+++ b/pkg/controllers/dtprometheus/reconciler_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/dtprometheus"
 	"github.com/Dynatrace/dynatrace-operator/test/integrationtests"
@@ -210,6 +211,51 @@ func TestSetupWithManager(t *testing.T) {
 
 		assertReconcileTriggered(t, key, func() {
 			dk.Spec.ResourceAttributes = map[string]string{"foo": "bar"}
+			require.NoError(t, clt.Update(t.Context(), dk))
+		})
+	})
+
+	t.Run("DynaKube trusted CAs change triggers reconcile", func(t *testing.T) {
+		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-trusted-cas", "dynakube")
+
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: "https://dummy.dynatrace.com/api"},
+		}
+		integrationtests.CreateDynakube(t, clt, dk)
+
+		assertReconcileTriggered(t, key, func() {
+			dk.Spec.TrustedCAs = "test"
+			require.NoError(t, clt.Update(t.Context(), dk))
+		})
+	})
+
+	t.Run("DynaKube proxy change triggers reconcile", func(t *testing.T) {
+		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-proxy", "dynakube")
+
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: "https://dummy.dynatrace.com/api"},
+		}
+		integrationtests.CreateDynakube(t, clt, dk)
+
+		assertReconcileTriggered(t, key, func() {
+			dk.Spec.Proxy = &value.Source{Value: "test"}
+			require.NoError(t, clt.Update(t.Context(), dk))
+		})
+	})
+
+	t.Run("DynaKube API request threshold triggers reconcile", func(t *testing.T) {
+		dtprom, key := createDTPrometheus(t, "dtprom-dynakube-api-request-threshold", "dynakube")
+
+		dk := &dynakube.DynaKube{
+			ObjectMeta: metav1.ObjectMeta{Name: dtprom.Spec.DynaKubeName, Namespace: dtprom.Namespace},
+			Spec:       dynakube.DynaKubeSpec{APIURL: "https://dummy.dynatrace.com/api"},
+		}
+		integrationtests.CreateDynakube(t, clt, dk)
+
+		assertReconcileTriggered(t, key, func() {
+			dk.Spec.DynatraceAPIRequestThreshold = new(uint16(14))
 			require.NoError(t, clt.Update(t.Context(), dk))
 		})
 	})

--- a/pkg/controllers/dtprometheus/reconciler_test.go
+++ b/pkg/controllers/dtprometheus/reconciler_test.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/v1alpha1/dtprometheus"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/token"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -218,6 +220,33 @@ func Test_setPhase(t *testing.T) {
 			} else {
 				require.ErrorIs(t, gotErr, tt.expectedErr)
 			}
+		})
+	}
+}
+
+func Test_dynaKubeProxyChanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		oldProxy *value.Source
+		newProxy *value.Source
+		expect   bool
+	}{
+		{"both nil", nil, nil, false},
+		{"old nil", nil, &value.Source{Value: "test"}, true},
+		{"new nil", &value.Source{Value: "test"}, nil, true},
+		{"value equal", &value.Source{Value: "test"}, &value.Source{Value: "test"}, false},
+		{"value diff", &value.Source{Value: "foo"}, &value.Source{Value: "bar"}, true},
+		{"valueFrom equal", &value.Source{ValueFrom: "test"}, &value.Source{ValueFrom: "test"}, false},
+		{"valueFrom diff", &value.Source{ValueFrom: "foo"}, &value.Source{ValueFrom: "bar"}, true},
+		{"field diff", &value.Source{Value: "test"}, &value.Source{ValueFrom: "test"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynaKubeProxyChanged(
+				&dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{Proxy: tt.oldProxy}},
+				&dynakube.DynaKube{Spec: dynakube.DynaKubeSpec{Proxy: tt.newProxy}},
+			)
+			assert.Equal(t, tt.expect, got)
 		})
 	}
 }


### PR DESCRIPTION
## Description

The DynaKube resource attributes are part of the gateway config, so the reconciler needs to react when they change.
This is meant to cover the case when the DynaKube does not deploy any workload. If the ActiveGate is deployed, the change in resource attributes will cause a phase change since there will be a rolling restart.

ICP-9419

## How can this be tested?

`make go/test`
