### PR TITLE
Address Renovate warnings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,7 @@
   automergeType: "pr",
   automerge: true,
   branchNameStrict: true,
+  branchPrefix: "rnv/",
   prConcurrentLimit: 10,
   hashedBranchLength: 27, // 63 character limit for label values with space for "dynatrace-operator.v0.0.0-snapshot-" prefix
   "osvVulnerabilityAlerts": true,
@@ -233,6 +234,10 @@
     {
       matchManagers: ["pip_requirements", "npm", "regex"],
       groupName: "Dev tooling",
+    },
+    {
+      matchPackageNames: ["gcr.io/cloud-marketplace-tools/**"],
+      enabled: false,
     },
   ],
   platformAutomerge: true,


### PR DESCRIPTION

## Description
Fixes the following warnings:
> `hashedBranchLength` must allow for at least the minimum hash length in addition to `branchPrefix`. Using the minimum hash length instead.

Fixed by changing Renovate's PR branch prefix from `renovate/` to `rnv/`

> No docker auth found - returning

Fixed by excluding `gcr.io/cloud-marketplace-tools/**` => doesn't need to be updated, and requires authentication
