### PR TITLE
e2e tests for kubemon (split, full, +kspm)

### DIFF
--- a/config/helm/chart/default/tests/Common/activegate/clusterrole-activegate_test.yaml
+++ b/config/helm/chart/default/tests/Common/activegate/clusterrole-activegate_test.yaml
@@ -1,0 +1,103 @@
+# Copyright Dynatrace LLC
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test activegate clusterrole for openshift and OLM
+templates:
+  - Common/activegate/clusterrole-activegate.yaml
+tests:
+  - it: ClusterRole should exist on OpenShift
+    documentIndex: 0
+    set:
+      platform: openshift
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: dynatrace-activegate
+      - isNotEmpty:
+          path: metadata.labels
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resourceNames:
+              - privileged
+              - nonroot-v2
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - use
+
+  - it: ClusterRoleBinding should exist on OpenShift
+    documentIndex: 1
+    set:
+      platform: openshift
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-activegate
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: dynatrace-activegate
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: dynatrace-activegate
+            namespace: NAMESPACE
+
+  - it: ClusterRole should exist on OLM
+    documentIndex: 0
+    set:
+      olm: true
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: dynatrace-activegate
+
+  - it: ClusterRoleBinding should exist on OLM
+    documentIndex: 1
+    set:
+      olm: true
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: dynatrace-activegate
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: dynatrace-activegate
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: dynatrace-activegate
+            namespace: NAMESPACE
+
+  - it: shouldn't exist on plain Kubernetes
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: shouldn't exist if rbac.activeGate.create is false
+    set:
+      platform: openshift
+      rbac.activeGate.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/doc/coding-style-guide.md
+++ b/doc/coding-style-guide.md
@@ -760,6 +760,8 @@ So here are some basic guidelines:
   - Reason: Most things that the operator deploys (name of services and pods, contents of labels, should CSI be used, etc...) depend on the `DynaKube`
   - Also the namespace of the `DynaKube` should be the same as the operator, so it can help how the operator should be deployed
   - This eliminates lots of hardcoded strings and such
+- **E2E test function names use snake_case** for the test identifier after the prefix (e.g., `TestNoCSI_activegate`, `TestNoCSI_app_monitoring_without_csi`)
+  - Reason: The snake_case identifiers are used in `-run` patterns in `hack/make/tests/e2e.mk` to run specific tests via make targets (e.g., `test/e2e/activegate`, `test/e2e/applicationmonitoring/withoutcsi`), ensuring consistency between test names and makefile targets.
 - Don't reinvent the wheel, try to use what is already there.
   - If a helper function is almost fits your use case then first just try to "renovate the wheel" and make what is already there better :)
 - **Use Makefile defaults for versions and image tags** in E2E helpers — do not hardcode values like `0.0.1` or a specific image digest inline when the Makefile already defines a sensible default. Hardcoded values get forgotten and drift from reality.

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -418,11 +418,11 @@ test/e2e/kubemon:
 
 ## Runs Kubernetes Monitoring split-AG provisioning, RBAC and cleanup e2e test
 test/e2e/kubemon/split-ag:
-	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "kubemon_SplitAG" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "kubemon_split_ag" $(SKIPCLEANUP)
 
 ## Runs Kubernetes Monitoring restart-triggers e2e test
 test/e2e/kubemon/restart-triggers:
-	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "kubemon_RestartTriggers" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "kubemon_kubemon_restart_triggers" $(SKIPCLEANUP)
 
 test/e2e/token/migration:
 	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "token_migration" $(SKIPCLEANUP)

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -414,15 +414,15 @@ test/e2e/kspm/optionalscopes:
 
 ## Runs all Kubernetes Monitoring e2e tests
 test/e2e/kubemon:
-	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "Kubemon" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "kubemon" $(SKIPCLEANUP)
 
 ## Runs Kubernetes Monitoring split-AG provisioning, RBAC and cleanup e2e test
 test/e2e/kubemon/split-ag:
-	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "Kubemon_SplitAG" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "kubemon_SplitAG" $(SKIPCLEANUP)
 
 ## Runs Kubernetes Monitoring restart-triggers e2e test
 test/e2e/kubemon/restart-triggers:
-	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "Kubemon_RestartTriggers" $(SKIPCLEANUP)
+	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "kubemon_RestartTriggers" $(SKIPCLEANUP)
 
 test/e2e/token/migration:
 	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "token_migration" $(SKIPCLEANUP)

--- a/hack/make/tests/e2e.mk
+++ b/hack/make/tests/e2e.mk
@@ -412,5 +412,17 @@ test/e2e/kspm/kubemon:
 test/e2e/kspm/optionalscopes:
 	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "kspm_with_optional_scopes" $(SKIPCLEANUP)
 
