### PR TITLE
Respect the proxy and no-proxy in Kubemon

### DIFF
--- a/pkg/api/latest/dynakube/operands_props.go
+++ b/pkg/api/latest/dynakube/operands_props.go
@@ -64,7 +64,7 @@ func (dk *DynaKube) KubernetesMonitoring() *kubemon.KubeMon {
 	}
 	km.SetName(dk.Name)
 	km.SetAPIURLHost(dk.APIURLHost())
-	km.SetNeedsDeploymentProperties(len(dk.GetResourceAttributes()) > 0)
+	km.SetNeedsDeploymentProperties(len(dk.GetResourceAttributes()) > 0 || dk.NeedsCustomNoProxy())
 
 	return km
 }

--- a/pkg/controllers/dynakube/activegate/consts/consts.go
+++ b/pkg/controllers/dynakube/activegate/consts/consts.go
@@ -25,6 +25,9 @@ const (
 	AnnotationActiveGateTenantTokenHash   = api.InternalFlagPrefix + "activegate-tenant-token-hash"
 	AnnotationActiveGateContainerAppArmor = corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix + ActiveGateContainerName
 
+	PropertiesClientInternalSection = "[http.client.internal]"
+	PropertiesNoProxyFieldName      = "proxy-non-proxy-hosts"
+
 	EnvDTCapabilities    = "DT_CAPABILITIES"
 	EnvDTIDSeedNamespace = "DT_ID_SEED_NAMESPACE"
 	EnvDTIDSeedClusterID = "DT_ID_SEED_K8S_CLUSTER_ID"

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8sconditions"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/objects/k8ssecret"
@@ -24,9 +25,6 @@ const (
 	Suffix   = "custom-properties"
 	DataKey  = "customProperties"
 	DataPath = "custom.properties"
-
-	clientInternalSection = "[http.client.internal]"
-	noProxyFieldName      = "proxy-non-proxy-hosts"
 
 	customPropertiesConditionType string = "CustomPropertiesSecret"
 )
@@ -122,12 +120,12 @@ func (r *Reconciler) buildCustomPropertiesValue(ctx context.Context, dk *dynakub
 
 func (r *Reconciler) addNonProxyHostsSettingsToValue(ffNoProxy string, lines []string) []string {
 	noProxyValue := strings.ReplaceAll(ffNoProxy, ",", "|")
-	proxySettings := fmt.Sprintf("%s\n%s=%s", clientInternalSection, noProxyFieldName, noProxyValue)
+	proxySettings := fmt.Sprintf("%s\n%s=%s", consts.PropertiesClientInternalSection, consts.PropertiesNoProxyFieldName, noProxyValue)
 
 	found := false
 
 	for i, line := range lines {
-		if strings.Contains(line, clientInternalSection) {
+		if strings.Contains(line, consts.PropertiesClientInternalSection) {
 			found = true
 			lines[i] = proxySettings
 

--- a/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
+++ b/pkg/controllers/dynakube/activegate/internal/customproperties/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.NotEmpty(t, customPropertiesSecret.Data)
 		assert.Contains(t, customPropertiesSecret.Data, DataKey)
 
-		expectedValue := "\n" + clientInternalSection + "\n" + noProxyFieldName + "=" + testValue
+		expectedValue := "\n" + consts.PropertiesClientInternalSection + "\n" + consts.PropertiesNoProxyFieldName + "=" + testValue
 
 		assert.Equal(t, []byte(expectedValue), customPropertiesSecret.Data[DataKey])
 
@@ -105,7 +106,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		assert.NotEmpty(t, customPropertiesSecret.Data)
 		assert.Contains(t, customPropertiesSecret.Data, DataKey)
 
-		expectedValue := testValue + "\n" + clientInternalSection + "\n" + noProxyFieldName + "=" + testValue
+		expectedValue := testValue + "\n" + consts.PropertiesClientInternalSection + "\n" + consts.PropertiesNoProxyFieldName + "=" + testValue
 
 		assert.Equal(t, []byte(expectedValue), customPropertiesSecret.Data[DataKey])
 	})

--- a/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
@@ -64,12 +64,12 @@ func secretData(dk *dynakube.DynaKube) map[string][]byte {
 	if len(dk.GetResourceAttributes()) > 0 {
 		data += deploymentproperties.BuildContent(dk.GetResourceAttributes())
 	}
-data += "\n"
+
 	if dk.NeedsCustomNoProxy() {
 		noProxyValue := strings.ReplaceAll(dk.FF().GetNoProxy(), ",", "|")
-		data += fmt.Sprintf("%s\n%s=%s", agconsts.PropertiesClientInternalSection, agconsts.PropertiesNoProxyFieldName, noProxyValue)
+		data += fmt.Sprintf("%s\n%s=%s\n", agconsts.PropertiesClientInternalSection, agconsts.PropertiesNoProxyFieldName, noProxyValue)
 	}
-data += "\n"
+
 	return map[string][]byte{
 		agconsts.DeploymentPropertiesFileName: []byte(data),
 	}

--- a/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
@@ -5,6 +5,8 @@ package deploymentproperties
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
@@ -61,6 +63,11 @@ func secretData(dk *dynakube.DynaKube) map[string][]byte {
 
 	if len(dk.GetResourceAttributes()) > 0 {
 		data += deploymentproperties.BuildContent(dk.GetResourceAttributes())
+	}
+
+	if dk.NeedsCustomNoProxy() {
+		noProxyValue := strings.ReplaceAll(dk.FF().GetNoProxy(), ",", "|")
+		data += fmt.Sprintf("%s\n%s=%s", agconsts.PropertiesClientInternalSection, agconsts.PropertiesNoProxyFieldName, noProxyValue)
 	}
 
 	return map[string][]byte{

--- a/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
@@ -69,7 +69,7 @@ data += "\n"
 		noProxyValue := strings.ReplaceAll(dk.FF().GetNoProxy(), ",", "|")
 		data += fmt.Sprintf("%s\n%s=%s", agconsts.PropertiesClientInternalSection, agconsts.PropertiesNoProxyFieldName, noProxyValue)
 	}
-
+data += "\n"
 	return map[string][]byte{
 		agconsts.DeploymentPropertiesFileName: []byte(data),
 	}

--- a/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler.go
@@ -64,7 +64,7 @@ func secretData(dk *dynakube.DynaKube) map[string][]byte {
 	if len(dk.GetResourceAttributes()) > 0 {
 		data += deploymentproperties.BuildContent(dk.GetResourceAttributes())
 	}
-
+data += "\n"
 	if dk.NeedsCustomNoProxy() {
 		noProxyValue := strings.ReplaceAll(dk.FF().GetNoProxy(), ",", "|")
 		data += fmt.Sprintf("%s\n%s=%s", agconsts.PropertiesClientInternalSection, agconsts.PropertiesNoProxyFieldName, noProxyValue)

--- a/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler_test.go
@@ -134,7 +134,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, r.Reconcile(t.Context(), dk))
 
 		secret := getDeploymentPropertiesSecret(t, clt, dk)
-		expectedContent := agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=" + testNoProxyValue
+		expectedContent := agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=" + testNoProxyValue + "\n"
 		assert.Equal(t, expectedContent, string(secret.Data[agconsts.DeploymentPropertiesFileName]))
 	})
 
@@ -146,7 +146,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, r.Reconcile(t.Context(), dk))
 
 		secret := getDeploymentPropertiesSecret(t, clt, dk)
-		expectedContent := testDataValue + agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=" + testNoProxyValue
+		expectedContent := testDataValue + agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=" + testNoProxyValue + "\n"
 		assert.Equal(t, expectedContent, string(secret.Data[agconsts.DeploymentPropertiesFileName]))
 	})
 
@@ -158,7 +158,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, r.Reconcile(t.Context(), dk))
 
 		secret := getDeploymentPropertiesSecret(t, clt, dk)
-		expectedContent := agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=svc.cluster.local|10.0.0.0/8"
+		expectedContent := agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=svc.cluster.local|10.0.0.0/8\n"
 		assert.Equal(t, expectedContent, string(secret.Data[agconsts.DeploymentPropertiesFileName]))
 	})
 

