### PR TITLE
Bump go version to 1.26.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
 
   tests:
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.is_protected_branch || needs.detect-changes.outputs.go_changed || needs.detect-changes.outputs.prerequisites_changed || needs.detect-changes.outputs.ci_changed
+    if: needs.detect-changes.outputs.is_protected_branch || needs.detect-changes.outputs.go_changed || needs.detect-changes.outputs.prerequisites_changed || needs.detect-changes.outputs.ci_changed || needs.detect-changes.outputs.docker_changed
     name: Run unit tests
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,7 +200,7 @@ jobs:
 
   linting:
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.is_protected_branch || needs.detect-changes.outputs.go_changed || needs.detect-changes.outputs.prerequisites_changed || needs.detect-changes.outputs.ci_changed
+    if: needs.detect-changes.outputs.is_protected_branch || needs.detect-changes.outputs.go_changed || needs.detect-changes.outputs.prerequisites_changed || needs.detect-changes.outputs.ci_changed || needs.detect-changes.outputs.docker_changed
     name: Run linting
     runs-on: ubuntu-24.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # check=skip=RedundantTargetPlatform
 # setup build image
-FROM --platform=$BUILDPLATFORM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS operator-build
+FROM --platform=$BUILDPLATFORM golang:1.26.8@sha256:2d54f6c8c6ea532a321e0b4c69553b2ed3637608d4f4357dbed37939fe2620cc AS operator-build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

No renovate PR. 

```
$ podman pull golang:1.26.8
$ podman inspect golang:1.26.8 --format='{{index .RepoDigests 0}}' 
docker.io/library/golang@sha256:2d54f6c8c6ea532a321e0b4c69553b2ed3637608d4f4357dbed37939fe2620cc
```

1.26.8 fixes a few CVEs (1 critical).

## How can this be tested?

Deploy dk+everything