### PR TITLE
add k8s 1.37 to ondemand tests, remove 1.30 unsupported since aug 1, 2026

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -33,10 +33,6 @@ jobs:
       max-parallel: 10
       matrix:
         include:
-          - version: 1-30
-            platform: k8s
-            token: platform
-            tenantPhase: 3
           - version: 1-31
             platform: k8s
           - version: 1-32
@@ -53,6 +49,8 @@ jobs:
           - version: 1-36
             platform: k8s
             token: platform
+          - version: 1-37
+            platform: k8s
           - version: 4-14
             platform: ocp
           - version: 4-15

--- a/hack/slack/slack-e2e-ondemand-payload.json
+++ b/hack/slack/slack-e2e-ondemand-payload.json
@@ -83,7 +83,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-30 (platform token) (phase 3)"
+                    "text": "k8s_1-31"
                   }
                 ]
               }
@@ -97,12 +97,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_30_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_31_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_30_EMOJI }}"
+                    "name": "${{ env.K8S_1_31_EMOJI }}"
                   }
                 ]
               }
@@ -151,7 +151,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-31"
+                    "text": "k8s_1-32 (platform token)"
                   }
                 ]
               }
@@ -165,12 +165,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_31_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_32_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_31_EMOJI }}"
+                    "name": "${{ env.K8S_1_32_EMOJI }}"
                   }
                 ]
               }
@@ -219,7 +219,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-32 (platform token)"
+                    "text": "k8s_1-33"
                   }
                 ]
               }
@@ -233,12 +233,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_32_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_33_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_32_EMOJI }}"
+                    "name": "${{ env.K8S_1_33_EMOJI }}"
                   }
                 ]
               }
@@ -287,7 +287,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-33"
+                    "text": "k8s_1-34 (platform token) (phase 3)"
                   }
                 ]
               }
@@ -301,12 +301,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_33_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_34_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_33_EMOJI }}"
+                    "name": "${{ env.K8S_1_34_EMOJI }}"
                   }
                 ]
               }
@@ -355,7 +355,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-34 (platform token) (phase 3)"
+                    "text": "k8s_1-35"
                   }
                 ]
               }
@@ -369,12 +369,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_34_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_35_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_34_EMOJI }}"
+                    "name": "${{ env.K8S_1_35_EMOJI }}"
                   }
                 ]
               }
@@ -423,7 +423,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-35"
+                    "text": "k8s_1-36 (platform token)"
                   }
                 ]
               }
@@ -437,12 +437,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_35_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_36_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_35_EMOJI }}"
+                    "name": "${{ env.K8S_1_36_EMOJI }}"
                   }
                 ]
               }
@@ -491,7 +491,7 @@
                 "elements": [
                   {
                     "type": "text",
-                    "text": "k8s_1-36 (platform token)"
+                    "text": "k8s_1-37"
                   }
                 ]
               }
@@ -505,12 +505,12 @@
                 "elements": [
                   {
                     "type": "link",
-                    "url": "${{ env.K8S_1_36_RUN_ID_URL }}",
+                    "url": "${{ env.K8S_1_37_RUN_ID_URL }}",
                     "text": "tests "
                   },
                   {
                     "type": "emoji",
-                    "name": "${{ env.K8S_1_36_EMOJI }}"
+                    "name": "${{ env.K8S_1_37_EMOJI }}"
                   }
                 ]
               }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

resolves https://dt-rnd.atlassian.net/browse/ICP-9378

according to https://docs.dynatrace.com/docs/ingest-from/technology-support/support-model-and-issues

<img width="1038" height="378" alt="image" src="https://github.com/user-attachments/assets/663ba95d-5e02-4683-974e-a52958e3fc26" />


## How can this be tested?

n/a