--- a/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/deploymentproperties/reconciler_test.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/exp"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	kubemonapi "github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/kubemon"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/scheme/fake"
+	"github.com/Dynatrace/dynatrace-operator/pkg/api/shared/value"
 	agconsts "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/activegate/consts"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/deploymentproperties"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +35,9 @@ const (
 	testResourceAttributeKey2   = "key2"
 	testResourceAttributeValue2 = "value2"
 	testDataValue2              = "[resource_attributes]\n" + testResourceAttributeKey2 + " = " + testResourceAttributeValue2 + "\n"
+
+	testNoProxyValue     = "svc.cluster.local"
+	testNoProxyWithComma = "svc.cluster.local,10.0.0.0/8"
 )
 
 func TestReconcile(t *testing.T) {
@@ -115,6 +120,58 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, testDataValue, string(configMap.Data[agconsts.DeploymentPropertiesFileName]))
 
 		dk.Spec.KubernetesMonitoring = nil
+
+		require.NoError(t, r.Reconcile(t.Context(), dk))
+
+		assertDeploymentPropertiesSecretAbsent(t, clt, dk)
+	})
+
+	t.Run("creates secret when only no-proxy is set (no resource attributes)", func(t *testing.T) {
+		dk := newTestDynaKube(withoutResourceAttributes(), withNoProxy(testNoProxyValue))
+		clt := fake.NewClient(dk)
+
+		r := deploymentproperties.NewReconciler(clt)
+		require.NoError(t, r.Reconcile(t.Context(), dk))
+
+		secret := getDeploymentPropertiesSecret(t, clt, dk)
+		expectedContent := agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=" + testNoProxyValue
+		assert.Equal(t, expectedContent, string(secret.Data[agconsts.DeploymentPropertiesFileName]))
+	})
+
+	t.Run("creates secret with both resource attributes and no-proxy section", func(t *testing.T) {
+		dk := newTestDynaKube(withNoProxy(testNoProxyValue))
+		clt := fake.NewClient(dk)
+
+		r := deploymentproperties.NewReconciler(clt)
+		require.NoError(t, r.Reconcile(t.Context(), dk))
+
+		secret := getDeploymentPropertiesSecret(t, clt, dk)
+		expectedContent := testDataValue + agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=" + testNoProxyValue
+		assert.Equal(t, expectedContent, string(secret.Data[agconsts.DeploymentPropertiesFileName]))
+	})
+
+	t.Run("replaces commas with pipes in no-proxy value", func(t *testing.T) {
+		dk := newTestDynaKube(withoutResourceAttributes(), withNoProxy(testNoProxyWithComma))
+		clt := fake.NewClient(dk)
+
+		r := deploymentproperties.NewReconciler(clt)
+		require.NoError(t, r.Reconcile(t.Context(), dk))
+
+		secret := getDeploymentPropertiesSecret(t, clt, dk)
+		expectedContent := agconsts.PropertiesClientInternalSection + "\n" + agconsts.PropertiesNoProxyFieldName + "=svc.cluster.local|10.0.0.0/8"
+		assert.Equal(t, expectedContent, string(secret.Data[agconsts.DeploymentPropertiesFileName]))
+	})
+
+	t.Run("deletes secret when no-proxy removed and no resource attributes", func(t *testing.T) {
+		dk := newTestDynaKube(withoutResourceAttributes(), withNoProxy(testNoProxyValue))
+		clt := fake.NewClient(dk)
+
+		r := deploymentproperties.NewReconciler(clt)
+		require.NoError(t, r.Reconcile(t.Context(), dk))
+
+		getDeploymentPropertiesSecret(t, clt, dk)
+
+		delete(dk.Annotations, exp.NoProxyKey)
 
 		require.NoError(t, r.Reconcile(t.Context(), dk))
 
@@ -223,6 +280,18 @@ func withoutResourceAttributes() func(*dynakube.DynaKube) {
 func withoutKubernetesMonitoring() func(*dynakube.DynaKube) {
 	return func(dk *dynakube.DynaKube) {
 		dk.Spec.KubernetesMonitoring = nil
+	}
+}
+
+func withNoProxy(noProxy string) func(*dynakube.DynaKube) {
+	return func(dk *dynakube.DynaKube) {
+		dk.Spec.Proxy = &value.Source{Value: "http://proxy:8080"}
+
+		if dk.Annotations == nil {
+			dk.Annotations = make(map[string]string)
+		}
+
+		dk.Annotations[exp.NoProxyKey] = noProxy
 	}
 }
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -413,7 +413,7 @@ func buildVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 		mounts = append(mounts, corev1.VolumeMount{
 			ReadOnly: true,
 			Name:     agconsts.ProxySecretVolumeName,
-			SubPath:  agconsts.ProxySecretMountPath,
+			MountPath:  agconsts.ProxySecretMountPath,
 		})
 	}
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/deploymentmetadata"
 	kubemonauthtoken "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/authtoken"
 	kubemoncustomproperties "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/customproperties"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/hasher"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
@@ -308,6 +309,18 @@ func buildVolumes(dk *dynakube.DynaKube) []corev1.Volume {
 		})
 	}
 