+## Runs all Kubernetes Monitoring e2e tests
+test/e2e/kubemon:
+	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "Kubemon" $(SKIPCLEANUP)
+
+## Runs Kubernetes Monitoring split-AG provisioning, RBAC and cleanup e2e test
+test/e2e/kubemon/split-ag:
+	$(GOTESTCMD) -timeout 30m ./test/e2e/scenarios/nocsi -run "Kubemon_SplitAG" $(SKIPCLEANUP)
+
+## Runs Kubernetes Monitoring restart-triggers e2e test
+test/e2e/kubemon/restart-triggers:
+	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "Kubemon_RestartTriggers" $(SKIPCLEANUP)
+
 test/e2e/token/migration:
 	$(GOTESTCMD) -timeout 20m ./test/e2e/scenarios/nocsi -run "token_migration" $(SKIPCLEANUP)

--- a/test/e2e/features/activegate/activegate.go
+++ b/test/e2e/features/activegate/activegate.go
@@ -85,7 +85,7 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 	// make sure that if separate kubemon activegate is not used - it does not create separate statefulset and secret
 	builder.Assess("kubemon statefulset does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		_, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.Name+"-kubemon", testDynakube.Namespace)
-		require.True(t, k8serrors.IsNotFound(err))
+require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
 
 		return ctx
 	})

--- a/test/e2e/features/activegate/activegate.go
+++ b/test/e2e/features/activegate/activegate.go
@@ -84,7 +84,7 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 	// only activegate capabilities are used in this test
 	// make sure that if separate kubemon activegate is not used - it does not create separate statefulset and secret
 	builder.Assess("kubemon statefulset does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		_, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.Name+"-kubemon", testDynakube.Namespace)
+		_, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace)
 		require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
 
 		return ctx
@@ -92,7 +92,7 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 
 	builder.Assess("kubemon authtoken secret does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		var secret corev1.Secret
-		err := envConfig.Client().Resources().Get(ctx, testDynakube.Name+"-kubemon-authtoken-secret", testDynakube.Namespace, &secret)
+		err := envConfig.Client().Resources().Get(ctx, testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace, &secret)
 		require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
 
 		return ctx

--- a/test/e2e/features/activegate/activegate.go
+++ b/test/e2e/features/activegate/activegate.go
@@ -15,8 +15,10 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
 	dynakubeComponents "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/dynakube"
+	componentOperator "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8spod"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/proxy"
@@ -25,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -72,11 +75,30 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
 	proxy.IsDynatraceNamespaceCutOff(builder, testDynakube)
 
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+
 	// Register actual test
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)
 	assessActiveGate(builder, &testDynakube)
 
 	assessReadOnlyActiveGate(builder, &testDynakube)
+
+	// only activegate capabilities are used in this test
+	// make sure that if separate kubemon activegate is not used - it does not create separate statefulset and secret
+	builder.Assess("kubemon statefulset does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		_, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.Name+"-kubemon", testDynakube.Namespace)
+		require.True(t, k8serrors.IsNotFound(err))
+
+		return ctx
+	})
+
+	builder.Assess("kubemon authtoken secret does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var secret corev1.Secret
+		err := envConfig.Client().Resources().Get(ctx, testDynakube.Name+"-kubemon-authtoken-secret", testDynakube.Namespace, &secret)
+		require.True(t, k8serrors.IsNotFound(err))
+
+		return ctx
+	})
 
 	return builder.Feature()
 }

--- a/test/e2e/features/activegate/activegate.go
+++ b/test/e2e/features/activegate/activegate.go
@@ -85,7 +85,7 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 	// make sure that if separate kubemon activegate is not used - it does not create separate statefulset and secret
 	builder.Assess("kubemon statefulset does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		_, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.Name+"-kubemon", testDynakube.Namespace)
-require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
+		require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
 
 		return ctx
 	})
@@ -93,7 +93,7 @@ require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
 	builder.Assess("kubemon authtoken secret does not exist", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		var secret corev1.Secret
 		err := envConfig.Client().Resources().Get(ctx, testDynakube.Name+"-kubemon-authtoken-secret", testDynakube.Namespace, &secret)
-		require.True(t, k8serrors.IsNotFound(err))
+		require.Truef(t, k8serrors.IsNotFound(err), "expected NotFound, got: %v", err)
 
 		return ctx
 	})

--- a/test/e2e/features/activegate/activegate.go
+++ b/test/e2e/features/activegate/activegate.go
@@ -73,7 +73,7 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 	proxy.CutOffDynatraceNamespace(builder, proxySpec)
 	proxy.IsDynatraceNamespaceCutOff(builder, testDynakube)
 
-	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()), true))
 
 	// Register actual test
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)

--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -6,7 +6,6 @@
 package kspm
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers"
@@ -17,9 +16,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
 	componentKspm "github.com/Dynatrace/dynatrace-operator/test/helpers/components/kspm"
