### PR TITLE
Sanitize resource attribute keys

### DIFF
--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties.go
@@ -8,6 +8,9 @@ import (
 	"maps"
 	"slices"
 	"strings"
+
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/resourceattributes"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
 func BuildContent(attrs map[string]string) string {
@@ -23,7 +26,7 @@ func BuildContent(attrs map[string]string) string {
 	sb.WriteString("[resource_attributes]\n")
 
 	for _, k := range keys {
-		fmt.Fprintf(&sb, "%s = %s\n", k, attrs[k])
+		fmt.Fprintf(&sb, "%s = %s\n", resourceattributes.SanitizeKey(k), sanitize.CommandLineArg(attrs[k]))
 	}
 
 	return sb.String()

--- a/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties_test.go
+++ b/pkg/controllers/dynakube/activegate/deploymentproperties/deploymentproperties_test.go
@@ -34,4 +34,12 @@ func TestBuildContent(t *testing.T) {
 		content := BuildContent(attrs)
 		assert.Equal(t, "[resource_attributes]\naaa = first\nmmm = middle\nzzz = last\n", content)
 	})
+
+	t.Run("sanitize input", func(t *testing.T) {
+		attrs := map[string]string{
+			"foo\nbar": "sa\nnit\riz\ted",
+		}
+		content := BuildContent(attrs)
+		assert.Equal(t, "[resource_attributes]\nfoo_bar = sanitized\n", content)
+	})
 }

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/resourceattributes"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 )
 
@@ -32,7 +33,7 @@ func getInitArgs(dk dynakube.DynaKube) []string {
 
 	attrs := dk.GetResourceAttributes()
 	for _, key := range slices.Sorted(maps.Keys(attrs)) {
-		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", sanitize.CommandLineArg(key), sanitize.CommandLineArg(attrs[key])))
+		baseArgs = append(baseArgs, fmt.Sprintf("-p %s=%s", resourceattributes.SanitizeKey(key), sanitize.CommandLineArg(attrs[key])))
 	}
 
 	return append(baseArgs, sanitize.CommandLineArgs(dk.LogMonitoring().Template().Args)...)

--- a/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
+++ b/pkg/controllers/dynakube/logmonitoring/daemonset/args_test.go
@@ -117,7 +117,7 @@ func Test_getInitArgs(t *testing.T) {
 			name:        "sanitize args",
 			expectedLen: expectedBaseInitArgsLen,
 			resourceAttrs: map[string]string{
-				"foo": "a\ntest",
+				"foo_": "a\ntest",
 			},
 			templateArgs: []string{
 				"-p bar=b\ntest",

--- a/pkg/controllers/dynakube/oneagent/daemonset/init.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/init.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/resourceattributes"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/sanitize"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func (b *builder) initContainerArguments() []string {
 
 	resourceAttrs := b.dk.OneAgent().GetResourceAttributes()
 	for _, k := range slices.Sorted(maps.Keys(resourceAttrs)) {
-		attributes = append(attributes, k+"="+resourceAttrs[k])
+		attributes = append(attributes, resourceattributes.SanitizeKey(k)+"="+sanitize.CommandLineArg(resourceAttrs[k]))
 	}
 
 	initArgs := []string{

--- a/pkg/controllers/dynakube/oneagent/daemonset/init_test.go
+++ b/pkg/controllers/dynakube/oneagent/daemonset/init_test.go
@@ -256,7 +256,7 @@ func TestInitContainerArguments(t *testing.T) {
 		}
 		dsBuilder := builder{dk: dk}
 		attributes := strings.Split(dsBuilder.initContainerArguments()[4], ",")
-		assert.Contains(t, attributes, "key=value")
+		assert.Contains(t, attributes, "ke_y=value")
 	})
 }
 


### PR DESCRIPTION
## Description

Sanitize resource attribute keys wherever they are used.

ICP-9511

## How can this be tested?

Deploy a DynaKube with resourceAttributes that produce a warning, e.g. `mykey_` and then check that the key gets sanitized everywhere.
