### PR TITLE
Remove tlsSecretHash field from status.KubernetesMonitoring section

### DIFF
--- a/config/crd/bases/dynatrace.com_dynakubes.yaml
+++ b/config/crd/bases/dynatrace.com_dynakubes.yaml
@@ -6758,8 +6758,6 @@ spec:
                     type: object
                   image:
                     type: string
-                  tlsSecretHash:
-                    type: string
                 type: object
               metadataEnrichment:
                 properties:

--- a/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
+++ b/config/helm/chart/default/templates/Common/crd/dynatrace-operator-crd.yaml
@@ -6774,8 +6774,6 @@ spec:
                     type: object
                   image:
                     type: string
-                  tlsSecretHash:
-                    type: string
                 type: object
               metadataEnrichment:
                 properties:

--- a/pkg/api/latest/dynakube/kubemon/status.go
+++ b/pkg/api/latest/dynakube/kubemon/status.go
@@ -17,8 +17,4 @@ type Status struct {
 	// Information about KubernetesMonitoring's connections.
 	// +kubebuilder:validation:Optional
 	ConnectionInfo communication.ConnectionInfo `json:"connectionInfo,omitzero"`
-
-	// TLSSecretHash contains the hash of the TLS certificate and key that is passed to both the Kubernetes Monitoring ActiveGate and Node-Configuration-Collector.
-	// Meant to keep the two in sync.
-	TLSSecretHash string `json:"tlsSecretHash,omitempty"`
 }

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler.go
@@ -11,13 +11,16 @@ import (
 	dtimage "github.com/Dynatrace/dynatrace-operator/pkg/clients/dynatrace/image"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/registry"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
+	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8saffinity"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8ssecuritycontext"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8sdaemonset"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,12 +34,14 @@ const (
 )
 
 type Reconciler struct {
-	daemonset k8sdaemonset.QueryObject
+	kubeClient client.Client
+	daemonset  k8sdaemonset.QueryObject
 }
 
 func NewReconciler(clt client.Client, apiReader client.Reader) *Reconciler {
 	return &Reconciler{
-		daemonset: k8sdaemonset.Query(clt, apiReader),
+		kubeClient: clt,
+		daemonset:  k8sdaemonset.Query(clt, apiReader),
 	}
 }
 
@@ -82,7 +87,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 		return err
 	}
 
-	ds, err := r.generateDaemonSet(dk)
+	tlsSecretHash, err := r.getTLSSecretHash(ctx, dk)
+	if err != nil {
+		return err
+	}
+
+	ds, err := r.generateDaemonSet(dk, tlsSecretHash)
 	if err != nil {
 		return err
 	}
@@ -102,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageClient dtimage.Client, 
 	return nil
 }
 
-func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube) (*appsv1.DaemonSet, error) {
+func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube, tlsSecretHash string) (*appsv1.DaemonSet, error) {
 	tenantUUID, err := dk.TenantUUID()
 	if err != nil {
 		return nil, err
@@ -111,7 +121,7 @@ func (r *Reconciler) generateDaemonSet(dk *dynakube.DynaKube) (*appsv1.DaemonSet
 	labels := k8slabel.NewAppLabels(k8slabel.KSPMComponentLabel, dk.Name, k8slabel.KSPMComponentLabel, dk.Spec.Templates.KSPMNodeConfigurationCollector.ImageRef.Tag)
 	templateAnnotations := map[string]string{
 		tokenSecretHashAnnotation: dk.KSPM().TokenSecretHash,
-		tlsSecretHashAnnotation:   dk.KubernetesMonitoring().TLSSecretHash,
+		tlsSecretHashAnnotation:   tlsSecretHash,
 	}
 	maps.Copy(templateAnnotations, k8ssecuritycontext.RemoveAppArmorAnnotation(dk.KSPM().Annotations, containerName))
 
@@ -174,4 +184,44 @@ func buildPodSecurityContext() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
 		FSGroup: new(runAs),
 	}
+}
+
+func (r *Reconciler) getTLSSecretHash(ctx context.Context, dk *dynakube.DynaKube) (string, error) {
+	var secret corev1.Secret
+
+	var tlsSecretName string
+
+	switch {
+	case dk.IsKubemonEnabled():
+		tlsSecretName = dk.KubernetesMonitoring().GetTLSSecretName()
+	case dk.ActiveGate().IsEnabled():
+		tlsSecretName = dk.ActiveGate().GetTLSSecretName()
+		if tlsSecretName == "" {
+			return "", nil
+		}
+	default:
+		return "", nil
+	}
+
+	err := r.kubeClient.Get(ctx, client.ObjectKey{Name: tlsSecretName, Namespace: dk.Namespace}, &secret)
+	if k8serrors.IsNotFound(err) {
+		return "", nil
+	}
+
+	if err != nil {
+		k8sconditions.SetKubeAPIError(dk.Conditions(), conditionType, err)
+
+		return "", errors.WithStack(err)
+	}
+
+	if len(secret.Data) == 0 {
+		return "", nil
+	}
+
+	hash, err := hasher.GenerateSecureHash(secret.Data)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to hash TLS secret")
+	}
+
+	return hash, nil
 }