-	"github.com/stretchr/testify/require"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
@@ -75,13 +71,6 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 	builder.Assess("kspm node config collector started", k8sdaemonset.IsReady(testDynakube.KSPM().GetDaemonSetName(), testDynakube.Namespace))
 
 	builder.Assess("check if KSPM settings were created on tenant", componentKspm.CheckKSPMSettingsExistOnTenant(secretConfig, &testDynakube))
-
-	builder.Assess("dynatrace-kubernetes-monitoring-kspm ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		var cr rbacv1.ClusterRole
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-kspm", "", &cr))
-
-		return ctx
-	})
 
 	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(
 		false,

--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -53,11 +53,7 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
 	builder.Setup(componentKspm.DeleteKSPMSettingsFromTenant(secretConfig))
-	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(
-		false,
-		helm.WithArgs("--reuse-values"),
-		helm.WithArgs("--set", "experimental.enableKubemonOperand=true"),
-	), true))
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
 
 	options := []componentDynakube.Option{
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
@@ -73,6 +69,8 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 	builder.Assess("kubemon statefulset is ready", k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
 
 	builder.Assess("kspm node config collector started", k8sdaemonset.IsReady(testDynakube.KSPM().GetDaemonSetName(), testDynakube.Namespace))
+
+	builder.Assess("check if KSPM settings were created on tenant", componentKspm.CheckKSPMSettingsExistOnTenant(secretConfig, &testDynakube))
 
 	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(
 		false,

--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -52,7 +52,7 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
 	builder.Setup(componentKspm.DeleteKSPMSettingsFromTenant(secretConfig))
-	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()), true))
 
 	options := []componentDynakube.Option{
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
@@ -71,7 +71,7 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 
 	builder.Assess("check if KSPM settings were created on tenant", componentKspm.CheckKSPMSettingsExistOnTenant(secretConfig, &testDynakube))
 
-	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()...), false))
+	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()), false))
 
 	return builder.Feature()
 }

--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -6,6 +6,7 @@
 package kspm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers"
@@ -16,6 +17,9 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
 	componentKspm "github.com/Dynatrace/dynatrace-operator/test/helpers/components/kspm"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
@@ -71,6 +75,13 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 	builder.Assess("kspm node config collector started", k8sdaemonset.IsReady(testDynakube.KSPM().GetDaemonSetName(), testDynakube.Namespace))
 
 	builder.Assess("check if KSPM settings were created on tenant", componentKspm.CheckKSPMSettingsExistOnTenant(secretConfig, &testDynakube))
+
+	builder.Assess("dynatrace-kubernetes-monitoring-kspm ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var cr rbacv1.ClusterRole
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-kspm", "", &cr))
+
+		return ctx
+	})
 
 	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(
 		false,

--- a/test/e2e/features/kspm/kspm.go
+++ b/test/e2e/features/kspm/kspm.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
 	componentKspm "github.com/Dynatrace/dynatrace-operator/test/helpers/components/kspm"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
 
 func Feature(t *testing.T) features.Feature {
@@ -72,11 +71,7 @@ func FeatureWithKubemon(t *testing.T) features.Feature {
 
 	builder.Assess("check if KSPM settings were created on tenant", componentKspm.CheckKSPMSettingsExistOnTenant(secretConfig, &testDynakube))
 
-	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(
-		false,
-		helm.WithArgs("--reuse-values"),
-		helm.WithArgs("--set", "experimental.enableKubemonOperand=false"),
-	), false))
+	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()...), false))
 
 	return builder.Feature()
 }

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -51,7 +51,7 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube), testDynakube.Namespace))
 
 	builder.Assess("kubemon statefulset is ready",
-		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+		k8sstatefulset.IsReady(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
 
 	builder.Assess("kubemon authtoken secret exists",
 		k8ssecret.Exists(testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace))
@@ -147,7 +147,7 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 	componentDynakube.Install(builder, &secretConfig, testDynakube)
 
 	builder.Assess("kubemon statefulset is ready",
-		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+		k8sstatefulset.IsReady(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
 
 	builder.Assess("KubernetesMonitoringAvailable condition is True",
 		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -85,6 +85,8 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 	builder.Assess("generic activegate statefulset is still ready",
 		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube), testDynakube.Namespace))
 
+	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()...), false))
+
 	return builder.Feature()
 }
 
@@ -116,6 +118,8 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 
 	builder.Assess("KubernetesMonitoringAvailable condition is True after rotation",
 		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
+
+	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()...), false))
 
 	return builder.Feature()
 }

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -10,7 +10,8 @@ import (
 	"os"
 	"testing"
 
-	agv1beta6 "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
+	dynakubeapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers"
 	agHelper "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
@@ -38,8 +39,8 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 	testDynakube := *componentDynakube.New(
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
 		componentDynakube.WithActiveGateModules(
-			agv1beta6.RoutingCapability.DisplayName,
-			agv1beta6.MetricsIngestCapability.DisplayName,
+			activegate.RoutingCapability.DisplayName,
+			activegate.MetricsIngestCapability.DisplayName,
 		),
 		componentDynakube.WithKubernetesMonitoringRegistration(),
 	)
@@ -101,10 +102,17 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 		return ctx
 	})
 
