### PR TITLE
[DynaKube] Auto-update NCC image from fleet management

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -6731,6 +6731,8 @@ spec:
                 x-kubernetes-list-type: map
               kspm:
                 properties:
+                  image:
+                    type: string
                   tokenSecretHash:
                     type: string
                 type: object

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -6747,6 +6747,8 @@ spec:
                 x-kubernetes-list-type: map
               kspm:
                 properties:
+                  image:
+                    type: string
                   tokenSecretHash:
                     type: string
                 type: object

--- a/pkg/api/latest/dynakube/kspm/spec.go
+++ b/pkg/api/latest/dynakube/kspm/spec.go
@@ -34,6 +34,10 @@ type Status struct {
 	// TokenSecretHash contains the hash of the token that is passed to both the ActiveGate and Node-Configuration-Collector.
 	// Meant to keep the two in sync.
 	TokenSecretHash string `json:"tokenSecretHash,omitempty"`
+
+	// The resolved NodeConfigurationCollector image that is currently deployed.
+	// The JSON tag uses "image" while the Go field name is ResolvedImage to distinguish it from the ImageRef in the spec.
+	ResolvedImage string `json:"image,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/api/validation/dynakube/kspm.go
+++ b/pkg/api/validation/dynakube/kspm.go
@@ -46,11 +46,15 @@ func missingKSPMImage(_ context.Context, _ *Validator, dk *dynakube.DynaKube) st
 		return ""
 	}
 
-	if !dk.KSPM().ImageRef.HasImage() {
-		return errorKSPMMissingImage
+	if dk.KSPM().ImageRef.HasImage() {
+		return ""
 	}
 
-	return ""
+	if dk.FF().IsPublicRegistry() {
+		return ""
+	}
+
+	return errorKSPMMissingImage
 }
 
 func noMappedHostPaths(_ context.Context, _ *Validator, dk *dynakube.DynaKube) string {

--- a/pkg/api/validation/dynakube/kspm_test.go
+++ b/pkg/api/validation/dynakube/kspm_test.go
@@ -440,6 +440,70 @@ func TestMissingKSPMImage(t *testing.T) {
 				},
 			})
 	})
+
+	t.Run("no image ref and public registry enabled, image comes from fleet management", func(t *testing.T) {
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				ObjectMeta: publicRegistryDynakubeObjectMeta(),
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					KSPM:   &kspm.Spec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
+				},
+			})
+	})
+
+	t.Run("no image ref and public registry enabled with override, image comes from the override registry", func(t *testing.T) {
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				ObjectMeta: publicRegistryDynakubeObjectMeta(),
+				Spec: dynakube.DynaKubeSpec{
+					APIURL:                 testAPIURL,
+					KSPM:                   &kspm.Spec{},
+					PublicRegistryOverride: "my.registry.example.com",
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
+				},
+			})
+	})
+
+	t.Run("image ref set and public registry enabled, the custom image wins", func(t *testing.T) {
+		assertAllowed(t,
+			&dynakube.DynaKube{
+				ObjectMeta: publicRegistryDynakubeObjectMeta(),
+				Spec: dynakube.DynaKubeSpec{
+					APIURL: testAPIURL,
+					KSPM:   &kspm.Spec{},
+					ActiveGate: activegate.Spec{
+						Capabilities: []activegate.CapabilityDisplayName{
+							activegate.KubeMonCapability.DisplayName,
+						},
+					},
+					Templates: dynakube.TemplatesSpec{
+						KSPMNodeConfigurationCollector: kspm.NodeConfigurationCollectorSpec{
+							ImageRef: image.Ref{
+								Repository: "repo/image",
+								Tag:        "version",
+							},
+						},
+					},
+				},
+			})
+	})
+}
+
+func publicRegistryDynakubeObjectMeta() metav1.ObjectMeta {
+	objectMeta := *defaultDynakubeObjectMeta.DeepCopy()
+	objectMeta.Annotations = map[string]string{exp.UsePublicRegistryKey: "true"}
+
+	return objectMeta
 }
 
 func TestMappedHostPath(t *testing.T) {

--- a/pkg/clients/dynatrace/image/client.go
+++ b/pkg/clients/dynatrace/image/client.go
@@ -21,6 +21,7 @@ const (
 	ActiveGate      ComponentType = "activegate"
 	EEC             ComponentType = "eec"
 	LogModule       ComponentType = "logmodule"
+	NCC             ComponentType = "ncc"
 	OTelCollector   ComponentType = "otel-collector"
 	DBExecutor      ComponentType = "sql-extension-executor"
 	Gateway         ComponentType = "" // TODO: image name is still unknown

--- a/pkg/controllers/dynakube/controller.go
+++ b/pkg/controllers/dynakube/controller.go
@@ -168,7 +168,7 @@ type activeGateReconciler interface {
 }
 
 type kspmReconciler interface {
-	Reconcile(ctx context.Context, dtClient settings.Client, dk *dynakube.DynaKube) error
+	Reconcile(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error
 }
 
 type injectionReconciler interface {
@@ -438,7 +438,7 @@ func (controller *Controller) reconcileComponents(ctx context.Context, dtClient 
 
 	log.Info("start reconciling KSPM")
 
-	if err := controller.kspmReconciler.Reconcile(ctx, dtClient.Settings, dk); err != nil {
+	if err := controller.kspmReconciler.Reconcile(ctx, dtClient, dk); err != nil {
 		log.Info("could not reconcile kspm")
 
 		componentErrors = append(componentErrors, err)

--- a/pkg/controllers/dynakube/controller_test.go
+++ b/pkg/controllers/dynakube/controller_test.go
@@ -360,7 +360,7 @@ func TestReconcileComponents(t *testing.T) {
 		mockLogMonitoringReconciler := newMockLogMonitoringReconciler(t)
 
 		mockExtensionReconciler := newMockExtensionReconciler(t)
-		mockKSPMReconciler := newMockDtSettingReconciler(t)
+		mockKSPMReconciler := newMockKspmReconciler(t)
 		mockK8sEntityReconciler := newMockDtSettingReconciler(t)
 		mockOTelColReconciler := newMockOTelColReconciler(t)
 		mockIstioReconciler := newMockIstioReconciler(t)
@@ -391,7 +391,7 @@ func TestReconcileComponents(t *testing.T) {
 		expectReconcileError(t, mockLogMonitoringReconciler, &err, dtClient, dk)
 		expectReconcileError(t, mockExtensionReconciler, &err, dtClient.Images, dk)
 		expectReconcileError(t, mockOTelColReconciler, &err, dtClient.Images, dk)
-		expectReconcileError(t, mockKSPMReconciler, &err, dtClient.Settings, dk)
+		expectReconcileError(t, mockKSPMReconciler, &err, dtClient, dk)
 		expectReconcileError(t, mockK8sEntityReconciler, &err, dtClient.Settings, dk)
 
 		err = controller.reconcileComponents(ctx, dtClient, dk)
@@ -434,7 +434,7 @@ func TestReconcileComponents(t *testing.T) {
 		expectReconcileError(t, mockExtensionReconciler, &err, dtClient.Images, dk)
 		expectReconcileError(t, mockOTelColReconciler, &err, dtClient.Images, dk)
 		expectReconcileError(t, k8sEntityReconciler, &err, dtClient.Settings, dk)
-		expectReconcileError(t, mockKSPMReconciler, &err, dtClient.Settings, dk)
+		expectReconcileError(t, mockKSPMReconciler, &err, dtClient, dk)
 
 		err = controller.reconcileComponents(ctx, dtClient, dk)
 		require.Error(t, err)
@@ -450,7 +450,7 @@ func TestReconcileComponents(t *testing.T) {
 		mockInjectionReconciler := newMockInjectionReconciler(t)
 		mockLogMonitoringReconciler := newMockLogMonitoringReconciler(t)
 		mockExtensionReconciler := newMockExtensionReconciler(t)
-		mockKSPMReconciler := newMockDtSettingReconciler(t)
+		mockKSPMReconciler := newMockKspmReconciler(t)
 		mockK8sEntityReconciler := newMockDtSettingReconciler(t)
 		mockOTelColReconciler := newMockOTelColReconciler(t)
 
@@ -477,7 +477,7 @@ func TestReconcileComponents(t *testing.T) {
 		mockKubemonReconciler.EXPECT().Reconcile(anyCtx, dk, dtClient, token.Tokens(nil)).Return(k8sstatefulset.ErrRolloutInProgress).Once()
 		mockExtensionReconciler.EXPECT().Reconcile(anyCtx, dtClient.Images, dk).Return(nil).Once()
 		mockOTelColReconciler.EXPECT().Reconcile(anyCtx, dtClient.Images, dk).Return(nil).Once()
-		mockKSPMReconciler.EXPECT().Reconcile(anyCtx, dtClient.Settings, dk).Return(nil).Once()
+		mockKSPMReconciler.EXPECT().Reconcile(anyCtx, dtClient, dk).Return(nil).Once()
 		mockLogMonitoringReconciler.EXPECT().Reconcile(anyCtx, dtClient, dk).Return(nil).Once()
 		mockInjectionReconciler.EXPECT().Reconcile(anyCtx, dtClient, dk).Return(nil).Once()
 		mockOneAgentReconciler.EXPECT().Reconcile(anyCtx, dk, dtClient, token.Tokens(nil)).Return(nil).Once()
@@ -497,7 +497,7 @@ func TestReconcileComponents(t *testing.T) {
 		mockInjectionReconciler := newMockInjectionReconciler(t)
 		mockLogMonitoringReconciler := newMockLogMonitoringReconciler(t)
 		mockExtensionReconciler := newMockExtensionReconciler(t)
-		mockKSPMReconciler := newMockDtSettingReconciler(t)
+		mockKSPMReconciler := newMockKspmReconciler(t)
 		mockK8sEntityReconciler := newMockDtSettingReconciler(t)
 		mockOTelColReconciler := newMockOTelColReconciler(t)
 
@@ -524,7 +524,7 @@ func TestReconcileComponents(t *testing.T) {
 		mockKubemonReconciler.EXPECT().Reconcile(anyCtx, dk, dtClient, token.Tokens(nil)).Return(kubemonconnectioninfo.ErrConnectionInfoNotReady).Once()
 		mockExtensionReconciler.EXPECT().Reconcile(anyCtx, dtClient.Images, dk).Return(nil).Once()
 		mockOTelColReconciler.EXPECT().Reconcile(anyCtx, dtClient.Images, dk).Return(nil).Once()
-		mockKSPMReconciler.EXPECT().Reconcile(anyCtx, dtClient.Settings, dk).Return(nil).Once()
+		mockKSPMReconciler.EXPECT().Reconcile(anyCtx, dtClient, dk).Return(nil).Once()
 		mockLogMonitoringReconciler.EXPECT().Reconcile(anyCtx, dtClient, dk).Return(nil).Once()
 		mockInjectionReconciler.EXPECT().Reconcile(anyCtx, dtClient, dk).Return(nil).Once()
 		mockOneAgentReconciler.EXPECT().Reconcile(anyCtx, dk, dtClient, token.Tokens(nil)).Return(nil).Once()
@@ -588,8 +588,8 @@ func TestReconcileDynaKube(t *testing.T) {
 	mockIstioReconciler := newMockIstioReconciler(t)
 	mockIstioReconciler.EXPECT().ReconcileAPIURL(anyCtx, anyDynaKube).Return(nil)
 
-	mockKSPMReconciler := newMockDtSettingReconciler(t)
-	mockKSPMReconciler.EXPECT().Reconcile(anyCtx, dtClient.Settings, anyDynaKube).Return(nil)
+	mockKSPMReconciler := newMockKspmReconciler(t)
+	mockKSPMReconciler.EXPECT().Reconcile(anyCtx, dtClient, anyDynaKube).Return(nil)
 
 	mockK8sEntityReconciler := newMockDtSettingReconciler(t)
 	mockK8sEntityReconciler.EXPECT().Reconcile(anyCtx, dtClient.Settings, anyDynaKube).Return(nil)

--- a/pkg/controllers/dynakube/kspm/daemonset/container.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/container.go
@@ -11,9 +11,6 @@ import (
 )
 
 const (
-	defaultImageRepo = "public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector"
-	defaultImageTag  = "latest"
-
 	containerName       = "node-config-collector"
 	runAs         int64 = 65532
 )
@@ -24,7 +21,7 @@ func getContainer(dk dynakube.DynaKube, tenantUUID string) corev1.Container {
 
 	container := corev1.Container{
 		Name:            containerName,
-		Image:           dk.KSPM().ImageRef.StringWithDefaults(defaultImageRepo, defaultImageTag),
+		Image:           dk.Status.KSPM.ResolvedImage,
 		ImagePullPolicy: dk.KSPM().ImageRef.PullPolicy,
 		VolumeMounts:    getMounts(dk),
 		Env:             getEnvs(dk, tenantUUID),

--- a/pkg/controllers/dynakube/kspm/daemonset/container_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/container_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestGetContainer(t *testing.T) {
@@ -24,13 +25,16 @@ func TestGetContainer(t *testing.T) {
 			Spec: dynakube.DynaKubeSpec{
 				KSPM: &kspm.Spec{},
 			},
+			Status: dynakube.DynaKubeStatus{
+				KSPM: kspm.Status{ResolvedImage: "test-repo/test-image:test-tag"},
+			},
 		}
 		mainContainer := getContainer(dk, tenant)
 
 		require.NotEmpty(t, mainContainer)
 
 		assert.NotEmpty(t, mainContainer.Name)
-		assert.NotEmpty(t, mainContainer.Image)
+		assert.Equal(t, "test-repo/test-image:test-tag", mainContainer.Image)
 		assert.Empty(t, mainContainer.ImagePullPolicy)
 		assert.NotEmpty(t, mainContainer.VolumeMounts)
 		assert.Len(t, mainContainer.VolumeMounts, expectedMountLen)
@@ -40,22 +44,21 @@ func TestGetContainer(t *testing.T) {
 		assert.NotEmpty(t, mainContainer.SecurityContext.SeccompProfile)
 	})
 
-	t.Run("image-ref is respected", func(t *testing.T) {
-		expectedRepo := "my-test-repo"
-		expectedTag := "my-test-tag"
+	// the image itself comes from the status, see TestImageResolution
+	t.Run("pull policy is taken from the image-ref", func(t *testing.T) {
 		dk := dynakube.DynaKube{
 			Spec: dynakube.DynaKubeSpec{
 				KSPM: &kspm.Spec{},
 			},
 		}
 		dk.KSPM().ImageRef = image.Ref{
-			Repository: expectedRepo,
-			Tag:        expectedTag,
+			Repository: "my-test-repo",
+			Tag:        "my-test-tag",
+			PullPolicy: corev1.PullAlways,
 		}
 		mainContainer := getContainer(dk, tenant)
 
 		require.NotEmpty(t, mainContainer)
-		assert.NotEmpty(t, mainContainer.Image)
-		assert.Equal(t, expectedRepo+":"+expectedTag, mainContainer.Image)
+		assert.Equal(t, corev1.PullAlways, mainContainer.ImagePullPolicy)
 	})
 }

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -8,6 +8,8 @@ import (
 	"maps"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	dtimage "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8saffinity"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
@@ -38,7 +40,26 @@ func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 	}
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error {
+// resolveImage records the image to deploy in the status. The templates section takes
+// precedence over the image reported by the public registry.
+func resolveImage(ctx context.Context, imageClient dtimage.Client, dk *dynakube.DynaKube) error {
+	if ref := dk.KSPM().ImageRef; ref.HasImage() {
+		dk.Status.KSPM.ResolvedImage = ref.String()
+
+		return nil
+	}
+
+	imageURI, err := registry.ResolveImage(ctx, imageClient, dk.PublicRegistryOverride(), dtimage.NCC)
+	if err != nil {
+		return err
+	}
+
+	dk.Status.KSPM.ResolvedImage = imageURI
+
+	return nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, dk *dynakube.DynaKube) error {
 	ctx, log := logd.NewFromContext(ctx, "daemonset")
 
 	if !dk.KSPM().IsEnabled() {
@@ -54,6 +75,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error
 		}
 
 		return nil // clean-up shouldn't cause a failure
+	}
+
+	// has to run before the daemonset is generated, the container image is taken from the status
+	if err := resolveImage(ctx, imageClient, dk); err != nil {
+		return err
 	}
 
 	ds, err := r.generateDaemonSet(dk)

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
@@ -12,12 +12,16 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
+	sharedimage "github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
+	dtimage "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/version"
+	imageclientmock "github.com/Dynatrace/dynatrace-operator/test/mocks/pkg/clients/dynatrace/image"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +36,11 @@ import (
 const (
 	dkName      = "test-name"
 	dkNamespace = "test-namespace"
+
+	testImageRepo         = "test-repo/dynatrace-k8s-node-config-collector"
+	testImageTag          = "1.289.0"
+	testFleetMgmtImageURI = "registry.example.com/dynatrace-k8s-node-config-collector:1.300.0"
+	testRegistryOverride  = "my.registry.example.com"
 )
 
 func TestReconcile(t *testing.T) {
@@ -44,7 +53,7 @@ func TestReconcile(t *testing.T) {
 		mockK8sClient := fake.NewClient()
 
 		reconciler := NewReconciler(mockK8sClient, mockK8sClient)
-		err := reconciler.Reconcile(ctx, dk)
+		err := reconciler.Reconcile(ctx, imageclientmock.NewClient(t), dk)
 		require.NoError(t, err)
 
 		condition := meta.FindStatusCondition(*dk.Conditions(), conditionType)
@@ -54,7 +63,7 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, k8sconditions.DaemonSetSetCreatedReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 
-		err = reconciler.Reconcile(t.Context(), dk)
+		err = reconciler.Reconcile(t.Context(), imageclientmock.NewClient(t), dk)
 		require.NoError(t, err)
 
 		var daemonset appsv1.DaemonSet
@@ -77,7 +86,7 @@ func TestReconcile(t *testing.T) {
 		k8sconditions.SetDaemonSetCreated(dk.Conditions(), conditionType, "this is a test")
 
 		reconciler := NewReconciler(mockK8sClient, mockK8sClient)
-		err := reconciler.Reconcile(ctx, dk)
+		err := reconciler.Reconcile(ctx, imageclientmock.NewClient(t), dk)
 
 		require.NoError(t, err)
 		assert.Empty(t, *dk.Conditions())
@@ -97,13 +106,94 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := NewReconciler(boomClient, boomClient)
 
-		err := reconciler.Reconcile(t.Context(), dk)
+		err := reconciler.Reconcile(t.Context(), imageclientmock.NewClient(t), dk)
 
 		require.Error(t, err)
 		require.Len(t, *dk.Conditions(), 1)
 		condition := meta.FindStatusCondition(*dk.Conditions(), conditionType)
 		assert.Equal(t, k8sconditions.KubeAPIErrorReason, condition.Reason)
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	})
+}
+
+func TestImageResolution(t *testing.T) {
+	t.Cleanup(version.DisableCacheForTest(123))
+
+	ctx := t.Context()
+	anyCtx := mock.MatchedBy(func(context.Context) bool { return true })
+
+	reconcileDaemonSet := func(t *testing.T, dk *dynakube.DynaKube, imageClient *imageclientmock.Client) (appsv1.DaemonSet, error) {
+		t.Helper()
+
+		mockK8sClient := fake.NewClient()
+
+		err := NewReconciler(mockK8sClient, mockK8sClient).Reconcile(ctx, imageClient, dk)
+		if err != nil {
+			return appsv1.DaemonSet{}, err
+		}
+
+		var daemonset appsv1.DaemonSet
+
+		err = mockK8sClient.Get(ctx, types.NamespacedName{Name: dk.KSPM().GetDaemonSetName(), Namespace: dk.Namespace}, &daemonset)
+		require.NoError(t, err)
+
+		return daemonset, nil
+	}
+
+	t.Run("custom image-ref is used as-is, fleet management is not called", func(t *testing.T) {
+		dk := createDynakube(true)
+
+		// a mock without expectations fails the test if fleet management gets called
+		daemonset, err := reconcileDaemonSet(t, dk, imageclientmock.NewClient(t))
+		require.NoError(t, err)
+
+		assert.Equal(t, testImageRepo+":"+testImageTag, dk.Status.KSPM.ResolvedImage)
+		assert.Equal(t, testImageRepo+":"+testImageTag, daemonset.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("no image-ref takes the image from fleet management using the default registry", func(t *testing.T) {
+		dk := createDynakube(true)
+		dk.Spec.Templates.KSPMNodeConfigurationCollector.ImageRef = sharedimage.Ref{}
+
+		imageClient := imageclientmock.NewClient(t)
+		imageClient.EXPECT().GetComponentLatestInfo(anyCtx, dtimage.NCC, "").
+			Return(&dtimage.Info{URI: testFleetMgmtImageURI}, nil).Once()
+
+		daemonset, err := reconcileDaemonSet(t, dk, imageClient)
+		require.NoError(t, err)
+
+		assert.Equal(t, testFleetMgmtImageURI, dk.Status.KSPM.ResolvedImage)
+		assert.Equal(t, testFleetMgmtImageURI, daemonset.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("no image-ref takes the image from fleet management using the override registry", func(t *testing.T) {
+		dk := createDynakube(true)
+		dk.Spec.Templates.KSPMNodeConfigurationCollector.ImageRef = sharedimage.Ref{}
+		dk.Spec.PublicRegistryOverride = testRegistryOverride
+
+		imageClient := imageclientmock.NewClient(t)
+		imageClient.EXPECT().GetComponentLatestInfo(anyCtx, dtimage.NCC, testRegistryOverride).
+			Return(&dtimage.Info{URI: testFleetMgmtImageURI}, nil).Once()
+
+		daemonset, err := reconcileDaemonSet(t, dk, imageClient)
+		require.NoError(t, err)
+
+		assert.Equal(t, testFleetMgmtImageURI, daemonset.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("failing image resolution is propagated and leaves the status empty", func(t *testing.T) {
+		dk := createDynakube(true)
+		dk.Spec.Templates.KSPMNodeConfigurationCollector.ImageRef = sharedimage.Ref{}
+
+		expectedErr := errors.New("fleet management is unreachable")
+
+		imageClient := imageclientmock.NewClient(t)
+		imageClient.EXPECT().GetComponentLatestInfo(anyCtx, dtimage.NCC, "").Return(nil, expectedErr).Once()
+
+		_, err := reconcileDaemonSet(t, dk, imageClient)
+		require.ErrorIs(t, err, expectedErr)
+
+		assert.Empty(t, dk.Status.KSPM.ResolvedImage)
 	})
 }
 
@@ -311,6 +401,11 @@ func createDynakube(isEnabled bool) *dynakube.DynaKube {
 			ActiveGate: activegate.Spec{
 				Capabilities: []activegate.CapabilityDisplayName{
 					activegate.KubeMonCapability.DisplayName,
+				},
+			},
+			Templates: dynakube.TemplatesSpec{
+				KSPMNodeConfigurationCollector: kspm.NodeConfigurationCollectorSpec{
+					ImageRef: sharedimage.Ref{Repository: testImageRepo, Tag: testImageTag},
 				},
 			},
 		},

--- a/pkg/controllers/dynakube/kspm/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/reconciler.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
-	dtsettings "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/settings"
+	"github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kspm/daemonset"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kspm/kspmsettings"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kspm/token"
@@ -29,7 +29,7 @@ func NewReconciler(client client.Client, apiReader client.Reader) *Reconciler {
 	}
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, dtClient dtsettings.Client, dk *dynakube.DynaKube) error {
+func (r *Reconciler) Reconcile(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error {
 	ctx, log := logd.NewFromContext(ctx, "kspm")
 
 	err := r.tokenReconciler.Reconcile(ctx, dk)
@@ -39,14 +39,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, dtClient dtsettings.Client, 
 		return err
 	}
 
-	err = r.settingsReconciler.Reconcile(ctx, dtClient, dk)
+	err = r.settingsReconciler.Reconcile(ctx, dtClient.Settings, dk)
 	if err != nil {
 		log.Info("failed to reconcile KSPM Settings")
 
 		return err
 	}
 
-	err = r.daemonSetReconciler.Reconcile(ctx, dk)
+	err = r.daemonSetReconciler.Reconcile(ctx, dtClient.Images, dk)
 	if err != nil {
 		log.Info("failed to reconcile Dynatrace KSPM DaemonSet")
 

--- a/pkg/controllers/dynakube/mock_reconcilers_test.go
+++ b/pkg/controllers/dynakube/mock_reconcilers_test.go
@@ -766,7 +766,7 @@ func (_m *mockKspmReconciler) EXPECT() *mockKspmReconciler_Expecter {
 }
 
 // Reconcile provides a mock function for the type mockKspmReconciler
-func (_mock *mockKspmReconciler) Reconcile(ctx context.Context, dtClient settings.Client, dk *dynakube.DynaKube) error {
+func (_mock *mockKspmReconciler) Reconcile(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error {
 	ret := _mock.Called(ctx, dtClient, dk)
 
 	if len(ret) == 0 {
@@ -774,7 +774,7 @@ func (_mock *mockKspmReconciler) Reconcile(ctx context.Context, dtClient setting
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, settings.Client, *dynakube.DynaKube) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *dynatrace.Client, *dynakube.DynaKube) error); ok {
 		r0 = returnFunc(ctx, dtClient, dk)
 	} else {
 		r0 = ret.Error(0)
@@ -789,21 +789,21 @@ type mockKspmReconciler_Reconcile_Call struct {
 
 // Reconcile is a helper method to define mock.On call
 //   - ctx context.Context
-//   - dtClient settings.Client
+//   - dtClient *dynatrace.Client
 //   - dk *dynakube.DynaKube
 func (_e *mockKspmReconciler_Expecter) Reconcile(ctx any, dtClient any, dk any) *mockKspmReconciler_Reconcile_Call {
 	return &mockKspmReconciler_Reconcile_Call{Call: _e.mock.On("Reconcile", ctx, dtClient, dk)}
 }
 
-func (_c *mockKspmReconciler_Reconcile_Call) Run(run func(ctx context.Context, dtClient settings.Client, dk *dynakube.DynaKube)) *mockKspmReconciler_Reconcile_Call {
+func (_c *mockKspmReconciler_Reconcile_Call) Run(run func(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube)) *mockKspmReconciler_Reconcile_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 settings.Client
+		var arg1 *dynatrace.Client
 		if args[1] != nil {
-			arg1 = args[1].(settings.Client)
+			arg1 = args[1].(*dynatrace.Client)
 		}
 		var arg2 *dynakube.DynaKube
 		if args[2] != nil {
@@ -823,7 +823,7 @@ func (_c *mockKspmReconciler_Reconcile_Call) Return(err error) *mockKspmReconcil
 	return _c
 }
 
-func (_c *mockKspmReconciler_Reconcile_Call) RunAndReturn(run func(ctx context.Context, dtClient settings.Client, dk *dynakube.DynaKube) error) *mockKspmReconciler_Reconcile_Call {
+func (_c *mockKspmReconciler_Reconcile_Call) RunAndReturn(run func(ctx context.Context, dtClient *dynatrace.Client, dk *dynakube.DynaKube) error) *mockKspmReconciler_Reconcile_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
ICP-8208

## Description

- Fetch node config collector from the fleetManagement endpoint
- validation: imageRef is optional when the public registry is enabled, still required otherwise
- removed the hardcoded `public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector:latest` default

## How can this be tested?

Manually set imageRef gets priority
```
  kspm: {}
  templates:
    kspmNodeConfigurationCollector:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector
        tag: latest
```
```
kubectl get dynakube your-dynakube -n dynatrace -o jsonpath='{.status.kspm}' | jq
{
  "image": "public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector:latest"
}
```

**OR**

```
  kspm: {}
```
currently fails as expected with
```
image discovery failed for \"ncc\": no matching image in DT API response
```
`ncc` is not served by the endpoint yet, tracked in [ICP-1940](https://dt-rnd.atlassian.net/browse/ICP-1940).


[ICP-1940]: https://dt-rnd.atlassian.net/browse/ICP-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