+	if dk.HasProxy() {
+		volumes = append(volumes, corev1.Volume{
+			Name: agconsts.ProxySecretVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  proxy.BuildSecretName(dk.Name),
+					DefaultMode: new(int32(0o640)),
+				},
+			},
+		})
+	}
+
 	return volumes
 }
 
@@ -393,6 +406,14 @@ func buildVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 			Name:      agconsts.DeploymentPropertiesVolumeName,
 			MountPath: agconsts.DeploymentPropertiesMountPath,
 			SubPath:   agconsts.DeploymentPropertiesFileName,
+		})
+	}
+
+	if dk.HasProxy() {
+		mounts = append(mounts, corev1.VolumeMount{
+			ReadOnly: true,
+			Name:     agconsts.ProxySecretVolumeName,
+			SubPath:  agconsts.ProxySecretMountPath,
 		})
 	}
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler.go
@@ -411,9 +411,9 @@ func buildVolumeMounts(dk *dynakube.DynaKube) []corev1.VolumeMount {
 
 	if dk.HasProxy() {
 		mounts = append(mounts, corev1.VolumeMount{
-			ReadOnly: true,
-			Name:     agconsts.ProxySecretVolumeName,
-			MountPath:  agconsts.ProxySecretMountPath,
+			ReadOnly:  true,
+			Name:      agconsts.ProxySecretVolumeName,
+			MountPath: agconsts.ProxySecretMountPath,
 		})
 	}
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
@@ -785,7 +785,7 @@ func TestReconcileBuildsStatefulSetVolumes(t *testing.T) {
 		proxyMount, err := k8smount.Find(container.VolumeMounts, agconsts.ProxySecretVolumeName)
 		require.NoError(t, err)
 		assert.True(t, proxyMount.ReadOnly)
-		assert.Equal(t, agconsts.ProxySecretMountPath, proxyMount.SubPath)
+		assert.Equal(t, agconsts.ProxySecretMountPath, proxyMount.MountPath)
 	})
 }
 