-	// remove kubemon from dynakube and make sure it was cleaned up properly
-	cleanedDK := testDynakube
-	cleanedDK.Spec.KubernetesMonitoring = nil
-	componentDynakube.Update(builder, cleanedDK)
+	// remove kubemon from dynakube and make sure it was cleaned up properly.
+	// Fetch the live cluster state first so fields like CustomPullSecret that were
+	// set by Install (on a local copy) are not lost by a full snapshot replacement.
+	builder.Assess("dynakube updated - kubemon removed", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var currentDK dynakubeapi.DynaKube
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, testDynakube.Name, testDynakube.Namespace, &currentDK))
+		currentDK.Spec.KubernetesMonitoring = nil
+		require.NoError(t, envConfig.Client().Resources().Update(ctx, &currentDK))
+
+		return ctx
+	})
 
 	builder.Assess("kubemon statefulset is deleted",
 		k8sstatefulset.WaitForAbsence(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -134,6 +134,7 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 	testDynakube := *componentDynakube.New(
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
 		componentDynakube.WithKubernetesMonitoringRegistration(),
+		componentDynakube.WithUsePublicRegistryFF(),
 	)
 
 	componentDynakube.Install(builder, &secretConfig, testDynakube)
@@ -147,8 +148,8 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 	builder.Assess("rotate authtoken secret",
 		k8ssecret.Delete(k8ssecret.New(testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace, nil)))
 
-	builder.Assess("kubemon statefulset re-rolls after secret rotation",
-		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+	builder.Assess("KubernetesMonitoringAvailable condition is False immediately after secret rotation",
+		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionFalse))
 
 	builder.Assess("KubernetesMonitoringAvailable condition is True after rotation",
 		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -7,7 +7,6 @@ package kubemon
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	dynakubeapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
@@ -19,11 +18,8 @@ import (
 	componentOperator "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8ssecret"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
-	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/platform"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -61,38 +57,6 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 
 	builder.Assess("KubernetesMonitoringAvailable condition is True",
 		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
-
-	builder.Assess("dynatrace-kubernetes-monitoring-default ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		var cr rbacv1.ClusterRole
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-default", "", &cr))
-
-		return ctx
-	})
-
-	builder.Assess("dynatrace-kubernetes-monitoring-default ClusterRoleBinding exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		var crb rbacv1.ClusterRoleBinding
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-default", "", &crb))
-		assert.Equal(t, "dynatrace-kubernetes-monitoring-default", crb.RoleRef.Name)
-
-		return ctx
-	})
-
-	builder.Assess("dynatrace-activegate ClusterRole and ClusterRoleBinding exist on OLM or OpenShift", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		isOpenshift, err := platform.NewResolver().IsOpenshift()
-		require.NoError(t, err)
-		if !isOpenshift && os.Getenv("OLM") != "true" {
-			t.Skip("dynatrace-activegate ClusterRole is only rendered on OpenShift or OLM installs")
-		}
-
-		var cr rbacv1.ClusterRole
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &cr))
-
-		var crb rbacv1.ClusterRoleBinding
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &crb))
-		assert.Equal(t, "dynatrace-activegate", crb.RoleRef.Name)
-
-		return ctx
-	})
 
 	// remove kubemon from dynakube and make sure it was cleaned up properly.
 	// Fetch the live cluster state first so fields like CustomPullSecret that were

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -56,7 +56,7 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 		k8ssecret.Exists(testDynakube.KubernetesMonitoring().GetTenantSecretName(), testDynakube.Namespace))
 
 	builder.Assess("KubernetesMonitoringAvailable condition is True",
-		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
+		componentDynakube.CheckCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
 
 	// remove kubemon from dynakube and make sure it was cleaned up properly.
 	// Fetch the live cluster state first so fields like CustomPullSecret that were
@@ -98,7 +98,6 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 	testDynakube := *componentDynakube.New(
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
 		componentDynakube.WithKubernetesMonitoringRegistration(),
-		componentDynakube.WithUsePublicRegistryFF(),
 	)
 
 	componentDynakube.Install(builder, &secretConfig, testDynakube)
@@ -107,7 +106,7 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 		k8sstatefulset.IsReady(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
 
 	builder.Assess("KubernetesMonitoringAvailable condition is True",
-		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
+		componentDynakube.CheckCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
 
 	builder.Assess("rotate authtoken secret",
 		k8ssecret.Delete(k8ssecret.New(testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace, nil)))

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -30,7 +30,7 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
-	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()), true))
 
 	testDynakube := *componentDynakube.New(
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
@@ -85,7 +85,7 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 	builder.Assess("generic activegate statefulset is still ready",
 		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube), testDynakube.Namespace))
 
