### PR TITLE
refactor: remove redundant component param from ActiveGate e2e helpers

### DIFF
--- a/test/e2e/features/activegate/activegate.go
+++ b/test/e2e/features/activegate/activegate.go
@@ -31,8 +31,6 @@ import (
 )
 
 var (
-	agComponentName = "activegate"
-
 	agContainers = map[string]bool{
 		consts.ActiveGateContainerName: false,
 	}
@@ -82,7 +80,7 @@ func Feature(t *testing.T, proxySpec *value.Source) features.Feature {
 }
 
 func assessActiveGate(builder *features.FeatureBuilder, dk *dynakube.DynaKube) {
-	builder.Assess("ActiveGate started", k8sstatefulset.IsReady(activegate.GetActiveGateStateFulSetName(dk, "activegate"), dk.Namespace))
+	builder.Assess("ActiveGate started", k8sstatefulset.IsReady(activegate.GetActiveGateStateFulSetName(dk), dk.Namespace))
 	builder.Assess("ActiveGate has required containers", checkIfAgHasContainers(dk))
 	builder.Assess("ActiveGate modules are active", checkActiveModules(dk))
 	if dk.Spec.Proxy != nil {
@@ -107,7 +105,7 @@ func checkIfAgHasContainers(dk *dynakube.DynaKube) features.Func {
 		kubeResources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
-		require.NoError(t, kubeResources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk, agComponentName), dk.Namespace, &activeGatePod))
+		require.NoError(t, kubeResources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk), dk.Namespace, &activeGatePod))
 
 		require.NotNil(t, activeGatePod.Spec)
 		require.NotEmpty(t, activeGatePod.Spec.InitContainers)