--- a/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kspm/daemonset/reconciler_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/activegate"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kspm"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/communication"
 	sharedimage "github.com/Dynatrace/dynatrace-operator/pkg/api/shared/image"
@@ -206,7 +208,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk := createDynakube(true)
 
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -243,7 +245,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk.KSPM().Labels = customLabels
 
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -259,7 +261,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk.KSPM().Annotations = customAnnotations
 
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -274,7 +276,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk.KSPM().PriorityClassName = customClass
 
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -288,7 +290,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk.Spec.CustomPullSecret = customPullSecret
 
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -309,7 +311,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk := createDynakube(true)
 		dk.KSPM().Tolerations = customTolerations
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -323,7 +325,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk := createDynakube(true)
 		dk.KSPM().NodeSelector = customNodeSelector
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -340,7 +342,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 		dk := createDynakube(true)
 		dk.KSPM().NodeAffinity = customNodeAffinity
 		reconciler := NewReconciler(nil, nil)
-		daemonset, err := reconciler.generateDaemonSet(dk)
+		daemonset, err := reconciler.generateDaemonSet(dk, "")
 		require.NoError(t, err)
 		require.NotNil(t, daemonset)
 
@@ -357,7 +359,7 @@ func TestAppArmorAnnotationHandling(t *testing.T) {
 		dk := createDynakube(true)
 		dk.Spec.Templates.KSPMNodeConfigurationCollector.Annotations = map[string]string{appArmorAnnotationKey: corev1.DeprecatedAppArmorBetaProfileRuntimeDefault}
 
-		ds, err := NewReconciler(nil, nil).generateDaemonSet(dk)
+		ds, err := NewReconciler(nil, nil).generateDaemonSet(dk, "")
 		require.NoError(t, err)
 
 		return ds
@@ -381,6 +383,89 @@ func TestAppArmorAnnotationHandling(t *testing.T) {
 		require.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext)
 		assert.NotNil(t, sts.Spec.Template.Spec.Containers[0].SecurityContext.AppArmorProfile)
 		assert.NotContains(t, sts.Spec.Template.Annotations, appArmorAnnotationKey)
+	})
+}
+
+func TestTlsSecretHashAnnotationHandling(t *testing.T) {
+	t.Run("no AG TLS secret", func(t *testing.T) {
+		dk := createDynakube(true)
+		dk.Annotations = map[string]string{
+			exp.AGAutomaticTLSCertificateKey: "false",
+		}
+
+		kubeClient := fake.NewClientWithInterceptors(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return errors.New("secret should not be read")
+				}
+
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+
+		reconciler := NewReconciler(kubeClient, nil)
+		hash, err := reconciler.getTLSSecretHash(t.Context(), dk)
+		require.NoError(t, err)
+		assert.Empty(t, hash)
+	})
+
+	t.Run("generic AG TLS secret used", func(t *testing.T) {
+		dk := createDynakube(true)
+
+		kubeClient := fake.NewClientWithInterceptors(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					if key.Name != dk.ActiveGate().GetTLSSecretName() {
+						return errors.New("wrong secret is read")
+					}
+				}
+
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.ActiveGate().GetTLSSecretName(),
+				Namespace: dk.Namespace,
+			},
+			Data: map[string][]byte{
+				"tls.key": []byte("foo"),
+			},
+		})
+		reconciler := NewReconciler(kubeClient, nil)
+		hash, err := reconciler.getTLSSecretHash(t.Context(), dk)
+		require.NoError(t, err)
+		assert.NotEmpty(t, hash)
+	})
+
+	t.Run("kubemon AG preferred", func(t *testing.T) {
+		t.Setenv(k8senv.ExperimentalEnableKubemonOperand, "true")
+
+		dk := createDynakube(true)
+		dk.Spec.KubernetesMonitoring = &kubemon.Spec{}
+
+		kubeClient := fake.NewClientWithInterceptors(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					if key.Name != dk.KubernetesMonitoring().GetTLSSecretName() {
+						return errors.New("wrong secret is read")
+					}
+				}
+
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dk.KubernetesMonitoring().GetTLSSecretName(),
+				Namespace: dk.Namespace,
+			},
+			Data: map[string][]byte{
+				"tls.key": []byte("foo"),
+			},
+		})
+		reconciler := NewReconciler(kubeClient, nil)
+		hash, err := reconciler.getTLSSecretHash(t.Context(), dk)
+		require.NoError(t, err)
+		assert.NotEmpty(t, hash)
 	})
 }
 