--- a/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
+++ b/pkg/controllers/dynakube/kubemon/statefulset/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	kubemonauthtoken "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/authtoken"
 	kubemoncustomproperties "github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/customproperties"
 	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/kubemon/statefulset"
+	"github.com/Dynatrace/dynatrace-operator/pkg/controllers/dynakube/proxy"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8slabel"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8smount"
@@ -752,6 +753,39 @@ func TestReconcileBuildsStatefulSetVolumes(t *testing.T) {
 		for _, volume := range volumes {
 			assert.Contains(t, sts.Spec.Template.Spec.Volumes, volume, "valid %s volume not found", volume.Name)
 		}
+	})
+
+	t.Run("no proxy volume or mount when proxy is not configured", func(t *testing.T) {
+		dk := newTestDynaKube()
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		assert.False(t, slices.ContainsFunc(sts.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+			return v.Name == agconsts.ProxySecretVolumeName
+		}), "proxy volume should not be present when proxy is not configured")
+
+		container := sts.Spec.Template.Spec.Containers[0]
+		assert.False(t, slices.ContainsFunc(container.VolumeMounts, func(m corev1.VolumeMount) bool {
+			return m.Name == agconsts.ProxySecretVolumeName
+		}), "proxy volume mount should not be present when proxy is not configured")
+	})
+
+	t.Run("proxy volume and mount are added when proxy is configured", func(t *testing.T) {
+		dk := newTestDynaKube()
+		dk.Spec.Proxy = &value.Source{Value: "http://proxy.example.com:8080"}
+		sts := reconcileAndGetSTS(t, dk, imageclientmock.NewClient(t), versionclientmock.NewClient(t))
+
+		proxyVolume := k8svolume.FindByName(sts.Spec.Template.Spec.Volumes, agconsts.ProxySecretVolumeName)
+		require.NotNil(t, proxyVolume, "proxy volume not found")
+		require.NotNil(t, proxyVolume.Secret)
+		assert.Equal(t, proxy.BuildSecretName(dk.Name), proxyVolume.Secret.SecretName)
+		require.NotNil(t, proxyVolume.Secret.DefaultMode)
+		assert.EqualValues(t, 0o640, *proxyVolume.Secret.DefaultMode)
+
+		container := sts.Spec.Template.Spec.Containers[0]
+		proxyMount, err := k8smount.Find(container.VolumeMounts, agconsts.ProxySecretVolumeName)
+		require.NoError(t, err)
+		assert.True(t, proxyMount.ReadOnly)
+		assert.Equal(t, agconsts.ProxySecretMountPath, proxyMount.SubPath)
 	})
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-8504](https://dt-rnd.atlassian.net/browse/ICP-8504)

If the `spec.proxy` is used, the kubemon statefulset should use the `dk-internal-proxy` Secret to get the config.
If the `feature.dynatrace.com/no-proxy` FF is used, the kubemon statefulset should use its `deployment.properties` to get the config.

## How can this be tested?

Example DK:
```yaml
apiVersion: dynatrace.com/v1beta6
kind: DynaKube
metadata:
  name: example
  namespace: dynatrace
  annotations:
    feature.dynatrace.com/no-proxy: "no.proxy"
spec:
  apiUrl: https://example.dev.dynatracelabs.com/api
   proxy:
      # Make sure whatever you put here is a working proxy otherwise your whole Operator will fail 😅
      value: http://squid.proxy.svc.cluster.local:3128 

  kubernetesMonitoring:
    registration: {}
```

[ICP-8504]: https://dt-rnd.atlassian.net/browse/ICP-8504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