### PR TITLE
Propagate spec.runtimeClassName to OA injected containers

### DIFF
--- a/pkg/webhook/mutation/pod/mutator/oneagent/config.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/config.go
@@ -57,4 +57,6 @@ const (
 	// This should be replaced by the `storage` property in the ruxitagentproc.conf
 	DTStorageEnv  = "DT_STORAGE"
 	DTStoragePath = volumes.ConfigMountPath + "/oneagent"
+
+	PodRuntimeClassEnv = "DT_K8S_POD_RUNTIME_CLASS"
 )

--- a/pkg/webhook/mutation/pod/mutator/oneagent/env.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/env.go
@@ -88,6 +88,19 @@ func addDTStorageEnv(container *corev1.Container) {
 		})
 }
 
+func addPodRuntimeClassEnv(container *corev1.Container, runtimeClassName string) {
+	if k8senv.Contains(container.Env, PodRuntimeClassEnv) {
+		return
+	}
+
+	container.Env = append(container.Env,
+		corev1.EnvVar{
+			Name:  PodRuntimeClassEnv,
+			Value: runtimeClassName,
+		},
+	)
+}
+
 func concatPreloadPaths(originalPaths, additionalPath string) string {
 	if strings.Contains(originalPaths, " ") {
 		return originalPaths + " " + additionalPath

--- a/pkg/webhook/mutation/pod/mutator/oneagent/env_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/env_test.go
@@ -133,6 +133,33 @@ func TestAddDeploymentMetadataEnv(t *testing.T) {
 	})
 }
 
+func TestAddPodRuntimeClassEnv(t *testing.T) {
+	t.Run("adds env when runtimeClassName is set", func(t *testing.T) {
+		container := &corev1.Container{}
+		runtimeClassName := "gvisor"
+
+		addPodRuntimeClassEnv(container, runtimeClassName)
+
+		require.Len(t, container.Env, 1)
+		assert.Equal(t, PodRuntimeClassEnv, container.Env[0].Name)
+		assert.Equal(t, runtimeClassName, container.Env[0].Value)
+	})
+
+	t.Run("does not overwrite existing env", func(t *testing.T) {
+		existingValue := "existing-runtime"
+		container := &corev1.Container{
+			Env: []corev1.EnvVar{
+				{Name: PodRuntimeClassEnv, Value: existingValue},
+			},
+		}
+
+		addPodRuntimeClassEnv(container, "new-runtime")
+
+		require.Len(t, container.Env, 1)
+		assert.Equal(t, existingValue, container.Env[0].Value)
+	})
+}
+
 func TestAddVersionDetection(t *testing.T) {
 	t.Run("adds defaults", func(t *testing.T) {
 		container := &corev1.Container{}

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -148,15 +149,15 @@ func mutateUserContainers(request *dtwebhook.BaseRequest, installPath string, lo
 
 	newContainers := request.NewContainers(containerIsInjected)
 	for _, container := range newContainers {
+		log.Info("adding OneAgent to container", "name", container.Name)
 		addVolumeMounts(container, installPath, isImageVolumeEnabled)
-		addOneAgentEnvsToContainer(request.DynaKube, container, request.Namespace, installPath, log)
+		addOneAgentEnvsToContainer(request.DynaKube, container, request.Namespace, installPath, ptr.Deref(request.Pod.Spec.RuntimeClassName, ""))
 	}
 
 	return len(newContainers) > 0
 }
 
-func addOneAgentEnvsToContainer(dk dynakube.DynaKube, container *corev1.Container, namespace corev1.Namespace, installPath string, log logd.Logger) {
-	log.Info("adding OneAgent envs to container", "name", container.Name)
+func addOneAgentEnvsToContainer(dk dynakube.DynaKube, container *corev1.Container, namespace corev1.Namespace, installPath string, runtimeClassName string) {
 	addDeploymentMetadataEnv(container, dk)
 	addPreloadEnv(container, installPath)
 	addDTStorageEnv(container)
@@ -167,6 +168,10 @@ func addOneAgentEnvsToContainer(dk dynakube.DynaKube, container *corev1.Containe
 
 	if dk.FF().IsLabelVersionDetection() {
 		addVersionDetectionEnvs(container, namespace)
+	}
+
+	if runtimeClassName != "" {
+		addPodRuntimeClassEnv(container, runtimeClassName)
 	}
 }
 

--- a/pkg/webhook/mutation/pod/mutator/oneagent/mutator_test.go
+++ b/pkg/webhook/mutation/pod/mutator/oneagent/mutator_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/latest/dynakube/oneagent"
 	"github.com/Dynatrace/dynatrace-operator/pkg/api/status"
-	"github.com/Dynatrace/dynatrace-operator/pkg/logd"
 	"github.com/Dynatrace/dynatrace-operator/pkg/util/kubernetes/fields/k8senv"
 	dtwebhook "github.com/Dynatrace/dynatrace-operator/pkg/webhook/mutation/pod/mutator"
 	"github.com/stretchr/testify/assert"
@@ -418,7 +417,7 @@ func TestAddOneAgentToContainer(t *testing.T) {
 			},
 		}
 		addVolumeMounts(&container, installPath, isImageVolume(baseReq))
-		addOneAgentEnvsToContainer(baseReq.DynaKube, &container, corev1.Namespace{}, installPath, logd.Get())
+		addOneAgentEnvsToContainer(baseReq.DynaKube, &container, corev1.Namespace{}, installPath, "")
 
 		assert.Len(t, container.VolumeMounts, 2) // preload,bin
 
@@ -438,7 +437,26 @@ func TestAddOneAgentToContainer(t *testing.T) {
 		require.NotNil(t, storageEnv)
 		assert.Contains(t, storageEnv.Value, DTStoragePath)
 
+		runtimeClassEnv := k8senv.Find(container.Env, PodRuntimeClassEnv)
+		assert.Nil(t, runtimeClassEnv)
+
 		assert.True(t, containerIsInjected(container, nil))
+	})
+
+	t.Run("add runtime class env when runtimeClassName is set", func(t *testing.T) {
+		container := corev1.Container{}
+		dk := dynakube.DynaKube{
+			Spec: dynakube.DynaKubeSpec{
+				OneAgent: oneagent.Spec{ApplicationMonitoring: &oneagent.ApplicationMonitoringSpec{}},
+			},
+		}
+		runtimeClassName := "gvisor"
+
+		addOneAgentEnvsToContainer(dk, &container, corev1.Namespace{}, installPath, runtimeClassName)
+
+		runtimeClassEnv := k8senv.Find(container.Env, PodRuntimeClassEnv)
+		require.NotNil(t, runtimeClassEnv)
+		assert.Equal(t, runtimeClassName, runtimeClassEnv.Value)
 	})
 }
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-9160](https://dt-rnd.atlassian.net/browse/ICP-9160)

If `spec.runtimeClassName` is set on a to-be-injected Pod then we just pass the value of it through to `DT_K8S_POD_RUNTIME_CLASS` on each injected container.

## How can this be tested?

If you are using GKE to test you can use `gvisor`, you need to create a new node-pool, otherwise gvisor won't be available on your nodes.
<img width="871" height="802" alt="image" src="https://github.com/user-attachments/assets/c38d71f0-42ab-4d3e-b56c-faaae37f1492" />

Then set `runtimeClassName: gvisor` on your sample -> check for env on containers.

[ICP-9160]: https://dt-rnd.atlassian.net/browse/ICP-9160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