### PR TITLE
fix: use golang version from Dockerfile for actions/setup-go

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -42,7 +42,7 @@ runs:
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
     - name: Get go version
       id: go-version
-      uses: ./.github/actions/get-go-version
+      uses: $/.github/actions/get-go-version
       with:
         dockerfile: ${{ inputs.dockerfile }}
     - name: Set up Golang

--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -43,7 +43,9 @@ runs:
     - name: Get go version
       id: go-version
       shell: bash
-      run: echo "go_version=$(grep -m1 'FROM.*golang:' ${{ inputs.dockerfile }} | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+      env:
+        DOCKERFILE: ${{ inputs.dockerfile }}
+      run: echo "go_version=$(grep -m1 'FROM.*golang:' "$DOCKERFILE" | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
     - name: Set up Golang
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:

--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -40,10 +40,14 @@ runs:
       uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+    - name: Get go version
+      id: go-version
+      shell: bash
+      run: echo "go_version=$(grep -m1 'FROM.*golang:' ${{ inputs.dockerfile }} | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
     - name: Set up Golang
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 'stable' # Latest stable version
+        go-version: ${{ steps.go-version.outputs.go_version }}
         cache: false
     - name: Download third party licenses
       shell: bash

--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -42,10 +42,9 @@ runs:
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
     - name: Get go version
       id: go-version
-      shell: bash
-      env:
-        DOCKERFILE: ${{ inputs.dockerfile }}
-      run: echo "go_version=$(grep -m1 'FROM.*golang:' "$DOCKERFILE" | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+      uses: ./.github/actions/get-go-version
+      with:
+        dockerfile: ${{ inputs.dockerfile }}
     - name: Set up Golang
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:

--- a/.github/actions/get-go-version/action.yaml
+++ b/.github/actions/get-go-version/action.yaml
@@ -1,0 +1,19 @@
+name: Get Go version from Dockerfile
+description: Reads the Go version from a Dockerfile and outputs it
+inputs:
+  dockerfile:
+    description: Path to the Dockerfile
+    default: ./Dockerfile
+outputs:
+  go_version:
+    description: The Go version extracted from the Dockerfile
+    value: ${{ steps.go-version.outputs.go_version }}
+runs:
+  using: composite
+  steps:
+    - name: Get Go version from Dockerfile
+      id: go-version
+      shell: bash
+      env:
+        DOCKERFILE: ${{ inputs.dockerfile }}
+      run: echo "go_version=$(grep -m1 'FROM.*golang:' "$DOCKERFILE" | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -128,7 +128,7 @@ runs:
       uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
     - name: Get go version
       id: go-version
-      uses: ./.github/actions/get-go-version
+      uses: $/.github/actions/get-go-version
       with:
         dockerfile: ./target/Dockerfile
     - name: Set up go

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -128,8 +128,9 @@ runs:
       uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
     - name: Get go version
       id: go-version
-      shell: bash
-      run: echo "go_version=$(grep -m1 'FROM.*golang:' ./target/Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+      uses: ./.github/actions/get-go-version
+      with:
+        dockerfile: ./target/Dockerfile
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -126,10 +126,14 @@ runs:
         persist-credentials: false
     - name: Set up kubectl
       uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+    - name: Get go version
+      id: go-version
+      shell: bash
+      run: echo "go_version=$(grep -m1 'FROM.*golang:' ./target/Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 'stable' # Latest stable version
+        go-version: ${{ steps.go-version.outputs.go_version }}
         cache: false
     - name: Set up helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,8 +130,7 @@ jobs:
           CHANGED_PREREQUISITES_MK_FILE: ${{ steps.prerequisites.outputs.all_changed_files }}
       - name: Get Go version from Dockerfile
         id: go-version
-        run: |
-          echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-go-version
 
   helm-test:
     needs: [detect-changes]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,7 @@ jobs:
           CHANGED_PREREQUISITES_MK_FILE: ${{ steps.prerequisites.outputs.all_changed_files }}
       - name: Get Go version from Dockerfile
         id: go-version
-        uses: ./.github/actions/get-go-version
+        uses: $/.github/actions/get-go-version
 
   helm-test:
     needs: [detect-changes]

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -60,7 +60,7 @@ jobs:
           install_only: true
       - name: Get go version
         id: go-version
-        uses: ./.github/actions/get-go-version
+        uses: $/.github/actions/get-go-version
       - name: Set up go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -58,10 +58,13 @@ jobs:
           # renovate datasource=github-releases depName=kubernetes-sigs/kind
           version: v0.33.0
           install_only: true
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Set up go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
       - name: Set up helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -60,7 +60,7 @@ jobs:
           install_only: true
       - name: Get go version
         id: go-version
-        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-go-version
       - name: Set up go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -242,7 +242,7 @@ jobs:
           persist-credentials: false
       - name: Get go version
         id: go-version
-        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-go-version
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -242,7 +242,7 @@ jobs:
           persist-credentials: false
       - name: Get go version
         id: go-version
-        uses: ./.github/actions/get-go-version
+        uses: $/.github/actions/get-go-version
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -240,10 +240,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
       - name: Build helm packages
         uses: ./.github/actions/build-helm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -386,7 +386,7 @@ jobs:
           persist-credentials: false
       - name: Get go version
         id: go-version
-        uses: ./.github/actions/get-go-version
+        uses: $/.github/actions/get-go-version
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -384,10 +384,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 'stable' # Latest stable version
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
       - name: Generate release notes
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -386,7 +386,7 @@ jobs:
           persist-credentials: false
       - name: Get go version
         id: go-version
-        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-go-version
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/sync-openapi-schema.yaml
+++ b/.github/workflows/sync-openapi-schema.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Get go version
         id: go-version
-        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-go-version
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/sync-openapi-schema.yaml
+++ b/.github/workflows/sync-openapi-schema.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Get go version
         id: go-version
-        uses: ./.github/actions/get-go-version
+        uses: $/.github/actions/get-go-version
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/sync-openapi-schema.yaml
+++ b/.github/workflows/sync-openapi-schema.yaml
@@ -60,9 +60,13 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y make
 
+      - name: Get go version
+        id: go-version
+        run: echo "go_version=$(grep -m1 'FROM.*golang:' Dockerfile | sed 's/.*golang:\([0-9.]*\).*/\1/')" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 'stable'
+          go-version: ${{ steps.go-version.outputs.go_version }}
           cache: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## Description

I've introduced this on release branches, but not on main:
1.10 https://github.com/Dynatrace/dynatrace-operator/pull/7341
1.9 https://github.com/Dynatrace/dynatrace-operator/pull/7342


we used `'stable'` version in setup-go actions. 
This cause misalignment between golang version in ci and code causing errors in linting and generating files like:

```
  Error: ../../../../../opt/hostedtoolcache/go/1.27.0/x64/src/crypto/internal/randutil/randutil.go:11:2: could not import math/rand/v2 (/opt/hostedtoolcache/go/1.27.0/x64/src/math/rand/v2/rand.go:213:17: method must have no type parameters) (typecheck)
```

## How can this be tested?
CI runs