### PR TITLE
Don't inject istio placeholder containers

### DIFF
--- a/pkg/webhook/mutation/pod/mutator/container.go
+++ b/pkg/webhook/mutation/pod/mutator/container.go
@@ -20,6 +20,6 @@ func checkInjectionAnnotation(annotations map[string]string, name string) bool {
 	return false
 }
 
-func IsContainerExcludedFromInjection(dkAnnotations, podAnnotations map[string]string, name string) bool {
-	return checkInjectionAnnotation(dkAnnotations, name) || checkInjectionAnnotation(podAnnotations, name)
+func IsContainerExcludedFromInjection(dkAnnotations, podAnnotations map[string]string, containerName string) bool {
+	return checkInjectionAnnotation(dkAnnotations, containerName) || checkInjectionAnnotation(podAnnotations, containerName)
 }

--- a/pkg/webhook/mutation/pod/mutator/request.go
+++ b/pkg/webhook/mutation/pod/mutator/request.go
@@ -12,6 +12,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	// plaholderContainerImageName is the container image used by service meshes (e.g. Istio) as a
+	// placeholder/template entry in a pod spec that gets replaced during sidecar injection.
+	// Containers with this image must not be mutated, because they are not real workload containers
+	// and maybe converted into native-sidecars (ie.: init-containers) which can break our injection.
+	// See: https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
+	plaholderContainerImageName = "auto"
+)
+
 func NewMutationRequest(ctx context.Context, namespace corev1.Namespace, installContainer *corev1.Container, pod *corev1.Pod, dk dynakube.DynaKube) *MutationRequest {
 	return &MutationRequest{
 		BaseRequest:      newBaseRequest(pod, namespace, dk),
@@ -92,6 +101,10 @@ func (req *BaseRequest) NewContainers(isInjected func(corev1.Container, *BaseReq
 	for i := range req.Pod.Spec.Containers {
 		container := &req.Pod.Spec.Containers[i]
 		if IsContainerExcludedFromInjection(req.DynaKube.Annotations, req.Pod.Annotations, container.Name) {
+			continue
+		}
+
+		if container.Image == plaholderContainerImageName {
 			continue
 		}
 

--- a/pkg/webhook/mutation/pod/mutator/request_test.go
+++ b/pkg/webhook/mutation/pod/mutator/request_test.go
@@ -1,0 +1,109 @@
+// Copyright Dynatrace LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewContainers(t *testing.T) {
+	neverInjected := func(_ corev1.Container, _ *BaseRequest) bool { return false }
+
+	t.Run("placeholder container is excluded", func(t *testing.T) {
+		req := &BaseRequest{
+			Pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "my-app:latest"},
+						{Name: "istio-placeholder", Image: plaholderContainerImageName},
+					},
+				},
+			},
+		}
+
+		containers := req.NewContainers(neverInjected)
+
+		assert.Len(t, containers, 1)
+		assert.Equal(t, "app", containers[0].Name)
+	})
+
+	t.Run("all placeholder containers are excluded", func(t *testing.T) {
+		req := &BaseRequest{
+			Pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "placeholder-1", Image: plaholderContainerImageName},
+						{Name: "placeholder-2", Image: plaholderContainerImageName},
+					},
+				},
+			},
+		}
+
+		containers := req.NewContainers(neverInjected)
+
+		assert.Empty(t, containers)
+	})
+
+	t.Run("non-placeholder containers are included", func(t *testing.T) {
+		req := &BaseRequest{
+			Pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "my-app:latest"},
+						{Name: "sidecar", Image: "sidecar:v1"},
+					},
+				},
+			},
+		}
+
+		containers := req.NewContainers(neverInjected)
+
+		assert.Len(t, containers, 2)
+	})
+
+	t.Run("already injected containers are excluded", func(t *testing.T) {
+		alwaysInjected := func(_ corev1.Container, _ *BaseRequest) bool { return true }
+
+		req := &BaseRequest{
+			Pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "my-app:latest"},
+					},
+				},
+			},
+		}
+
+		containers := req.NewContainers(alwaysInjected)
+
+		assert.Empty(t, containers)
+	})
+
+	t.Run("annotation-excluded containers are excluded", func(t *testing.T) {
+		req := &BaseRequest{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"container.inject.dynatrace.com/app": "false",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "my-app:latest"},
+						{Name: "other", Image: "other:latest"},
+					},
+				},
+			},
+		}
+
+		containers := req.NewContainers(neverInjected)
+
+		assert.Len(t, containers, 1)
+		assert.Equal(t, "other", containers[0].Name)
+	})
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[ICP-9122](https://dt-rnd.atlassian.net/browse/ICP-9122)

> [!NOTE]
> The ticket is only about documenting it and make the user exclude it manually. Which I will do but we could check for this.

The current check only looks for `auto` as a container image, so that we don't break anyone using https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection.

I tried to check anyone else doing this, but this trick seems to be istio only. 

So options:
- a) Close this and just document
- b) Leave as is
- c) Also check that the container name is `istio-proxy`, to be more targeted.

> [!WARNING]
>  The main issue with b) and c) is that `istio-proxy` as a non-native sidecar container is something we can monitor, and by doing this change we would make that impossible if the user will also want to configure it through this `image: auto` method.
> - Injection into istio native-sidecar support is whole other beast, as istio will always want its native sidecar init-container to be the first, which would break our injection every time if we attempted to inject into it.



## How can this be tested?
Follow https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection to customize an injected samples istio-proxy

[ICP-9122]: https://dt-rnd.atlassian.net/browse/ICP-9122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