-	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()...), false))
+	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()), false))
 
 	return builder.Feature()
 }
@@ -95,7 +95,7 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 
 	secretConfig := tenant.GetSingleTenantSecret(t)
 
-	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()), true))
 
 	testDynakube := *componentDynakube.New(
 		componentDynakube.WithAPIURL(secretConfig.APIURL),
@@ -119,7 +119,7 @@ func FeatureRestartTriggers(t *testing.T) features.Feature {
 	builder.Assess("KubernetesMonitoringAvailable condition is True after rotation",
 		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
 
-	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()...), false))
+	builder.Teardown(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.DisableKubemonOperand()), false))
 
 	return builder.Feature()
 }

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -62,14 +62,6 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 	builder.Assess("KubernetesMonitoringAvailable condition is True",
 		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
 
-	builder.Assess("kubemon pod uses dynatrace-activegate service account", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		sts, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace)
-		require.NoError(t, err)
-		assert.Equal(t, "dynatrace-activegate", sts.Spec.Template.Spec.ServiceAccountName)
-
-		return ctx
-	})
-
 	builder.Assess("dynatrace-kubernetes-monitoring-default ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		var cr rbacv1.ClusterRole
 		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-default", "", &cr))

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -7,6 +7,7 @@ package kubemon
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	agv1beta6 "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
@@ -17,6 +18,7 @@ import (
 	componentOperator "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8ssecret"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/platform"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,14 +69,31 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 		return ctx
 	})
 
-	builder.Assess("dynatrace-activegate ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+	builder.Assess("dynatrace-kubernetes-monitoring-default ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		var cr rbacv1.ClusterRole
-		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &cr))
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-default", "", &cr))
 
 		return ctx
 	})
 