--- a/pkg/controllers/dynakube/kubemon/gateway/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/gateway/reconciler.go
@@ -12,16 +12,13 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/certificates"
-	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	k8sobject "github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/timeprovider"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -44,8 +41,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error
 	ctx, _ = logd.NewFromContext(ctx, "gateway")
 
 	if !dk.KubernetesMonitoring().IsEnabled() || !dk.KSPM().IsEnabled() {
-		dk.KubernetesMonitoring().TLSSecretHash = ""
-
 		if err := client.IgnoreNotFound(r.client.Delete(ctx, kubemonService(dk))); err != nil {
 			return err
 		}
@@ -66,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, dk *dynakube.DynaKube) error
 		_ = r.client.Delete(ctx, tlsSecretSpec(dk, nil))
 	}
 
-	return r.setStatusTLSSecretHash(ctx, dk)
+	return nil
 }
 
 func (r *Reconciler) createService(ctx context.Context, dk *dynakube.DynaKube) error {
@@ -198,37 +193,4 @@ func tlsSecretSpec(dk *dynakube.DynaKube, data map[string][]byte) *corev1.Secret
 		Data: data,
 		Type: corev1.SecretTypeOpaque,
 	}
-}
-
-func (r *Reconciler) setStatusTLSSecretHash(ctx context.Context, dk *dynakube.DynaKube) error {
-	var secret corev1.Secret
-
-	// retry because a Secret created by the preceding createOrUpdate call may not be immediately visible in the API.
-	err := retry.OnError(retry.DefaultBackoff, k8serrors.IsNotFound, func() error {
-		err := r.client.Get(ctx, client.ObjectKey{Name: dk.KubernetesMonitoring().GetTLSSecretName(), Namespace: dk.Namespace}, &secret)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	if len(secret.Data) == 0 {
-		dk.KubernetesMonitoring().TLSSecretHash = ""
-
-		return nil
-	}
-
-	// custom secret may contain server.p12 field or tls.crt, tls.key fields
-	hash, err := hasher.GenerateSecureHash(secret.Data)
-	if err != nil {
-		return errors.Wrap(err, "failed to hash TLS secret")
-	}
-
-	dk.KubernetesMonitoring().TLSSecretHash = hash
-
-	return nil
 }

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -106,7 +106,7 @@ func ensureReady(dk *dynakube.DynaKube) error {
 	return nil
 }
 
-func buildPodAnnotations(dk *dynakube.DynaKube, tokenHash, authTokenHash, customPropertiesHash, deploymentPropertiesHash string) map[string]string {
+func buildPodAnnotations(dk *dynakube.DynaKube, tokenHash, authTokenHash, customPropertiesHash, deploymentPropertiesHash, tlsSecretHash string) map[string]string { //nolint:revive
 	annotations := map[string]string{
 		AnnotationTenantTokenHash:              tokenHash,
 		AnnotationAuthTokenHash:                authTokenHash,
@@ -117,7 +117,7 @@ func buildPodAnnotations(dk *dynakube.DynaKube, tokenHash, authTokenHash, custom
 
 	if dk.KSPM().IsEnabled() {
 		annotations[AnnotationKSPMTokenHash] = dk.KSPM().TokenSecretHash
-		annotations[AnnotationTLSSecretHash] = dk.KubernetesMonitoring().TLSSecretHash
+		annotations[AnnotationTLSSecretHash] = tlsSecretHash
 	}
 
 	return annotations
@@ -491,6 +491,11 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 		return nil, err
 	}
 
+	tlsSecretHash, err := r.getTLSSecretHash(ctx, dk)
+	if err != nil {
+		return nil, err
+	}
+
 	km := dk.KubernetesMonitoring()
 
 	initContainer := corev1.Container{
@@ -528,7 +533,7 @@ func (r *Reconciler) buildDesiredStatefulSet(ctx context.Context, dk *dynakube.D
 	opts := []k8sstatefulset.Option{
 		k8sstatefulset.SetReplicas(replicas),
 		k8sstatefulset.SetAllLabels(labels.AsMap(), labels.AsSelector(), labels.AsMap(), km.Labels),
-		k8sstatefulset.SetAllAnnotations(nil, maputil.MergeMap(km.Annotations, buildPodAnnotations(dk, tokenHash, authTokenHash, customPropertiesHash, deploymentPropertiesHash))),
+		k8sstatefulset.SetAllAnnotations(nil, maputil.MergeMap(km.Annotations, buildPodAnnotations(dk, tokenHash, authTokenHash, customPropertiesHash, deploymentPropertiesHash, tlsSecretHash))),
 		k8sstatefulset.SetServiceAccount(km.GetServiceAccountName()),
 		k8sstatefulset.SetNodeSelector(km.NodeSelector),
 		k8sstatefulset.SetTolerations(km.Tolerations),
@@ -669,6 +674,34 @@ func (r *Reconciler) getDeploymentPropertiesHash(ctx context.Context, dk *dynaku
 	hash, err := hasher.GenerateSecureHash(string(data))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to hash deployment properties secret")
+	}
+
+	return hash, nil
+}
+
+func (r *Reconciler) getTLSSecretHash(ctx context.Context, dk *dynakube.DynaKube) (string, error) {
+	if !dk.KSPM().IsEnabled() {
+		return "", nil
+	}
+
+	var secret corev1.Secret
+
+	err := r.kubeClient.Get(ctx, client.ObjectKey{Name: dk.KubernetesMonitoring().GetTLSSecretName(), Namespace: dk.Namespace}, &secret)
+	if k8serrors.IsNotFound(err) {
+		return "", nil
+	}
+
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	if len(secret.Data) == 0 {
+		return "", nil
+	}
+
+	hash, err := hasher.GenerateSecureHash(secret.Data)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to hash TLS secret")
 	}
 
 	return hash, nil


### PR DESCRIPTION
[ICP-9512](https://dt-rnd.atlassian.net/browse/ICP-9512)

## Description

## How can this be tested?

1) unittests
2) deploy dk with AG, KM and KSPM enabled
```
  activeGate:
    capabilities:
    - routing
  kubernetesMonitoring:
    registration: {}
  kspm:
    mappedHostPaths:
      - /boot
  templates:
    kspmNodeConfigurationCollector:
      imageRef:
        repository: public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector
        tag: 1.5.12
```
- delete KM TLS secret - KSPM and KM PODs should be restarted
- check dynakube.status.KubernetesMonitoring section

[ICP-9512]: https://dt-rnd.atlassian.net/browse/ICP-9512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