### PR TITLE
Add network zone to KubeMon statefulset

### DIFF
--- a/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
+++ b/pkg/controllers/dynakube/activegate/internal/statefulset/builder/modifiers/kspm.go
@@ -53,7 +53,8 @@ func (mod KSPMModifier) getVolumes() []corev1.Volume {
 			Name: consts.KSPMTokenVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mod.dk.KSPM().GetTokenSecretName(),
+					SecretName:  mod.dk.KSPM().GetTokenSecretName(),
+					DefaultMode: new(int32(0o640)),
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -176,6 +176,10 @@ func buildEnvs(dk *dynakube.DynaKube) []corev1.EnvVar {
 		envs = append(envs, corev1.EnvVar{Name: agconsts.EnvDTGroup, Value: dk.Spec.KubernetesMonitoring.Group})
 	}
 
+	if dk.Spec.NetworkZone != "" {
+		envs = append(envs, corev1.EnvVar{Name: agconsts.EnvDTNetworkZone, Value: dk.Spec.NetworkZone})
+	}
+
 	return append(envs, dk.KubernetesMonitoring().Env...)
 }
 


### PR DESCRIPTION
[ICP-9393](https://dt-rnd.atlassian.net/browse/ICP-9393)

## Description

Add network zone to KubeMon spec. (as in case of generic AG)
Set AG kspm-token secret permissions to 0640 (as in case of other secrets).

## How can this be tested?

1) deploy dk with AG and KSPM

```
2026/09/07 09:12:52.398368 Info: Collection uploaded to "https://dynakube-activegate.dynatrace/e/<tenant>/api/v2/kubernetes/node-config/ingest?node=<node name>".
```

2) deploy dk with NetworkZone and KubeMon
```
$ kubectl -n dynatrace get pod/dynakube-kubemon-0 -o jsonpath="{.spec.containers[0].env}"

[...,{"name":"DT_NETWORK_ZONE","value":"networkzone"}]
```

[ICP-9393]: https://dt-rnd.atlassian.net/browse/ICP-9393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