-	builder.Assess("dynatrace-activegate ClusterRoleBinding exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+	builder.Assess("dynatrace-kubernetes-monitoring-default ClusterRoleBinding exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var crb rbacv1.ClusterRoleBinding
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-kubernetes-monitoring-default", "", &crb))
+		assert.Equal(t, "dynatrace-kubernetes-monitoring-default", crb.RoleRef.Name)
+
+		return ctx
+	})
+
+	builder.Assess("dynatrace-activegate ClusterRole and ClusterRoleBinding exist on OLM or OpenShift", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		isOpenshift, err := platform.NewResolver().IsOpenshift()
+		require.NoError(t, err)
+		if !isOpenshift && os.Getenv("OLM") != "true" {
+			t.Skip("dynatrace-activegate ClusterRole is only rendered on OpenShift or OLM installs")
+		}
+
+		var cr rbacv1.ClusterRole
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &cr))
+
 		var crb rbacv1.ClusterRoleBinding
 		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &crb))
 		assert.Equal(t, "dynatrace-activegate", crb.RoleRef.Name)

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -1,0 +1,138 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package kubemon
+
+import (
+	"context"
+	"testing"
+
+	agv1beta6 "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers"
+	agHelper "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/activegate"
+	componentDynakube "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/dynakube"
+	componentOperator "github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/components/operator"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8ssecret"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/kubernetes/objects/k8sstatefulset"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/helpers/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func FeatureSplitAG(t *testing.T) features.Feature {
+	builder := features.New("kubemon-split-ag-mode")
+
+	secretConfig := tenant.GetSingleTenantSecret(t)
+
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+
+	testDynakube := *componentDynakube.New(
+		componentDynakube.WithAPIURL(secretConfig.APIURL),
+		componentDynakube.WithActiveGateModules(
+			agv1beta6.RoutingCapability.DisplayName,
+			agv1beta6.MetricsIngestCapability.DisplayName,
+		),
+		componentDynakube.WithKubernetesMonitoringRegistration(),
+	)
+
+	componentDynakube.Install(builder, &secretConfig, testDynakube)
+
+	builder.Assess("generic activegate statefulset is ready",
+		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube, "activegate"), testDynakube.Namespace))
+
+	builder.Assess("kubemon statefulset is ready",
+		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+
+	builder.Assess("kubemon authtoken secret exists",
+		k8ssecret.Exists(testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace))
+
+	builder.Assess("kubemon tenant secret exists",
+		k8ssecret.Exists(testDynakube.KubernetesMonitoring().GetTenantSecretName(), testDynakube.Namespace))
+
+	builder.Assess("KubernetesMonitoringAvailable condition is True",
+		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
+
+	builder.Assess("kubemon pod uses dynatrace-activegate service account", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		sts, err := k8sstatefulset.Get(ctx, envConfig.Client().Resources(), testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace)
+		require.NoError(t, err)
+		assert.Equal(t, "dynatrace-activegate", sts.Spec.Template.Spec.ServiceAccountName)
+
+		return ctx
+	})
+
+	builder.Assess("dynatrace-activegate ClusterRole exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var cr rbacv1.ClusterRole
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &cr))
+
+		return ctx
+	})
+
+	builder.Assess("dynatrace-activegate ClusterRoleBinding exists", func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		var crb rbacv1.ClusterRoleBinding
+		require.NoError(t, envConfig.Client().Resources().Get(ctx, "dynatrace-activegate", "", &crb))
+		assert.Equal(t, "dynatrace-activegate", crb.RoleRef.Name)
+
+		return ctx
+	})
+
+	// remove kubemon from dynakube and make sure it was cleaned up properly
+	cleanedDK := testDynakube
+	cleanedDK.Spec.KubernetesMonitoring = nil
+	componentDynakube.Update(builder, cleanedDK)
+
+	builder.Assess("kubemon statefulset is deleted",
+		k8sstatefulset.WaitForAbsence(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+
+	builder.Assess("kubemon authtoken secret is deleted",
+		k8ssecret.WaitForAbsence(testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace))
+
+	builder.Assess("kubemon tenant secret is deleted",
+		k8ssecret.WaitForAbsence(testDynakube.KubernetesMonitoring().GetTenantSecretName(), testDynakube.Namespace))
+
+	builder.Assess("KubernetesMonitoringAvailable condition is absent",
+		componentDynakube.WaitForConditionAbsent(testDynakube, kubemon.KubeMonAvailableConditionType))
+
+	builder.Assess("generic activegate statefulset is still ready",
+		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube, "activegate"), testDynakube.Namespace))
+
+	return builder.Feature()
+}
+
+func FeatureRestartTriggers(t *testing.T) features.Feature {
+	builder := features.New("kubemon-restart-triggers")
+
+	secretConfig := tenant.GetSingleTenantSecret(t)
+
+	builder.Setup(helpers.ToFeatureFunc(componentOperator.InstallLocal(false, componentOperator.EnableKubemonOperand()...), true))
+
+	testDynakube := *componentDynakube.New(
+		componentDynakube.WithAPIURL(secretConfig.APIURL),
+		componentDynakube.WithKubernetesMonitoringRegistration(),
+	)
+
+	componentDynakube.Install(builder, &secretConfig, testDynakube)
+
+	builder.Assess("kubemon statefulset is ready",
+		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+
+	builder.Assess("KubernetesMonitoringAvailable condition is True",
+		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
+
+	builder.Assess("rotate authtoken secret",
+		k8ssecret.Delete(k8ssecret.New(testDynakube.KubernetesMonitoring().GetAuthTokenSecretName(), testDynakube.Namespace, nil)))
+
+	builder.Assess("kubemon statefulset re-rolls after secret rotation",
+		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
+
+	builder.Assess("KubernetesMonitoringAvailable condition is True after rotation",
+		componentDynakube.WaitForCondition(testDynakube, kubemon.KubeMonAvailableConditionType, metav1.ConditionTrue))
+
+	return builder.Feature()
+}

--- a/test/e2e/features/kubemon/kubemon.go
+++ b/test/e2e/features/kubemon/kubemon.go
@@ -48,7 +48,7 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 	componentDynakube.Install(builder, &secretConfig, testDynakube)
 
 	builder.Assess("generic activegate statefulset is ready",
-		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube, "activegate"), testDynakube.Namespace))
+		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube), testDynakube.Namespace))
 
 	builder.Assess("kubemon statefulset is ready",
 		k8sstatefulset.WaitFor(testDynakube.KubernetesMonitoring().GetStatefulSetName(), testDynakube.Namespace))
@@ -127,7 +127,7 @@ func FeatureSplitAG(t *testing.T) features.Feature {
 		componentDynakube.WaitForConditionAbsent(testDynakube, kubemon.KubeMonAvailableConditionType))
 
 	builder.Assess("generic activegate statefulset is still ready",
-		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube, "activegate"), testDynakube.Namespace))
+		k8sstatefulset.IsReady(agHelper.GetActiveGateStateFulSetName(&testDynakube), testDynakube.Namespace))
 
 	return builder.Feature()
 }

--- a/test/e2e/helpers/components/dynakube/dynakube.go
+++ b/test/e2e/helpers/components/dynakube/dynakube.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
@@ -106,6 +107,38 @@ func VerifyStartup(builder *features.FeatureBuilder, level features.Level, dk dy
 		fmt.Sprintf("'%s' dynakube phase changes to 'Running'", dk.Name),
 		level,
 		WaitForPhase(dk, status.Running))
+}
+
+func WaitForCondition(dk dynakube.DynaKube, condType string, expectedStatus metav1.ConditionStatus) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
+		err := wait.For(conditions.New(resources).ResourceMatch(&dk, func(object k8s.Object) bool {
+			d, ok := object.(*dynakube.DynaKube)
+			if !ok {
+				return false
+			}
+			cond := meta.FindStatusCondition(d.Status.Conditions, condType)
+
+			return cond != nil && cond.Status == expectedStatus
+		}), wait.WithTimeout(5*time.Minute))
+		require.NoError(t, err)
+
+		return ctx
+	}
+}
+
+func WaitForConditionAbsent(dk dynakube.DynaKube, condType string) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
+		err := wait.For(conditions.New(resources).ResourceMatch(&dk, func(object k8s.Object) bool {
+			d, ok := object.(*dynakube.DynaKube)
+
+			return ok && meta.FindStatusCondition(d.Status.Conditions, condType) == nil
+		}), wait.WithTimeout(5*time.Minute))
+		require.NoError(t, err)
+
+		return ctx
+	}
 }
 
 func WaitForPhase(dk dynakube.DynaKube, phase status.DeploymentPhase) features.Func {

--- a/test/e2e/helpers/components/dynakube/dynakube.go
+++ b/test/e2e/helpers/components/dynakube/dynakube.go
@@ -109,18 +109,33 @@ func VerifyStartup(builder *features.FeatureBuilder, level features.Level, dk dy
 		WaitForPhase(dk, status.Running))
 }
 
+func conditionStatusMatch(condType string, expectedStatus metav1.ConditionStatus) func(k8s.Object) bool {
+	return func(object k8s.Object) bool {
+		d, ok := object.(*dynakube.DynaKube)
+		if !ok {
+			return false
+		}
+		cond := meta.FindStatusCondition(d.Status.Conditions, condType)
+
+		return cond != nil && cond.Status == expectedStatus
+	}
+}
+
+func CheckCondition(dk dynakube.DynaKube, condType string, expectedStatus metav1.ConditionStatus) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
+		done, err := conditions.New(resources).ResourceMatch(&dk, conditionStatusMatch(condType, expectedStatus))(ctx)
+		require.NoError(t, err)
+		require.True(t, done)
+
+		return ctx
+	}
+}
+
 func WaitForCondition(dk dynakube.DynaKube, condType string, expectedStatus metav1.ConditionStatus) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resources := envConfig.Client().Resources()
-		err := wait.For(conditions.New(resources).ResourceMatch(&dk, func(object k8s.Object) bool {
-			d, ok := object.(*dynakube.DynaKube)
-			if !ok {
-				return false
-			}
-			cond := meta.FindStatusCondition(d.Status.Conditions, condType)
-
-			return cond != nil && cond.Status == expectedStatus
-		}), wait.WithTimeout(5*time.Minute))
+		err := wait.For(conditions.New(resources).ResourceMatch(&dk, conditionStatusMatch(condType, expectedStatus)), wait.WithTimeout(5*time.Minute))
 		require.NoError(t, err)
 
 		return ctx

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -327,3 +327,10 @@ func EnableKubemonOperand() []helm.Option {
 		helm.WithArgs("--set", "experimental.enableKubemonOperand=true"),
 	}
 }
+
+func DisableKubemonOperand() []helm.Option {
+	return []helm.Option{
+		helm.WithArgs("--reuse-values"),
+		helm.WithArgs("--set", "experimental.enableKubemonOperand=false"),
+	}
+}

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -321,16 +321,10 @@ func getImageRef(rootDir string, fips140 bool) (string, error) {
 	return imageRef, nil
 }
 
-func EnableKubemonOperand() []helm.Option {
-	return []helm.Option{
-		helm.WithArgs("--reuse-values"),
-		helm.WithArgs("--set", "experimental.enableKubemonOperand=true"),
-	}
+func EnableKubemonOperand() helm.Option {
+	return helm.WithArgs("--reuse-values", "--set", "experimental.enableKubemonOperand=true")
 }
 
-func DisableKubemonOperand() []helm.Option {
-	return []helm.Option{
-		helm.WithArgs("--reuse-values"),
-		helm.WithArgs("--set", "experimental.enableKubemonOperand=false"),
-	}
+func DisableKubemonOperand() helm.Option {
+	return helm.WithArgs("--reuse-values", "--set", "experimental.enableKubemonOperand=false")
 }

--- a/test/e2e/helpers/components/operator/installation.go
+++ b/test/e2e/helpers/components/operator/installation.go
@@ -320,3 +320,10 @@ func getImageRef(rootDir string, fips140 bool) (string, error) {
 
 	return imageRef, nil
 }
+
+func EnableKubemonOperand() []helm.Option {
+	return []helm.Option{
+		helm.WithArgs("--reuse-values"),
+		helm.WithArgs("--set", "experimental.enableKubemonOperand=true"),
+	}
+}

--- a/test/e2e/helpers/kubernetes/objects/k8ssecret/secret.go
+++ b/test/e2e/helpers/kubernetes/objects/k8ssecret/secret.go
@@ -8,11 +8,14 @@ package k8ssecret
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -49,6 +52,21 @@ func Delete(secret corev1.Secret) features.Func {
 				err = nil
 			}
 		}
+		require.NoError(t, err)
+
+		return ctx
+	}
+}
+
+func WaitForAbsence(name, namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
+		err := wait.For(conditions.New(resources).ResourceDeleted(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}), wait.WithTimeout(2*time.Minute))
 		require.NoError(t, err)
 
 		return ctx

