### PR TITLE
Fix mocks ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,6 @@
 
 # ── Testing — shared harness and cross-operand feature tests ─────────────────
 /test/                                                     @Dynatrace/kubernetes-operator-commanders
-/.mockery.yaml
 /.testcoverage.yml                                         @Dynatrace/kubernetes-operator-commanders
 
 # ── Deployment — helm chart, OLM bundles ─────────────────────────────────────
@@ -143,3 +142,8 @@
 /.gitignore                                                @Incredible-O @waodim @jokuniew @Dynatrace/kubernetes-operator-commanders
 /.git-blame-ignore-revs                                    @Incredible-O @waodim @jokuniew @Dynatrace/kubernetes-operator-commanders
 /CODEOWNERS                                                @jdanieck @andriisoldatenko @StefanHauth @Dynatrace/kubernetes-operator-commanders
+
+# ── Mocks ─────────────────────────────────────────────────────────────────────
+/.mockery.yaml
+/test/mocks/
+mock_*_test.go


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

As they are autogenerated, they shouldn't be owned by anyone.
- Triggered by https://github.com/Dynatrace/dynatrace-operator/pull/7387 where all mocks were regenerated due to mockery version update. -> pinging everyone in the process


## How can this be tested?

📖