@@ -122,7 +120,7 @@ func checkIfAgHasContainers(dk *dynakube.DynaKube) features.Func {
 
 func checkActiveModules(dk *dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		log := activegate.ReadActiveGateLog(ctx, t, envConfig, dk, agComponentName)
+		log := activegate.ReadActiveGateLog(ctx, t, envConfig, dk)
 		assertExpectedModulesAreActive(t, log)
 
 		return ctx
@@ -131,7 +129,7 @@ func checkActiveModules(dk *dynakube.DynaKube) features.Func {
 
 func checkIfProxyUsed(dk *dynakube.DynaKube) features.Func {
 	return func(ctx context.Context, t *testing.T, envConfig *envconf.Config) context.Context {
-		log := activegate.ReadActiveGateLog(ctx, t, envConfig, dk, agComponentName)
+		log := activegate.ReadActiveGateLog(ctx, t, envConfig, dk)
 		assertProxyUsed(t, log, dk.Spec.Proxy.Value)
 
 		return ctx
@@ -143,7 +141,7 @@ func checkMountPoints(dk *dynakube.DynaKube) features.Func {
 		kubeResources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
-		require.NoError(t, kubeResources.Get(ctx, activegate.GetActiveGatePodName(dk, agComponentName), dk.Namespace, &activeGatePod))
+		require.NoError(t, kubeResources.Get(ctx, activegate.GetActiveGatePodName(dk), dk.Namespace, &activeGatePod))
 
 		for name, mountPoints := range agMounts {
 			assertMountPointsExist(ctx, t, kubeResources, activeGatePod, name, mountPoints)
@@ -246,7 +244,7 @@ func checkReadOnlySettings(dk *dynakube.DynaKube) features.Func {
 		kubeResources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
-		require.NoError(t, kubeResources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk, agComponentName), dk.Namespace, &activeGatePod))
+		require.NoError(t, kubeResources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk), dk.Namespace, &activeGatePod))
 
 		require.NotNil(t, activeGatePod.Spec)
 		require.NotEmpty(t, activeGatePod.Spec.InitContainers)

--- a/test/e2e/features/activegate/scaling.go
+++ b/test/e2e/features/activegate/scaling.go
@@ -33,7 +33,7 @@ func WithHPA(t *testing.T) features.Feature {
 
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)
 
-	activeGateSSName := activegate.GetActiveGateStateFulSetName(&testDynakube, "activegate")
+	activeGateSSName := activegate.GetActiveGateStateFulSetName(&testDynakube)
 
 	testHPA := &autoscalingv1.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
@@ -69,7 +69,7 @@ func EnforceReplicas(t *testing.T) features.Feature {
 
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)
 
-	activeGateSSName := activegate.GetActiveGateStateFulSetName(&testDynakube, "activegate")
+	activeGateSSName := activegate.GetActiveGateStateFulSetName(&testDynakube)
 
 	builder.Assess("scale AG statefulset replicas to 3", k8sstatefulset.Update(activeGateSSName, testDynakube.Namespace, func(ss *appsv1.StatefulSet) {
 		ss.Spec.Replicas = scaleReplicas

--- a/test/e2e/features/cloudnative/container.go
+++ b/test/e2e/features/cloudnative/container.go
@@ -85,7 +85,7 @@ func checkActiveGateContainer(dk *dynakube.DynaKube, trustedCAs []byte) features
 		resources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
-		require.NoError(t, resources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk, "activegate"), dk.Namespace, &activeGatePod))
+		require.NoError(t, resources.WithNamespace(dk.Namespace).Get(ctx, activegate.GetActiveGatePodName(dk), dk.Namespace, &activeGatePod))
 
 		require.NotNil(t, activeGatePod.Spec)
 		require.NotEmpty(t, activeGatePod.Spec.Containers)

--- a/test/e2e/features/publicregistry/publicregistry.go
+++ b/test/e2e/features/publicregistry/publicregistry.go
@@ -114,7 +114,7 @@ func feature(t *testing.T, featureName, sampleNS string, imageOpts []dynakube.Op
 	builder.Assess("install sample app", sampleApp.Install())
 	cloudnative.AssessSampleInitContainers(builder, sampleApp)
 
-	agStatefulSetName := activegate.GetActiveGateStateFulSetName(&testDynakube, "activegate")
+	agStatefulSetName := activegate.GetActiveGateStateFulSetName(&testDynakube)
 	builder.Assess("ActiveGate started", k8sstatefulset.IsReady(agStatefulSetName, testDynakube.Namespace))
 	builder.Assess("EEC started", k8sstatefulset.IsReady(testDynakube.Extensions().GetExecutionControllerStatefulsetName(), testDynakube.Namespace))
 	builder.Assess("KSPM node config collector started", k8sdaemonset.IsReady(testDynakube.KSPM().GetDaemonSetName(), testDynakube.Namespace))

--- a/test/e2e/features/telemetryingest/telemetryingest.go
+++ b/test/e2e/features/telemetryingest/telemetryingest.go
@@ -40,7 +40,6 @@ import (
 )
 
 const (
-	activeGateComponent   = "activegate"
 	TelemetryIngestTLSCrt = "custom-cas/tls-telemetry-ingest.crt"
 	TelemetryIngestTLSKey = "custom-cas/tls-telemetry-ingest.key"
 )
@@ -220,7 +219,7 @@ func assertTelemetryIngestActiveGateModulesAreActive(ctx context.Context, t *tes
 	var expectedModules = []string{"log_analytics_collector", "otlp_ingest"}
 	var expectedServices = []string{"generic_ingest"}
 
-	log := componentActiveGate.ReadActiveGateLog(ctx, t, envConfig, dk, activeGateComponent)
+	log := componentActiveGate.ReadActiveGateLog(ctx, t, envConfig, dk)
 
 	/* componentActiveGate 2025-03-24 15:08:02 UTC INFO    [<exq67461>] [<collector.services>, ServicesManager] Services active: [generic_filecache, local_support_archive, generic_ingest] */
 	servicesLog := logs.FindLineContainingText(log, "Services active:")

--- a/test/e2e/features/usepublicregistry/deploy.go
+++ b/test/e2e/features/usepublicregistry/deploy.go
@@ -193,9 +193,8 @@ func activeGateFeature(t *testing.T, featureName, dkName, override string) featu
 
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)
 
-	const agComponent = "activegate"
 	builder.Assess("ActiveGate StatefulSet ready",
-		k8sstatefulset.IsReady(activegate.GetActiveGateStateFulSetName(&testDynakube, agComponent), testDynakube.Namespace))
+		k8sstatefulset.IsReady(activegate.GetActiveGateStateFulSetName(&testDynakube), testDynakube.Namespace))
 	builder.Assess("ActiveGate status reports public-registry source",
 		statusSourceIsPublicRegistry(testDynakube, image.ActiveGate))
 
@@ -456,7 +455,7 @@ func allFeaturesWithImageOverridesFeature(t *testing.T, featureName, dkName stri
 
 	testDynakube := *dynakubeComponents.New(options...)
 
-	agStatefulSetName := activegate.GetActiveGateStateFulSetName(&testDynakube, "activegate")
+	agStatefulSetName := activegate.GetActiveGateStateFulSetName(&testDynakube)
 
 	dynakubeComponents.Install(builder, &secretConfig, testDynakube)
 

--- a/test/e2e/helpers/components/activegate/installation.go
+++ b/test/e2e/helpers/components/activegate/installation.go
@@ -19,16 +19,16 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func GetActiveGateStateFulSetName(dk *dynakube.DynaKube, component string) string {
-	return fmt.Sprintf("%s-%s", dk.Name, component)
+func GetActiveGateStateFulSetName(dk *dynakube.DynaKube) string {
+	return fmt.Sprintf("%s-%s", dk.Name, consts.MultiActiveGateName)
 }
 
-func GetActiveGatePodName(dk *dynakube.DynaKube, component string) string {
-	return fmt.Sprintf("%s-0", GetActiveGateStateFulSetName(dk, component))
+func GetActiveGatePodName(dk *dynakube.DynaKube) string {
+	return fmt.Sprintf("%s-0", GetActiveGateStateFulSetName(dk))
 }
 
-func ReadActiveGateLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, dk *dynakube.DynaKube, component string) string {
-	return logs.ReadLog(ctx, t, envConfig, dk.Namespace, GetActiveGatePodName(dk, component), consts.ActiveGateContainerName)
+func ReadActiveGateLog(ctx context.Context, t *testing.T, envConfig *envconf.Config, dk *dynakube.DynaKube) string {
+	return logs.ReadLog(ctx, t, envConfig, dk.Namespace, GetActiveGatePodName(dk), consts.ActiveGateContainerName)
 }
 
 func CheckContainer(dk *dynakube.DynaKube) features.Func {
@@ -36,7 +36,7 @@ func CheckContainer(dk *dynakube.DynaKube) features.Func {
 		resources := envConfig.Client().Resources()
 
 		var activeGatePod corev1.Pod
-		require.NoError(t, resources.WithNamespace(dk.Namespace).Get(ctx, GetActiveGatePodName(dk, "activegate"), dk.Namespace, &activeGatePod))
+		require.NoError(t, resources.WithNamespace(dk.Namespace).Get(ctx, GetActiveGatePodName(dk), dk.Namespace, &activeGatePod))
 
 		require.NotNil(t, activeGatePod.Spec)
 		require.NotEmpty(t, activeGatePod.Spec.Containers)


### PR DESCRIPTION
## Description

During #7374 I realized that we are always passing `component` as `activegate` to helpers like
- `GetActiveGatePodName`
- `GetActiveGateStateFulSetName`
- `ReadActiveGateLog`

so removed `component` variable and just use const directly in helper

## How can this be tested?
```
make test/e2e/activegate
make test/e2e/publicregistry
make test/e2e/usepublicregistry
```