--- a/test/e2e/helpers/kubernetes/objects/k8sstatefulset/statefulset.go
+++ b/test/e2e/helpers/kubernetes/objects/k8sstatefulset/statefulset.go
@@ -94,6 +94,21 @@ func WaitFor(name string, namespace string) features.Func {
 	}
 }
 
+func WaitForAbsence(name, namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
+		resources := envConfig.Client().Resources()
+		err := wait.For(conditions.New(resources).ResourceDeleted(&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}), wait.WithTimeout(5*time.Minute))
+		require.NoError(t, err)
+
+		return ctx
+	}
+}
+
 func WaitForReplicas(name, namespace string, replicas int32) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
 		resource := envConfig.Client().Resources()

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -255,11 +255,11 @@ func TestNoCSI_kspm_with_kubemon(t *testing.T) {
 	testEnv.Test(t, kspm.FeatureWithKubemon(t))
 }
 
-func TestNoCSI_kubemon_SplitAG(t *testing.T) {
+func TestNoCSI_kubemon_split_ag(t *testing.T) {
 	testEnv.Test(t, kubemon.FeatureSplitAG(t))
 }
 
-func TestNoCSI_kubemon_RestartTriggers(t *testing.T) {
+func TestNoCSI_kubemon_restart_triggers(t *testing.T) {
 	testEnv.Test(t, kubemon.FeatureRestartTriggers(t))
 }
 

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/extensions/dbexecutor"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/hostmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/kspm"
+	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/kubemon"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/logmonitoring"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/resourceattributes"
 	"github.com/Dynatrace/dynatrace-operator/test/e2e/features/telemetryingest"
@@ -256,6 +257,14 @@ func TestNoCSI_kspm_with_optional_scopes(t *testing.T) {
 
 func TestNoCSI_kspm_with_kubemon(t *testing.T) {
 	testEnv.Test(t, kspm.FeatureWithKubemon(t))
+}
+
+func TestNoCSI_Kubemon_SplitAG(t *testing.T) {
+	testEnv.Test(t, kubemon.FeatureSplitAG(t))
+}
+
+func TestNoCSI_Kubemon_RestartTriggers(t *testing.T) {
+	testEnv.Test(t, kubemon.FeatureRestartTriggers(t))
 }
 
 func TestNoCSI_extensions_db_executor(t *testing.T) {

--- a/test/e2e/scenarios/nocsi/no_csi_test.go
+++ b/test/e2e/scenarios/nocsi/no_csi_test.go
@@ -255,11 +255,11 @@ func TestNoCSI_kspm_with_kubemon(t *testing.T) {
 	testEnv.Test(t, kspm.FeatureWithKubemon(t))
 }
 
-func TestNoCSI_Kubemon_SplitAG(t *testing.T) {
+func TestNoCSI_kubemon_SplitAG(t *testing.T) {
 	testEnv.Test(t, kubemon.FeatureSplitAG(t))
 }
 
-func TestNoCSI_Kubemon_RestartTriggers(t *testing.T) {
+func TestNoCSI_kubemon_RestartTriggers(t *testing.T) {
 	testEnv.Test(t, kubemon.FeatureRestartTriggers(t))
 }
 


### PR DESCRIPTION
https://dt-rnd.atlassian.net/browse/ICP-7299
## Description

the ticket requires to cover the following criteria:
- **Split-AG mode (new)** - done in `test/e2e/features/kubemon/kubemon.go`
- **All-in AG mode (legacy)** - enabled kubemon experimental flag and extended checks in `test/e2e/features/activegate/activegate.go` that kubemon indeed is not deployed if not used 
- **Validation webhook** - no new code. I think we are covered in `pkg/api/validation/dynakube/kubemon_test.go`
- **Conditions** - no new code. I think we are covered in `pkg/controllers/dynakube/kubemon/reconciler_test.go`
- **Restart triggers** - done in `test/e2e/features/kubemon/kubemon.go`
- **Cleanup** -  done in `test/e2e/features/kubemon/kubemon.go` at the end
- **RBAC** - ~done in `test/e2e/features/kubemon/kubemon.go` - it's first time in e2e where we check rbac so precisely. ⚠️~ will be covered in helm unit tests
- **Integrations (with KSPM)** `test/e2e/features/kspm/kspm.go` - kspm was done already by @mihaitanasedt , i've expanded this tests with settings creation check and rbac

## How can this be tested?
``` 
make go/test (Webhook/Conditions)

make test/e2e/activegate
make test/e2e/kubemon
make test/e2e/kubemon/olm


# Test specific scenarios
make test/e2e/kubemon/split-ag
make test/e2e/kubemon/restart-triggers
```